### PR TITLE
Add two methods and return tokenId from mintAndRegisterIpAndMakeDerivative

### DIFF
--- a/packages/core-sdk/src/abi/generated.ts
+++ b/packages/core-sdk/src/abi/generated.ts
@@ -18485,6 +18485,26 @@ export type LicensingModuleRegisterDerivativeWithLicenseTokensRequest = {
 };
 
 /**
+ * LicensingModuleSetLicensingConfigRequest
+ *
+ * @param ipId address
+ * @param licenseTemplate address
+ * @param licenseTermsId uint256
+ * @param licensingConfig tuple
+ */
+export type LicensingModuleSetLicensingConfigRequest = {
+  ipId: Address;
+  licenseTemplate: Address;
+  licenseTermsId: bigint;
+  licensingConfig: {
+    isSet: boolean;
+    mintingFee: bigint;
+    licensingHook: Address;
+    hookData: Hex;
+  };
+};
+
+/**
  * contract LicensingModule event
  */
 export class LicensingModuleEventClient {
@@ -18799,6 +18819,54 @@ export class LicensingModuleClient extends LicensingModuleReadOnlyClient {
         abi: licensingModuleAbi,
         functionName: "registerDerivativeWithLicenseTokens",
         args: [request.childIpId, request.licenseTokenIds, request.royaltyContext],
+      }),
+    };
+  }
+
+  /**
+   * method setLicensingConfig for contract LicensingModule
+   *
+   * @param request LicensingModuleSetLicensingConfigRequest
+   * @return Promise<WriteContractReturnType>
+   */
+  public async setLicensingConfig(
+    request: LicensingModuleSetLicensingConfigRequest,
+  ): Promise<WriteContractReturnType> {
+    const { request: call } = await this.rpcClient.simulateContract({
+      abi: licensingModuleAbi,
+      address: this.address,
+      functionName: "setLicensingConfig",
+      account: this.wallet.account,
+      args: [
+        request.ipId,
+        request.licenseTemplate,
+        request.licenseTermsId,
+        request.licensingConfig,
+      ],
+    });
+    return await this.wallet.writeContract(call as WriteContractParameters);
+  }
+
+  /**
+   * method setLicensingConfig for contract LicensingModule with only encode
+   *
+   * @param request LicensingModuleSetLicensingConfigRequest
+   * @return EncodedTxData
+   */
+  public setLicensingConfigEncode(
+    request: LicensingModuleSetLicensingConfigRequest,
+  ): EncodedTxData {
+    return {
+      to: this.address,
+      data: encodeFunctionData({
+        abi: licensingModuleAbi,
+        functionName: "setLicensingConfig",
+        args: [
+          request.ipId,
+          request.licenseTemplate,
+          request.licenseTermsId,
+          request.licensingConfig,
+        ],
       }),
     };
   }

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -55,6 +55,8 @@ export type {
   LicenseTermsId,
   LicenseTerms,
   PredictMintingLicenseFeeRequest,
+  SetLicensingConfigRequest,
+  SetLicensingConfigResponse,
 } from "./types/resources/license";
 export { PIL_TYPE } from "./types/resources/license";
 

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -54,6 +54,7 @@ export type {
   MintLicenseTokensResponse,
   LicenseTermsId,
   LicenseTerms,
+  PredictMintingLicenseFeeRequest,
 } from "./types/resources/license";
 export { PIL_TYPE } from "./types/resources/license";
 
@@ -124,6 +125,7 @@ export type {
   PiLicenseTemplateGetLicenseTermsResponse,
   IpAccountImplStateResponse,
   EncodedTxData,
+  LicensingModulePredictMintingLicenseFeeResponse,
 } from "./abi/generated";
 
 export { getPermissionSignature } from "./utils/sign";

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -811,7 +811,7 @@ export class IPAssetClient {
    *   @param request.ipMetadata.nftMetadataHash [Optional] The hash of the metadata for the IP NFT.
    *   @param request.recipient [Optional] The address of the recipient of the minted NFT,default value is your wallet address.
    *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to an object containing the transaction hash and optional IP ID if waitForTxn is set to true.
+   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes child ip id and token id.
    * @emits IPRegistered (ipId, chainId, tokenContract, tokenId, name, uri, registrationDate)
    */
   public async mintAndRegisterIpAndMakeDerivative(
@@ -873,7 +873,7 @@ export class IPAssetClient {
             hash: txHash,
           });
           const log = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(receipt)[0];
-          return { txHash, childIpId: log.ipId };
+          return { txHash, childIpId: log.ipId, tokenId: log.tokenId };
         }
         return { txHash };
       }

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -41,6 +41,7 @@ export type RegisterDerivativeResponse = {
   txHash?: string;
   encodedTxData?: EncodedTxData;
   childIpId?: Address;
+  tokenId?: bigint;
 };
 
 export type CreateIpAssetWithPilTermsRequest = {

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -145,7 +145,7 @@ export type SetLicensingConfigRequest = {
     hookData: Hex;
   };
   licenseTemplate: Address;
-  txOptions?: TxOptions; 
+  txOptions?: TxOptions;
 };
 
 export type SetLicensingConfigResponse = {

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import { Address, Hex } from "viem";
 
 import { TxOptions } from "../options";
 import { EncodedTxData } from "../../abi/generated";
@@ -133,4 +133,23 @@ export type PredictMintingLicenseFeeRequest = {
   licenseTemplate?: Address;
   receiver?: Address;
   txOptions?: TxOptions;
+};
+
+export type SetLicensingConfigRequest = {
+  ipId: Address;
+  licenseTermsId: string | number | bigint;
+  licensingConfig: {
+    isSet: boolean;
+    mintingFee: bigint | string | number;
+    licensingHook: Address;
+    hookData: Hex;
+  };
+  licenseTemplate: Address;
+  txOptions?: TxOptions; 
+};
+
+export type SetLicensingConfigResponse = {
+  txHash?: string;
+  encodedTxData?: EncodedTxData;
+  success?: boolean;
 };

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -125,3 +125,12 @@ export enum PIL_TYPE {
 }
 
 export type LicenseTermsId = string | number | bigint;
+
+export type PredictMintingLicenseFeeRequest = {
+  licensorIpId: Address;
+  licenseTermsId: LicenseTermsId;
+  amount: string | number | bigint;
+  licenseTemplate?: Address;
+  receiver?: Address;
+  txOptions?: TxOptions;
+};

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -282,6 +282,7 @@ describe("IP Asset Functions ", () => {
       });
       expect(result.txHash).to.be.a("string").and.not.empty;
       expect(result.childIpId).to.be.a("string").and.not.empty;
+      expect(result.tokenId).to.be.a("bigint");
     });
 
     it("should not throw error when mint and register ip", async () => {

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -137,5 +137,25 @@ describe("License Functions", () => {
       expect(result.currencyToken).to.be.a("string").and.not.empty;
       expect(result.tokenAmount).to.be.a("bigint");
     });
+
+    it("should not throw error when set licensing config", async () => {
+      const licenseModule = licensingModuleAddress[odyssey];
+      const result = await client.license.setLicensingConfig({
+        ipId: ipId,
+        licenseTermsId: 0n,
+        licenseTemplate: zeroAddress,
+        licensingConfig: {
+          mintingFee: "1",
+          isSet: true,
+          licensingHook: zeroAddress,
+          hookData: "0xFcd3243590d29B131a26B1554B0b21a5B43e622e",
+        },
+        txOptions: {
+          waitForTransaction: true,
+        },
+      });
+      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.success).to.be.true;
+    });
   });
 });

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -127,5 +127,15 @@ describe("License Functions", () => {
       const result = await client.license.getLicenseTerms(licenseId);
       expect(result).not.empty;
     });
+
+    it("should not throw error when predict minting license fee", async () => {
+      const result = await client.license.predictMintingLicenseFee({
+        licenseTermsId: licenseId,
+        licensorIpId: ipId,
+        amount: 1,
+      });
+      expect(result.currencyToken).to.be.a("string").and.not.empty;
+      expect(result.tokenAmount).to.be.a("bigint");
+    });
   });
 });

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -829,4 +829,76 @@ describe("Test LicenseClient", () => {
       }
     });
   });
+
+  describe("Test licenseClient.predictMintingLicenseFee", async () => {
+    it("should throw register error when call predictMintingLicenseFee given licenseTermsId is not registered", async () => {
+      sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      try {
+        await licenseClient.predictMintingLicenseFee({
+          licenseTermsId: "1",
+          licensorIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+          amount: "",
+        });
+      } catch (error) {
+        expect((error as Error).message).equal(
+          "Failed to predict minting license fee: The licensor IP with id 0x73fcb515cee99e4991465ef586cfe2b072ebb512 is not registered.",
+        );
+      }
+    });
+
+    it("should throw licenseTermsId error when call predictMintingLicenseFee given licenseTermsId is not exist", async () => {
+      sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(licenseClient.piLicenseTemplateReadOnlyClient, "exists").resolves(false);
+      try {
+        await licenseClient.predictMintingLicenseFee({
+          licenseTermsId: "1",
+          licensorIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+          amount: "",
+        });
+      } catch (error) {
+        expect((error as Error).message).equal(
+          "Failed to predict minting license fee: License terms id 1 do not exist.",
+        );
+      }
+    });
+
+    it("should return currency token and token amount when call predictMintingLicenseFee given licenseTemplate and receiver", async () => {
+      sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(licenseClient.piLicenseTemplateReadOnlyClient, "exists").resolves(true);
+      sinon.stub(licenseClient.licensingModuleClient, "predictMintingLicenseFee").resolves({
+        currencyToken: zeroAddress,
+        tokenAmount: 1n,
+      });
+      const result = await licenseClient.predictMintingLicenseFee({
+        licenseTermsId: "1",
+        licensorIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+        amount: "",
+        licenseTemplate: zeroAddress,
+        receiver: zeroAddress,
+      });
+
+      expect(result).to.deep.equal({
+        currencyToken: zeroAddress,
+        tokenAmount: 1n,
+      });
+    });
+    it("should return currency token and token amount when call predictMintingLicenseFee given correct args ", async () => {
+      sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(licenseClient.piLicenseTemplateReadOnlyClient, "exists").resolves(true);
+      sinon.stub(licenseClient.licensingModuleClient, "predictMintingLicenseFee").resolves({
+        currencyToken: zeroAddress,
+        tokenAmount: 1n,
+      });
+      const result = await licenseClient.predictMintingLicenseFee({
+        licenseTermsId: "1",
+        licensorIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+        amount: "",
+      });
+
+      expect(result).to.deep.equal({
+        currencyToken: zeroAddress,
+        tokenAmount: 1n,
+      });
+    });
+  });
 });

--- a/packages/wagmi-generator/wagmi.config.ts
+++ b/packages/wagmi-generator/wagmi.config.ts
@@ -218,6 +218,7 @@ export default defineConfig(async () => {
             "getLicenseTerms",
             "LicenseTermsAttached",
             "predictMintingLicenseFee",
+            "setLicensingConfig",
           ],
           ModuleRegistry: ["isRegistered", "getDefaultLicenseTerms"],
           RoyaltyModule: [


### PR DESCRIPTION
## Description
- Return tokenId from mintAndRegisterIpAndMakeDerivative
- Add predictMintingLicenseFee to licensing module
- Add setLicenseConfig methods

## Test result

<img width="661" alt="image" src="https://github.com/user-attachments/assets/5f42290e-9e7b-4a94-863a-04dc6dd9396f">
<img width="711" alt="image" src="https://github.com/user-attachments/assets/42612969-1388-4264-8127-ef633d32ae55">


