### PR TITLE
fix: disable react-sdk integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "turbo run lint",
     "fix": "turbo run fix",
     "test": "turbo run test --no-cache --concurrency=1",
-    "test:integration": "turbo run test:integration --no-cache",
+    "test:integration": "turbo run test:integration --no-cache --filter=!@story-protocol/react-sdk",
     "prepare": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
Iliad is no longer available so these tests will fail and block some CI flows. disabling for now until we fix these tests.