### PR TITLE
remove attach license terms check from mintLicenseTokens

### DIFF
--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -370,20 +370,6 @@ export class LicenseClient {
       if (!isExisted) {
         throw new Error(`License terms id ${request.licenseTermsId} do not exist.`);
       }
-      const isAttachedLicenseTerms =
-        await this.licenseRegistryReadOnlyClient.hasIpAttachedLicenseTerms({
-          ipId: request.licensorIpId,
-          licenseTemplate:
-            (request.licenseTemplate &&
-              getAddress(request.licenseTemplate, "request.licenseTemplate")) ||
-            this.licenseTemplateClient.address,
-          licenseTermsId: request.licenseTermsId,
-        });
-      if (!isAttachedLicenseTerms) {
-        throw new Error(
-          `License terms id ${request.licenseTermsId} is not attached to the IP with id ${request.licensorIpId}.`,
-        );
-      }
       const amount = BigInt(request.amount || 1);
       const req = {
         licensorIpId: request.licensorIpId,


### PR DESCRIPTION
This PR removes the following code from `mintLicenseTokens`:

```
const isAttachedLicenseTerms =
        await this.licenseRegistryReadOnlyClient.hasIpAttachedLicenseTerms({
          ipId: request.licensorIpId,
          licenseTemplate:
            (request.licenseTemplate &&
              getAddress(request.licenseTemplate, "request.licenseTemplate")) ||
            this.licenseTemplateClient.address,
          licenseTermsId: request.licenseTermsId,
        });
      if (!isAttachedLicenseTerms) {
        throw new Error(
          `License terms id ${request.licenseTermsId} is not attached to the IP with id ${request.licensorIpId}.`,
        );
      }
```

The reason for this change is because, as the mintLicenseTokens function is described, it should be able to mint **private license tokens**: "IP owners can mint license tokens for their IPs for arbitrary license terms without attaching the license terms to IP." 

The function is currently throwing an error if the terms are not attached, but an IP owner should call this function and be able to mint license tokens even if the terms aren't attached.

I wanted to add a check to see if the IP owner == the sender of the call, but I couldn't find an SDK function to do this, and other functions like `attachLicenseTerms` don't make this check either.