### PR TITLE
Fix: StoryClient Initialization in StoryProvider

### DIFF
--- a/packages/react-sdk/src/StoryProtocolContext.tsx
+++ b/packages/react-sdk/src/StoryProtocolContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode, useState } from "react";
+import { createContext, useContext, ReactNode, useState, useEffect } from "react";
 import { StoryClient, StoryConfig } from "@story-protocol/core-sdk";
 
 type Props = {
@@ -9,16 +9,23 @@ type Props = {
 const StoryContext = createContext<StoryClient>({} as StoryClient);
 
 const StoryProvider = ({ config, children }: Props) => {
-  const [client, setClient] = useState<StoryClient>();
+  const [client, setClient] = useState<StoryClient | undefined>(undefined);
+
+  useEffect(() => {
+    setClient(StoryClient.newClient(config));
+  }, [config]);
 
   if (!client) {
-    setClient(StoryClient.newClient(config));
+    return <div>Loading...</div>; // Loading state while the client is being created
   }
+
   return (
-    <StoryContext.Provider value={client!}>{children}</StoryContext.Provider>
+    <StoryContext.Provider value={client}>{children}</StoryContext.Provider>
   );
 };
+
 const useStoryContext = (): StoryClient => {
   return useContext(StoryContext);
 };
+
 export { useStoryContext, StoryProvider };


### PR DESCRIPTION
## Description

This PR fixes an issue where the `StoryClient` was being re-initialized on every render inside the `StoryProvider` component. This led to an infinite re-render loop and impacted the application’s performance. 

### Problem & Solution:
The `StoryClient` was being re-created on every render, causing an infinite re-render loop. By implementing lazy initialization, the client is now created only once when needed, preventing unnecessary renders and improving performance.

### Key Changes:
1. **Lazy Initialization:** The `StoryClient` initialization is moved to a `useEffect` hook, ensuring it is created only once when the component is first mounted.
2. **Loading State:** A loading state is introduced during the client initialization process to enhance user experience, ensuring that the component remains stable while the client is being set up.

---

## Test Plan

### Steps to Verify:
1. **Initial Render:**
   - Ensure that `StoryClient` is created only once during the component's first render.
   - Confirm that no re-renders are triggered unnecessarily due to the client being re-created.

2. **Loading State:**
   - Verify that a loading state is displayed while the `StoryClient` is being initialized.
   - Confirm that the loading state disappears once the client is initialized and the child components are rendered.

3. **Edge Cases:**
   - Test the component with various configurations of `StoryClient` to ensure no unexpected errors or performance issues occur.

---

## Related Issue
N/A

---

## Notes
This update optimizes the performance of the `StoryProvider` component and ensures the `StoryClient` is only initialized when needed, reducing unnecessary renders. Minor refactoring has also been applied to maintain compatibility.
