### PR TITLE
Update ipAsset.ts

### DIFF
--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -833,7 +833,7 @@ export class IPAssetClient {
             hash: txHash,
           });
           const log = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(receipt)[0];
-          return { txHash, childIpId: log.ipId };
+          return { txHash, childIpId: log.ipId, tokenId: log.tokenId };
         }
         return { txHash };
       }


### PR DESCRIPTION
Modified the mintAndRegisterIpAndMakeDerivative function to include the return of tokenId, similar to the behavior in mintAndRegisterIpAssetWithPilTerms. This ensures consistency across functions that involve IP registration and minting.

## Description
- Added the `tokenId` to the return statement in `mintAndRegisterIpAndMakeDerivative`.
- This change brings parity with `mintAndRegisterIpAssetWithPilTerms` by ensuring both methods return the `tokenId`.

## Test Plan
- Validate the functionality by minting an IP and ensuring the response includes the `tokenId`.
- Conduct tests with different IP and derivative data to confirm the new return structure.

## Related Issue
[Issue #266](https://github.com/storyprotocol/sdk/issues/266)

## Notes
- No additional dependencies were added.
- Ensure downstream components are compatible with the updated return structure.
