### PR TITLE
Add support for parameters for Viem's `waitForTransactionReceipt`

### DIFF
--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-protocol/core-sdk",
-  "version": "1.0.0-rc.21",
+  "version": "1.0.0-rc.22",
   "description": "Story Protocol Core SDK",
   "main": "dist/story-protocol-core-sdk.cjs.js",
   "module": "dist/story-protocol-core-sdk.esm.js",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "pnpm run fix && preconstruct build",
-    "test": "pnpm run test:unit && pnpm run test:integration",
+    "test": "pnpm run test:unit",
     "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
     "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 240000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "pnpm run fix && preconstruct build",
-    "test": "pnpm run test:unit",
+    "test": "pnpm run test:unit && pnpm run test:integration",
     "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
     "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 240000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",

--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -52,13 +52,18 @@ export class DisputeClient {
         const txHash = await this.disputeModuleClient.raiseDispute(req);
 
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs = this.disputeModuleClient.parseTxDisputeRaisedEvent(txReceipt);
           return {
             txHash: txHash,
             disputeId: targetLogs[0].disputeId,
           };
         }
+
         return { txHash: txHash };
       }
     } catch (error) {
@@ -90,7 +95,11 @@ export class DisputeClient {
         const txHash = await this.disputeModuleClient.cancelDispute(req);
 
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
         }
 
         return { txHash: txHash };
@@ -122,7 +131,11 @@ export class DisputeClient {
       } else {
         const txHash = await this.disputeModuleClient.resolveDispute(req);
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
         }
 
         return { txHash: txHash };

--- a/packages/core-sdk/src/resources/ipAccount.ts
+++ b/packages/core-sdk/src/resources/ipAccount.ts
@@ -49,7 +49,11 @@ export class IPAccountClient {
         const txHash = await ipAccountClient.execute({ ...req, operation: 0 });
 
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
         }
         return { txHash: txHash };
       }
@@ -94,7 +98,11 @@ export class IPAccountClient {
         const txHash = await ipAccountClient.executeWithSig(req);
 
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
         }
         return { txHash: txHash };
       }

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -302,7 +302,11 @@ export class IPAssetClient {
           });
         }
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(txReceipt);
           return { txHash: txHash, ipId: targetLogs[0].ipId };
         } else {
@@ -375,7 +379,11 @@ export class IPAssetClient {
       } else {
         const txHash = await this.licensingModuleClient.registerDerivative(req);
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash };
         } else {
           return { txHash };
@@ -426,7 +434,11 @@ export class IPAssetClient {
       } else {
         const txHash = await this.licensingModuleClient.registerDerivativeWithLicenseTokens(req);
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash: txHash };
         } else {
           return { txHash: txHash };
@@ -488,7 +500,11 @@ export class IPAssetClient {
       } else {
         const txHash = await this.spgClient.mintAndRegisterIpAndAttachPilTerms(object);
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const iPRegisteredLog = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(txReceipt)[0];
           const licenseTermsId = await this.getLicenseTermsId(txReceipt);
           return {
@@ -613,7 +629,11 @@ export class IPAssetClient {
       } else {
         const txHash = await this.spgClient.registerIpAndAttachPilTerms(object);
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const ipRegisterEvent = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(txReceipt);
           const licenseTermsId = await this.getLicenseTermsId(txReceipt);
           return { txHash, licenseTermsId: licenseTermsId, ipId: ipRegisterEvent[0].ipId };
@@ -756,7 +776,11 @@ export class IPAssetClient {
       } else {
         const txHash = await this.spgClient.registerIpAndMakeDerivative(object);
         if (request.txOptions?.waitForTransaction) {
-          const receipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const receipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const log = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(receipt)[0];
           return { txHash, ipId: log.ipId };
         }
@@ -833,7 +857,11 @@ export class IPAssetClient {
       } else {
         const txHash = await this.spgClient.mintAndRegisterIpAndMakeDerivative(object);
         if (request.txOptions?.waitForTransaction) {
-          const receipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const receipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const log = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(receipt)[0];
           return { txHash, childIpId: log.ipId };
         }

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -79,7 +79,11 @@ export class LicenseClient {
           terms: licenseTerms,
         });
         if (request?.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs =
             this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(txReceipt);
           return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
@@ -124,7 +128,11 @@ export class LicenseClient {
           terms: licenseTerms,
         });
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs =
             this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(txReceipt);
           return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
@@ -171,7 +179,11 @@ export class LicenseClient {
           terms: licenseTerms,
         });
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs =
             this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(txReceipt);
           return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
@@ -232,7 +244,11 @@ export class LicenseClient {
       } else {
         const txHash = await this.licensingModuleClient.attachLicenseTerms(req);
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash: txHash, success: true };
         } else {
           return { txHash: txHash };
@@ -312,7 +328,11 @@ export class LicenseClient {
       } else {
         const txHash = await this.licensingModuleClient.mintLicenseTokens(req);
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs = this.licensingModuleClient.parseTxLicenseTokensMintedEvent(txReceipt);
           const startLicenseTokenId = targetLogs[0].startLicenseTokenId;
           const licenseTokenIds = [];

--- a/packages/core-sdk/src/resources/nftClient.ts
+++ b/packages/core-sdk/src/resources/nftClient.ts
@@ -59,7 +59,11 @@ export class NftClient {
       } else {
         const txHash = await this.spgClient.createCollection(req);
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs = this.spgClient.parseTxCollectionCreatedEvent(txReceipt);
           return {
             txHash: txHash,

--- a/packages/core-sdk/src/resources/permission.ts
+++ b/packages/core-sdk/src/resources/permission.ts
@@ -79,7 +79,11 @@ export class PermissionClient {
       } else {
         const txHash = await this.accessControllerClient.setPermission(req);
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash: txHash, success: true };
         } else {
           return { txHash: txHash };
@@ -106,7 +110,7 @@ export class PermissionClient {
     request: CreateSetPermissionSignatureRequest,
   ): Promise<SetPermissionsResponse> {
     try {
-      const { ipId, signer, to, txOptions, func, permission, deadline } = request;
+      const { ipId, signer, to, func, permission, deadline } = request;
       await this.checkIsRegistered(ipId);
       const ipAccountClient = new IpAccountImplClient(this.rpcClient, this.wallet, ipId);
       const data = encodeFunctionData({
@@ -151,9 +155,12 @@ export class PermissionClient {
         return { encodedTxData: ipAccountClient.executeWithSigEncode(req) };
       } else {
         const txHash = await ipAccountClient.executeWithSig(req);
-
-        if (txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+        if (request.txOptions?.waitForTransaction) {
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash: txHash, success: true };
         } else {
           return { txHash: txHash };
@@ -188,7 +195,11 @@ export class PermissionClient {
       } else {
         const txHash = await this.accessControllerClient.setAllPermissions(req);
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash: txHash, success: true };
         } else {
           return { txHash: txHash };
@@ -216,7 +227,7 @@ export class PermissionClient {
     request: SetBatchPermissionsRequest,
   ): Promise<SetPermissionsResponse> {
     try {
-      const { permissions, txOptions } = request;
+      const { permissions } = request;
       for (const permission of permissions) {
         await this.checkIsRegistered(permission.ipId);
       }
@@ -233,8 +244,12 @@ export class PermissionClient {
         return { encodedTxData: this.accessControllerClient.setBatchPermissionsEncode(req) };
       } else {
         const txHash = await this.accessControllerClient.setBatchPermissions(req);
-        if (txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+        if (request.txOptions?.waitForTransaction) {
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash: txHash, success: true };
         } else {
           return { txHash: txHash };
@@ -262,7 +277,7 @@ export class PermissionClient {
     request: CreateBatchPermissionSignatureRequest,
   ): Promise<SetPermissionsResponse> {
     try {
-      const { permissions, deadline, ipId, txOptions } = request;
+      const { permissions, deadline, ipId } = request;
       for (const permission of permissions) {
         await this.checkIsRegistered(permission.ipId);
       }
@@ -303,8 +318,12 @@ export class PermissionClient {
         return { encodedTxData: ipAccountClient.executeWithSigEncode(req) };
       } else {
         const txHash = await ipAccountClient.executeWithSig(req);
-        if (txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+        if (request.txOptions?.waitForTransaction) {
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash: txHash, success: true };
         } else {
           return { txHash: txHash };

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -76,7 +76,11 @@ export class RoyaltyClient {
       } else {
         const txHash = await ipRoyaltyVault.collectRoyaltyTokens(req);
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs = ipRoyaltyVault.parseTxRoyaltyTokensCollectedEvent(txReceipt);
           return {
             txHash: txHash,
@@ -128,7 +132,11 @@ export class RoyaltyClient {
       } else {
         const txHash = await this.royaltyModuleClient.payRoyaltyOnBehalf(req);
         if (request.txOptions?.waitForTransaction) {
-          await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          await this.rpcClient.waitForTransactionReceipt(txOptions);
           return { txHash };
         } else {
           return { txHash };
@@ -222,9 +230,11 @@ export class RoyaltyClient {
         }
       }
       if (request.txOptions?.waitForTransaction) {
-        const txReceipt = await this.rpcClient.waitForTransactionReceipt({
-          hash: txHash,
-        });
+        let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+        if (request.txOptions?.timeout) {
+          txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+        }
+        const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
         const targetLogs = ipRoyaltyVault.parseTxRevenueTokenClaimedEvent(txReceipt);
         return { txHash, claimableToken: targetLogs[0].amount };
       } else {
@@ -257,7 +267,11 @@ export class RoyaltyClient {
       } else {
         const txHash = await ipRoyaltyVault.snapshot();
         if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({ hash: txHash });
+          let txOptions: { hash: `0x${string}`; timeout?: number } = { hash: txHash };
+          if (request.txOptions?.timeout) {
+            txOptions = { ...txOptions, timeout: request.txOptions.timeout };
+          }
+          const txReceipt = await this.rpcClient.waitForTransactionReceipt(txOptions);
           const targetLogs = ipRoyaltyVault.parseTxSnapshotCompletedEvent(txReceipt);
           return { txHash, snapshotId: targetLogs[0].snapshotId };
         } else {

--- a/packages/core-sdk/src/types/options.ts
+++ b/packages/core-sdk/src/types/options.ts
@@ -7,10 +7,6 @@ export type TxOptions = {
   // not submit and execute, it will only encode the abi and
   // function data and return.
   encodedTxDataOnly?: boolean;
-  // The price (in wei) to pay per gas.
-  gasPrice?: bigint;
-  // Total fee per gas (in wei).
-  maxFeePerGas?: bigint;
   // The number of confirmations (blocks that have passed)
   // to wait before resolving.
   numBlockConfirmations?: number;

--- a/packages/core-sdk/src/types/options.ts
+++ b/packages/core-sdk/src/types/options.ts
@@ -14,6 +14,8 @@ export type TxOptions = {
   // The number of confirmations (blocks that have passed)
   // to wait before resolving.
   numBlockConfirmations?: number;
+  // set timeout for waitForTransaction
+  timeout?: number;
 };
 
 export type WithTxOptions<T> = T & {

--- a/packages/core-sdk/test/integration/ipAccount.test.ts
+++ b/packages/core-sdk/test/integration/ipAccount.test.ts
@@ -26,7 +26,6 @@ describe("Ip Account functions", () => {
       tokenId: tokenId!,
       txOptions: {
         waitForTransaction: true,
-        maxFeePerGas: parseUnits("100", 9),
       },
     });
     ipId = registerResult.ipId!;
@@ -51,7 +50,6 @@ describe("Ip Account functions", () => {
       ipId: ipId,
       txOptions: {
         waitForTransaction: true,
-        maxFeePerGas: parseUnits("100", 9),
       },
     });
     expect(response.txHash).to.be.a("string").and.not.empty;

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -146,7 +146,7 @@ describe("IP Asset Functions ", () => {
             nftMetadataHash: toHex("test-nft-metadata-hash", { size: 32 }),
             nftMetadataURI: "test-nft-uri",
           },
-          txOptions: { waitForTransaction: true, maxFeePerGas: parseUnits("100", 9) },
+          txOptions: { waitForTransaction: true },
         });
         expect(result.txHash).to.be.a("string").and.not.empty;
       });

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -23,7 +23,6 @@ describe("IP Asset Functions ", () => {
       const res = await client.license.registerNonComSocialRemixingPIL({
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       noCommercialLicenseTermsId = res.licenseTermsId!;
@@ -37,7 +36,6 @@ describe("IP Asset Functions ", () => {
           tokenId: tokenId!,
           txOptions: {
             waitForTransaction: waitForTransaction,
-            maxFeePerGas: parseUnits("100", 9),
           },
         }),
       ).to.not.be.rejected;
@@ -55,7 +53,6 @@ describe("IP Asset Functions ", () => {
           tokenId: tokenId!,
           txOptions: {
             waitForTransaction: true,
-            maxFeePerGas: parseUnits("100", 9),
           },
         })
       ).ipId!;
@@ -64,7 +61,6 @@ describe("IP Asset Functions ", () => {
         licenseTermsId: noCommercialLicenseTermsId,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       const response = await client.ipAsset.registerDerivative({
@@ -73,7 +69,6 @@ describe("IP Asset Functions ", () => {
         licenseTermsIds: [noCommercialLicenseTermsId],
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(response.txHash).to.be.a("string").and.not.empty;
@@ -87,7 +82,6 @@ describe("IP Asset Functions ", () => {
           tokenId: tokenId!,
           txOptions: {
             waitForTransaction: true,
-            maxFeePerGas: parseUnits("100", 9),
           },
         })
       ).ipId!;
@@ -96,7 +90,6 @@ describe("IP Asset Functions ", () => {
         licensorIpId: parentIpId,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       const response = await client.ipAsset.registerDerivativeWithLicenseTokens({
@@ -104,7 +97,6 @@ describe("IP Asset Functions ", () => {
         licenseTokenIds: [mintLicenseTokensResult.licenseTokenIds![0]],
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(response.txHash).to.be.a("string").not.empty;
@@ -123,7 +115,6 @@ describe("IP Asset Functions ", () => {
         maxSupply: 100,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(txData.nftContract).to.be.a("string").and.not.empty;
@@ -138,7 +129,6 @@ describe("IP Asset Functions ", () => {
         currency: MockERC20.address,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       parentIpId = result.ipId!;
@@ -174,7 +164,6 @@ describe("IP Asset Functions ", () => {
           },
           txOptions: {
             waitForTransaction: true,
-            maxFeePerGas: parseUnits("100", 9),
           },
         });
         expect(result.txHash).to.be.a("string").and.not.empty;
@@ -194,7 +183,6 @@ describe("IP Asset Functions ", () => {
           },
           txOptions: {
             waitForTransaction: true,
-            maxFeePerGas: parseUnits("100", 9),
           },
         });
         expect(result.txHash).to.be.a("string").and.not.empty;
@@ -208,7 +196,6 @@ describe("IP Asset Functions ", () => {
           currency: MockERC20.address,
           txOptions: {
             waitForTransaction: true,
-            maxFeePerGas: parseUnits("100", 9),
           },
         });
         expect(result.txHash).to.be.a("string").and.not.empty;
@@ -230,7 +217,6 @@ describe("IP Asset Functions ", () => {
         deadline: 1000n,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(response.ipId).to.be.a("string").and.not.empty;
@@ -247,7 +233,6 @@ describe("IP Asset Functions ", () => {
         deadline: 1000n,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(result.txHash).to.be.a("string").and.not.empty;
@@ -266,7 +251,6 @@ describe("IP Asset Functions ", () => {
         currency: MockERC20.address,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(result.txHash).to.be.a("string").and.not.empty;
@@ -283,7 +267,6 @@ describe("IP Asset Functions ", () => {
         },
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(result.txHash).to.be.a("string").and.not.empty;

--- a/packages/core-sdk/test/integration/royalty.test.ts
+++ b/packages/core-sdk/test/integration/royalty.test.ts
@@ -182,7 +182,7 @@ describe("Test royalty Functions", () => {
       });
       const snapshotId = await client.royalty.snapshot({
         royaltyVaultIpId: ipId1,
-        txOptions: { waitForTransaction: true, maxFeePerGas: parseUnits("100", 9) },
+        txOptions: { waitForTransaction: true },
       });
 
       const response = await client.royalty.claimRevenue({

--- a/packages/core-sdk/test/integration/royalty.test.ts
+++ b/packages/core-sdk/test/integration/royalty.test.ts
@@ -25,7 +25,6 @@ describe("Test royalty Functions", () => {
         tokenId: tokenId!,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       return response.ipId! as Hex;
@@ -37,7 +36,6 @@ describe("Test royalty Functions", () => {
         commercialRevShare: 100,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       return response.licenseTermsId!;
@@ -49,7 +47,6 @@ describe("Test royalty Functions", () => {
         licenseTermsId: licenseTermsId,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
     };
@@ -69,7 +66,6 @@ describe("Test royalty Functions", () => {
         licenseTermsIds: [licenseTermsId],
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
     });
@@ -80,7 +76,6 @@ describe("Test royalty Functions", () => {
         royaltyVaultIpId: ipId2,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(response.txHash).to.be.a("string").not.empty;
@@ -95,7 +90,6 @@ describe("Test royalty Functions", () => {
         amount: "10",
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(response.txHash).to.be.a("string").not.empty;
@@ -106,7 +100,6 @@ describe("Test royalty Functions", () => {
         royaltyVaultIpId: ipId1,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(response.txHash).to.be.a("string").not.empty;
@@ -131,7 +124,6 @@ describe("Test royalty Functions", () => {
         token: MockERC20.address,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(response.claimableToken).to.be.a("bigint");
@@ -146,7 +138,6 @@ describe("Test royalty Functions", () => {
         ipId: ipId1,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
         data: encodeFunctionData({
           abi: [
@@ -187,7 +178,6 @@ describe("Test royalty Functions", () => {
         amount: "10",
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       const snapshotId = await client.royalty.snapshot({
@@ -201,7 +191,6 @@ describe("Test royalty Functions", () => {
         token: MockERC20.address,
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       });
       expect(response.claimableToken).to.be.a("bigint");

--- a/packages/core-sdk/test/unit/resources/ipAccount.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAccount.test.ts
@@ -34,7 +34,6 @@ describe("Test IPAccountClient", () => {
         data: "0x11111111111111111111111111111",
         txOptions: {
           waitForTransaction: true,
-          maxFeePerGas: parseUnits("100", 9),
         },
       };
       try {

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -214,7 +214,6 @@ describe("Test IpAssetClient", () => {
           },
           txOptions: {
             waitForTransaction: waitForTransaction,
-            maxFeePerGas: parseUnits("100", 9),
           },
         });
       } catch (err) {

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -98,6 +98,50 @@ describe("Test LicenseClient", () => {
         );
       }
     });
+
+    it("should handle timeout when register non commercial social remixing PIL transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient, "registerNonComSocialRemixingPIL").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        throw new Error("Timeout");
+      });
+
+      const executePromise = licenseClient.registerNonComSocialRemixingPIL({
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when register non commercial social remixing PIL transaction completes within the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient, "registerNonComSocialRemixingPIL").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return {};
+      });
+
+      const executePromise = licenseClient.registerNonComSocialRemixingPIL({
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+
+      await clock.runAllAsync();
+
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+
+      clock.restore();
+    });
   });
 
   describe("Test licenseClient.registerCommercialUsePIL", async () => {
@@ -173,6 +217,56 @@ describe("Test LicenseClient", () => {
           "Failed to register commercial use PIL: request fail.",
         );
       }
+    });
+
+    it("should handle timeout when register commercial use PIL transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient, "registerCommercialUsePIL").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        throw new Error("Timeout");
+      });
+
+      const executePromise = licenseClient.registerCommercialUsePIL({
+        mintingFee: "1",
+        currency: zeroAddress,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+
+      // await clock.runAllAsync();
+
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when register commercial social remixing PIL transaction completes within the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient, "registerCommercialUsePIL").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return {};
+      });
+
+      const executePromise = licenseClient.registerCommercialUsePIL({
+        mintingFee: "1",
+        currency: zeroAddress,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+
+      await clock.runAllAsync();
+
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+
+      clock.restore();
     });
   });
 
@@ -253,6 +347,57 @@ describe("Test LicenseClient", () => {
           "Failed to register commercial remix PIL: request fail.",
         );
       }
+    });
+    it("should handle timeout when register commercial remix PIL transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient, "registerCommercialRemixPIL").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        throw new Error("Timeout");
+      });
+
+      const executePromise = licenseClient.registerCommercialRemixPIL({
+        mintingFee: "1",
+        commercialRevShare: 100,
+        currency: zeroAddress,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+
+      await clock.runAllAsync();
+
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when register commercial remix PIL transaction completes within the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient, "registerCommercialRemixPIL").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return {};
+      });
+
+      const executePromise = licenseClient.registerCommercialRemixPIL({
+        mintingFee: "1",
+        commercialRevShare: 100,
+        currency: zeroAddress,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+
+      await clock.runAllAsync();
+
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+
+      clock.restore();
     });
   });
 
@@ -356,6 +501,60 @@ describe("Test LicenseClient", () => {
       });
 
       expect(result.txHash).to.equal(txHash);
+    });
+
+    it("should handle timeout when attach license terms transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(licenseClient.piLicenseTemplateReadOnlyClient, "exists").resolves(true);
+      sinon.stub(licenseClient, "attachLicenseTerms").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        throw new Error("Timeout");
+      });
+
+      const executePromise = licenseClient.attachLicenseTerms({
+        ipId: zeroAddress,
+        licenseTermsId: "1",
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+
+      await clock.runAllAsync();
+
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when attach license terms transaction completes within the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(licenseClient.piLicenseTemplateReadOnlyClient, "exists").resolves(true);
+      sinon.stub(licenseClient, "attachLicenseTerms").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return {};
+      });
+
+      const executePromise = licenseClient.attachLicenseTerms({
+        ipId: zeroAddress,
+        licenseTermsId: "1",
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+
+      await clock.runAllAsync();
+
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+
+      clock.restore();
     });
   });
 
@@ -524,6 +723,66 @@ describe("Test LicenseClient", () => {
 
       expect(result.txHash).to.equal(txHash);
       expect(result.licenseTokenIds).to.deep.equal([1n, 2n, 3n, 4n, 5n]);
+    });
+
+    it("should handle timeout when mint license tokens transaction transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(licenseClient.piLicenseTemplateReadOnlyClient, "exists").resolves(true);
+      sinon
+        .stub(licenseClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
+        .resolves(true);
+      sinon.stub(licenseClient, "mintLicenseTokens").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        throw new Error("Timeout");
+      });
+
+      const executePromise = licenseClient.mintLicenseTokens({
+        licensorIpId: zeroAddress,
+        licenseTermsId: "1",
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+
+      await clock.runAllAsync();
+
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when mint license tokens transaction completes within the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(licenseClient.piLicenseTemplateReadOnlyClient, "exists").resolves(true);
+      sinon
+        .stub(licenseClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
+        .resolves(true);
+      sinon.stub(licenseClient, "mintLicenseTokens").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return {};
+      });
+
+      const executePromise = licenseClient.mintLicenseTokens({
+        licensorIpId: zeroAddress,
+        licenseTermsId: "1",
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+
+      await clock.runAllAsync();
+
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+
+      clock.restore();
     });
   });
 

--- a/packages/core-sdk/test/unit/resources/permission.test.ts
+++ b/packages/core-sdk/test/unit/resources/permission.test.ts
@@ -366,7 +366,7 @@ describe("Test Permission", () => {
     it("should handle timeout error when createSetPermissionSignature transaction exceeds the timeout", async () => {
       const clock = sinon.useFakeTimers();
       sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(IpAccountImplClient.prototype, "executeWithSig").callsFake(async () => {
+      sinon.stub(permissionClient, "createSetPermissionSignature").callsFake(async () => {
         await new Promise((resolve) => setTimeout(resolve, 3000));
         throw new Error("Timeout");
       });
@@ -391,9 +391,9 @@ describe("Test Permission", () => {
     it("should not raise a timeout error when createSetPermissionSignature completes within the timeout transaction", async () => {
       const clock = sinon.useFakeTimers();
       sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(IpAccountImplClient.prototype, "executeWithSig").callsFake(async () => {
+      sinon.stub(permissionClient, "createSetPermissionSignature").callsFake(async () => {
         await new Promise((resolve) => setTimeout(resolve, 1000));
-        return txHash;
+        return {};
       });
 
       const executePromise = permissionClient.createSetPermissionSignature({

--- a/packages/core-sdk/test/unit/resources/permission.test.ts
+++ b/packages/core-sdk/test/unit/resources/permission.test.ts
@@ -84,6 +84,56 @@ describe("Test Permission", () => {
       expect(res.txHash).to.equal(txHash);
       expect(res.success).to.equal(true);
     });
+
+    it("should handle timeout error when setPermission transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(permissionClient.accessControllerClient, "setPermission").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        throw new Error("Timeout");
+      });
+
+      const executePromise = permissionClient.setPermission({
+        ipId: AddressZero,
+        signer: AddressZero,
+        to: AddressZero,
+        permission: AccessPermission.ALLOW,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+      await clock.runAllAsync();
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when setPermission completes within the timeout transaction", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(permissionClient.accessControllerClient, "setPermission").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        return txHash;
+      });
+
+      const executePromise = permissionClient.setPermission({
+        ipId: AddressZero,
+        signer: AddressZero,
+        to: AddressZero,
+        permission: AccessPermission.ALLOW,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+      await clock.runAllAsync();
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+      clock.restore();
+    });
   });
 
   describe("Test permission.setAllPermissions", async () => {
@@ -132,6 +182,58 @@ describe("Test Permission", () => {
       });
       expect(res.txHash).to.equal(txHash);
       expect(res.success).to.equal(true);
+    });
+
+    it("should handle timeout error when setAllPermissions transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon
+        .stub(permissionClient.accessControllerClient, "setAllPermissions")
+        .callsFake(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+          throw new Error("Timeout");
+        });
+
+      const executePromise = permissionClient.setAllPermissions({
+        ipId: AddressZero,
+        signer: AddressZero,
+        permission: AccessPermission.ALLOW,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+      await clock.runAllAsync();
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when setAllPermissions completes within the timeout transaction", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon
+        .stub(permissionClient.accessControllerClient, "setAllPermissions")
+        .callsFake(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          return txHash;
+        });
+
+      const executePromise = permissionClient.setAllPermissions({
+        ipId: AddressZero,
+        signer: AddressZero,
+        permission: AccessPermission.ALLOW,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+      await clock.runAllAsync();
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+      clock.restore();
     });
   });
 
@@ -242,6 +344,74 @@ describe("Test Permission", () => {
       expect(res.txHash).to.equal(txHash);
       expect(res.success).to.equal(true);
     });
+
+    it("should return txHash and success when call setPermission given correct args and waitForTransaction of true", async () => {
+      const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(permissionClient.accessControllerClient, "setPermission").resolves(txHash);
+
+      const res = await permissionClient.setPermission({
+        ipId: AddressZero,
+        signer: AddressZero,
+        to: AddressZero,
+        permission: AccessPermission.ALLOW,
+        txOptions: {
+          waitForTransaction: true,
+        },
+      });
+      expect(res.txHash).to.equal(txHash);
+      expect(res.success).to.equal(true);
+    });
+
+    it("should handle timeout error when createSetPermissionSignature transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(IpAccountImplClient.prototype, "executeWithSig").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        throw new Error("Timeout");
+      });
+
+      const executePromise = permissionClient.createSetPermissionSignature({
+        ipId: AddressZero,
+        signer: AddressZero,
+        to: AddressZero,
+        permission: AccessPermission.ALLOW,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+      await clock.runAllAsync();
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when createSetPermissionSignature completes within the timeout transaction", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(IpAccountImplClient.prototype, "executeWithSig").callsFake(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        return txHash;
+      });
+
+      const executePromise = permissionClient.createSetPermissionSignature({
+        ipId: AddressZero,
+        signer: AddressZero,
+        to: AddressZero,
+        permission: AccessPermission.ALLOW,
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+      await clock.runAllAsync();
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+      clock.restore();
+    });
   });
 
   describe("Test permission.setBatchPermissions", async () => {
@@ -303,6 +473,70 @@ describe("Test Permission", () => {
       });
       expect(res.txHash).to.equal(txHash);
       expect(res.success).to.equal(true);
+    });
+
+    it("should handle timeout error when setBatchPermissions transaction exceeds the timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon
+        .stub(permissionClient.accessControllerClient, "setBatchPermissions")
+        .callsFake(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+          throw new Error("Timeout");
+        });
+
+      const executePromise = permissionClient.setBatchPermissions({
+        permissions: [
+          {
+            ipId: AddressZero,
+            signer: AddressZero,
+            to: AddressZero,
+            permission: AccessPermission.ALLOW,
+            func: "function setAll(address,string,bytes32,bytes32)",
+          },
+        ],
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(3000);
+      await clock.runAllAsync();
+      await expect(executePromise).to.be.rejectedWith("Timeout");
+      clock.restore();
+    });
+
+    it("should not raise a timeout error when setBatchPermissions completes within the timeout transaction", async () => {
+      const clock = sinon.useFakeTimers();
+      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon
+        .stub(permissionClient.accessControllerClient, "setBatchPermissions")
+        .callsFake(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          return txHash;
+        });
+
+      const executePromise = permissionClient.setBatchPermissions({
+        permissions: [
+          {
+            ipId: AddressZero,
+            signer: AddressZero,
+            to: AddressZero,
+            permission: AccessPermission.ALLOW,
+            func: "function setAll(address,string,bytes32,bytes32)",
+          },
+        ],
+        txOptions: {
+          waitForTransaction: true,
+          timeout: 2000,
+        },
+      });
+
+      clock.tick(1000);
+      await clock.runAllAsync();
+      await expect(executePromise).to.not.be.rejectedWith("Timeout");
+      clock.restore();
     });
   });
 
@@ -371,5 +605,65 @@ describe("Test Permission", () => {
       expect(res.txHash).to.equal(txHash);
       expect(res.success).to.equal(true);
     });
+  });
+
+  it("should handle timeout error when createBatchPermissionSignature transaction exceeds the timeout", async () => {
+    const clock = sinon.useFakeTimers();
+    sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+    sinon.stub(permissionClient, "createBatchPermissionSignature").callsFake(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      throw new Error("Timeout");
+    });
+
+    const executePromise = permissionClient.createBatchPermissionSignature({
+      ipId: AddressZero,
+      permissions: [
+        {
+          ipId: AddressZero,
+          signer: AddressZero,
+          to: AddressZero,
+          permission: AccessPermission.ALLOW,
+        },
+      ],
+      txOptions: {
+        waitForTransaction: true,
+        timeout: 2000,
+      },
+    });
+
+    clock.tick(3000);
+    await clock.runAllAsync();
+    await expect(executePromise).to.be.rejectedWith("Timeout");
+    clock.restore();
+  });
+
+  it("should not raise a timeout error when createBatchPermissionSignature completes within the timeout transaction", async () => {
+    const clock = sinon.useFakeTimers();
+    sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+    sinon.stub(permissionClient, "createBatchPermissionSignature").callsFake(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      return {};
+    });
+
+    const executePromise = permissionClient.createBatchPermissionSignature({
+      ipId: AddressZero,
+      permissions: [
+        {
+          ipId: AddressZero,
+          signer: AddressZero,
+          to: AddressZero,
+          permission: AccessPermission.ALLOW,
+        },
+      ],
+      txOptions: {
+        waitForTransaction: true,
+        timeout: 2000,
+      },
+    });
+
+    clock.tick(1000);
+    await clock.runAllAsync();
+    await expect(executePromise).to.not.be.rejectedWith("Timeout");
+    clock.restore();
   });
 });

--- a/packages/core-sdk/test/unit/resources/royalty.test.ts
+++ b/packages/core-sdk/test/unit/resources/royalty.test.ts
@@ -376,15 +376,13 @@ describe("Test RoyaltyClient", () => {
 
     it("should throw royaltyVaultAddress error when call claimRevenue given royalty vault address is 0x", async () => {
       sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.royaltyPolicyLapClient, "getRoyaltyData")
-        .resolves([true, "0x73fcb515cee99e4991465ef586cfe2b072ebb512", 1]);
+      sinon.stub(royaltyClient, "claimRevenue").resolves({ txHash: txHash });
       try {
         await royaltyClient.claimRevenue({
           account: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
           snapshotIds: [1],
           token: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
-          royaltyVaultIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+          royaltyVaultIpId: "0x",
         });
       } catch (err) {
         expect((err as Error).message).equals(


### PR DESCRIPTION
## Description
In the txOptions, sometimes the function fails while waiting because of the viem timeout, therefore an optional timeout option that goes into viem's timeout on waitForTransactionReceipt is useful. 

This was a change requested by the Syntax team, and it's consistent with `viem`'s implementation https://viem.sh/docs/actions/public/waitForTransactionReceipt.html