### PR TITLE
404 link fix in the pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3043,7 +3043,7 @@ packages:
 
   /@motionone/vue@10.16.4:
     resolution: {integrity: sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==}
-    deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion
+    deprecated: Motion One for Vue is deprecated. Use Oku Motion instead https://motion.oku-ui.com/
     dependencies:
       '@motionone/dom': 10.17.0
       tslib: 2.6.2


### PR DESCRIPTION
# Pull Request Title
Fix broken link in pnpm-lock.yaml

## Description
This PR fixes a broken link in the `pnpm-lock.yaml` file. The deprecated Motion One for Vue link has been updated to the correct Oku Motion URL.

## Changes
- **File**: `pnpm-lock.yaml`
- **Line**: 3043
- **Change**: Updated the deprecated link from `https://oku-ui.com/motion` to `https://motion.oku-ui.com/`.
