### PR TITLE
add getPolicyIdsForIpId

### DIFF
--- a/packages/core-sdk/src/abi/json/Errors.abi.ts
+++ b/packages/core-sdk/src/abi/json/Errors.abi.ts
@@ -27,6 +27,22 @@ export default [
     type: "error",
   },
   {
+    inputs: [
+      {
+        internalType: "address",
+        name: "signer",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+    ],
+    name: "AccessController__BothCallerAndRecipientAreNotRegisteredModule",
+    type: "error",
+  },
+  {
     inputs: [],
     name: "AccessController__CallerIsNotIPAccount",
     type: "error",
@@ -76,17 +92,6 @@ export default [
   {
     inputs: [],
     name: "AccessController__PermissionIsNotValid",
-    type: "error",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "to",
-        type: "address",
-      },
-    ],
-    name: "AccessController__RecipientIsNotRegisteredModule",
     type: "error",
   },
   {
@@ -452,6 +457,11 @@ export default [
   },
   {
     inputs: [],
+    name: "LicensingModule__MintAmountZero",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "LicensingModule__MintLicenseParamFailed",
     type: "error",
   },
@@ -493,6 +503,11 @@ export default [
   {
     inputs: [],
     name: "LicensingModule__PolicyNotFound",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "LicensingModule__ReceiverZeroAddress",
     type: "error",
   },
   {

--- a/packages/core-sdk/src/abi/json/Errors.json
+++ b/packages/core-sdk/src/abi/json/Errors.json
@@ -27,6 +27,22 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "AccessController__BothCallerAndRecipientAreNotRegisteredModule",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "AccessController__CallerIsNotIPAccount",
     "type": "error"
@@ -76,17 +92,6 @@
   {
     "inputs": [],
     "name": "AccessController__PermissionIsNotValid",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "to",
-        "type": "address"
-      }
-    ],
-    "name": "AccessController__RecipientIsNotRegisteredModule",
     "type": "error"
   },
   {
@@ -452,6 +457,11 @@
   },
   {
     "inputs": [],
+    "name": "LicensingModule__MintAmountZero",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "LicensingModule__MintLicenseParamFailed",
     "type": "error"
   },
@@ -493,6 +503,11 @@
   {
     "inputs": [],
     "name": "LicensingModule__PolicyNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LicensingModule__ReceiverZeroAddress",
     "type": "error"
   },
   {

--- a/packages/core-sdk/src/abi/json/LicensingModule.abi.ts
+++ b/packages/core-sdk/src/abi/json/LicensingModule.abi.ts
@@ -255,6 +255,30 @@ export default [
   {
     inputs: [
       {
+        internalType: "bool",
+        name: "isInherited",
+        type: "bool",
+      },
+      {
+        internalType: "address",
+        name: "ipId",
+        type: "address",
+      },
+    ],
+    name: "policyIdsForIp",
+    outputs: [
+      {
+        internalType: "uint256[]",
+        name: "policyIds",
+        type: "uint256[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         components: [
           {
             internalType: "bool",

--- a/packages/core-sdk/src/abi/sdkEntities.json
+++ b/packages/core-sdk/src/abi/sdkEntities.json
@@ -12,6 +12,7 @@
   "registerPolicy",
   "addPolicyToIp",
   "getPolicyId",
+  "policyIdsForIp",
   "PolicyRegistered",
   "PolicyAddedToIpId",
 

--- a/packages/core-sdk/src/resources/policy.ts
+++ b/packages/core-sdk/src/resources/policy.ts
@@ -18,6 +18,7 @@ import {
   AddPolicyToIpRequest,
   AddPolicyToIpResponse,
   FrameworkData,
+  GetPolicyIdsForIpIdRequest,
 } from "../types/resources/policy";
 
 export class PolicyClient {
@@ -401,6 +402,28 @@ export class PolicyClient {
       } else {
         return { txHash: txHash };
       }
+    } catch (error) {
+      handleError(error, "Failed to add policy to IP");
+    }
+  }
+
+  /**
+   * Gets an array of policies that are associated with an IP ID
+   * @param request The request object containing details to add a policy to an IP
+   *   @param request.ipId The id of the IP
+   * @return the transaction hash and the index of the policy in the IP's policy set if the txOptions.waitForTransaction is set to true
+   */
+  public async getPolicyIdsForIpId(request: GetPolicyIdsForIpIdRequest): Promise<string[]> {
+    try {
+      const policyIds = (await this.rpcClient.readContract({
+        ...this.licensingModuleConfig,
+        functionName: "policyIdsForIp",
+        args: [request.isInherited || false, request.ipId],
+        account: this.wallet.account,
+      })) as bigint[];
+
+      const policyIdsString = policyIds.map((policyId: bigint) => policyId.toString());
+      return policyIdsString;
     } catch (error) {
       handleError(error, "Failed to add policy to IP");
     }

--- a/packages/core-sdk/src/types/resources/policy.ts
+++ b/packages/core-sdk/src/types/resources/policy.ts
@@ -92,3 +92,9 @@ export type FrameworkData = {
   commercializerChecker: `0x${string}`;
   commercializerCheckerData: `0x${string}`;
 };
+
+export type GetPolicyIdsForIpIdRequest = {
+  ipId: `0x${string}`;
+  isInherited?: boolean;
+  txOptions?: TxOptions;
+};

--- a/packages/core-sdk/test/integration/policy.test.ts
+++ b/packages/core-sdk/test/integration/policy.test.ts
@@ -294,4 +294,23 @@ describe.skip("Test Policy Functions", () => {
       }
     });
   });
+
+  describe("Get policyIds from IP ID", async function () {
+    it("should not throw error when adding Policy to IP", async () => {
+      const ipId = "0x004e38104adc39cbf4cea9bd8876440a969e3d0b";
+
+      await client.policy.addPolicyToIp({
+        ipId: "0x004e38104adc39cbf4cea9bd8876440a969e3d0b",
+        policyId: "1",
+        txOptions: {
+          waitForTransaction: true,
+        },
+      });
+
+      const result = await client.policy.getPolicyIdsForIpId({ ipId: ipId });
+      expect(result).to.be.a("array");
+      expect(result).to.include("1");
+      expect(result).to.include("2");
+    });
+  });
 });

--- a/packages/core-sdk/test/unit/resources/policy.test.ts
+++ b/packages/core-sdk/test/unit/resources/policy.test.ts
@@ -503,4 +503,29 @@ describe("Test PolicyClient", () => {
       });
     });
   });
+
+  describe("Test getPolicyIdsForIpId", () => {
+    let policyClient: PolicyClient;
+    let rpcMock: PublicClient;
+    let walletMock: WalletClient;
+
+    beforeEach(function () {
+      rpcMock = createMock<PublicClient>();
+      walletMock = createMock<WalletClient>();
+      const accountMock = createMock<Account>();
+      accountMock.address = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
+      walletMock.account = accountMock;
+      policyClient = new PolicyClient(rpcMock, walletMock);
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+    it("should return licenseId if request.txOptions is present", async () => {
+      rpcMock.readContract = sinon.stub().resolves(["1", "2", "3"]);
+      const ipId = "0x1234567890123456789012345678901234567890";
+      const result = await policyClient.getPolicyIdsForIpId({ ipId: ipId });
+      expect(result).to.deep.equal(["1", "2", "3"]);
+    });
+  });
 });


### PR DESCRIPTION
Adds a function to read the LicensingModule contract storage variable `policyIdsForIp` to get the policyIds associated with an IP ID.

