### PR TITLE
Update variable name from WALLET_PRIVATE_KEY to PRIVATE_KEY in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The SDK supports using `viem` for initiating SDK client. Create a typescript fil
 import { privateKeyToAccount } from "viem/accounts";
 
 const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "0x";
-const account = privateKeyToAccount(WALLET_PRIVATE_KEY as Address);
+const account = privateKeyToAccount(PRIVATE_KEY as Address);
 ```
 
 The preceding code created the `account` object for creating the SDK client.


### PR DESCRIPTION
**This PR updates the variable name in the wallet setup example code for consistency:**
- Changed variable name from `WALLET_PRIVATE_KEY` to `PRIVATE_KEY` in `privateKeyToAccount` call
- Makes the code example more consistent by using the same variable name throughout
- Improves code readability and prevents potential confusion