### PR TITLE
Fix typos

### DIFF
--- a/packages/core-sdk/src/client.ts
+++ b/packages/core-sdk/src/client.ts
@@ -73,7 +73,7 @@ export class StoryClient {
   }
 
   /**
-   * Factory method for creating a SDK client with a signer.
+   * Factory method for creating an SDK client with a signer.
    *
    * @param config StoryClient - the configuration for a new SDK client
    */
@@ -82,7 +82,7 @@ export class StoryClient {
   }
 
   /**
-   * Factory method for creating a SDK client with a signer.
+   * Factory method for creating an SDK client with a signer.
    *
    * @param config WalletClientConfig - the configuration for a new SDK client
    */
@@ -95,7 +95,7 @@ export class StoryClient {
   }
 
   /**
-   * Factory method for creating a SDK client with a signer.
+   * Factory method for creating an SDK client with a signer.
    *
    * @param config UseAccountStoryConfig - the configuration for a new SDK client
    */

--- a/packages/core-sdk/src/resources/nftClient.ts
+++ b/packages/core-sdk/src/resources/nftClient.ts
@@ -25,7 +25,7 @@ export class NftClient {
 
   /**
    * Creates a new SPG NFT Collection.
-   * @param request - The request object containing necessary data to create a SPG NFT Collection.
+   * @param request - The request object containing necessary data to create an SPG NFT Collection.
    *   @param request.name - The name of the collection.
    * 	 @param request.symbol - The symbol of the collection.
    * 	 @param request.isPublicMinting - If true, anyone can mint from the collection. If false, only the addresses with the minter role can mint.
@@ -91,7 +91,7 @@ export class NftClient {
         return { txHash: txHash };
       }
     } catch (error) {
-      handleError(error, "Failed to create a SPG NFT collection");
+      handleError(error, "Failed to create an SPG NFT collection");
     }
   }
 }

--- a/packages/core-sdk/test/unit/resources/nftClient.test.ts
+++ b/packages/core-sdk/test/unit/resources/nftClient.test.ts
@@ -40,7 +40,7 @@ describe("Test NftClient", () => {
         });
       } catch (e) {
         expect((e as Error).message).equal(
-          "Failed to create a SPG NFT collection: Invalid mint fee token address, mint fee is greater than 0.",
+          "Failed to create an SPG NFT collection: Invalid mint fee token address, mint fee is greater than 0.",
         );
       }
     });
@@ -59,7 +59,7 @@ describe("Test NftClient", () => {
         });
       } catch (e) {
         expect((e as Error).message).equal(
-          "Failed to create a SPG NFT collection: Invalid mint fee token address, mint fee is greater than 0.",
+          "Failed to create an SPG NFT collection: Invalid mint fee token address, mint fee is greater than 0.",
         );
       }
     });

--- a/packages/react-sdk/src/resources/useNftClient.ts
+++ b/packages/react-sdk/src/resources/useNftClient.ts
@@ -18,7 +18,7 @@ const useNftClient = () => {
 
   /**
    * Creates a new SPG NFT Collection.
-   * @param request - The request object containing necessary data to create a SPG NFT Collection.
+   * @param request - The request object containing necessary data to create an SPG NFT Collection.
    *   @param request.name - The name of the collection.
    * 	 @param request.symbol - The symbol of the collection.
    * 	 @param request.maxSupply - The maximum supply of the collection.


### PR DESCRIPTION
This pull request addresses multiple occurrences of incorrect usage of the article "a" where "an" is required before words starting with vowel sounds. The changes improve grammatical accuracy in code comments and error messages.  

### Files Changed  
1. **`client.ts`**  
   - Updated comments to replace "a SDK" with "an SDK".  

2. **`nftClient.ts`**  
   - Replaced "a SPG NFT Collection" with "an SPG NFT Collection".  

3. **`nftClient.test.ts`**  
   - Corrected error messages: changed "a SPG NFT collection" to "an SPG NFT collection".  

4. **`useNftClient.ts`**  
   - Updated comments: replaced "a SPG NFT Collection" with "an SPG NFT Collection".  
