### PR TITLE
Update publish CI + Bump version

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -75,14 +75,30 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org/
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
       - name: Install dependencies
         run: pnpm install
+      
+      - name: Fix
+        run: pnpm fix
 
-      - name: Build
-        run: pnpm build
+      - name: Run Anvil
+        id: run_anvil
+        run: anvil --fork-url ${SEPOLIA_RPC_PROVIDER_URL} --block-time 1 --silent &
+
+      - name: Check on Run Anvil
+        if: steps.run_anvil.outcome != 'success'
+        run: exit 1
 
       - name: Test
         run: pnpm test
+      
+       - name: Build
+        run: pnpm build
 
       - name: Publish to npm
         run: |

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-protocol/core-sdk",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.10",
   "description": "Story Protocol Core SDK",
   "main": "dist/story-protocol-core-sdk.cjs.js",
   "module": "dist/story-protocol-core-sdk.esm.js",


### PR DESCRIPTION
## Description
Update the publish CI workflow to use the same logic as the internal testing. Later on we should reuse the same logic in build-and-test.yaml