### PR TITLE
feat: remove homer and add aeneid support

### DIFF
--- a/packages/core-sdk/src/client.ts
+++ b/packages/core-sdk/src/client.ts
@@ -43,7 +43,7 @@ export class StoryClient {
   private constructor(config: StoryConfig) {
     this.config = {
       ...config,
-      chainId: chain[config.chainId || "homer"],
+      chainId: chain[config.chainId || "aeneid"],
     };
     if (!this.config.transport) {
       throw new Error(

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -1,6 +1,6 @@
 export { StoryClient } from "./client";
 export { AddressZero, HashZero } from "./constants/common";
-export { homer } from "./utils/chain";
+export { aeneid } from "./utils/chain";
 export { IPAssetClient } from "./resources/ipAsset";
 export { PermissionClient } from "./resources/permission";
 export { LicenseClient } from "./resources/license";

--- a/packages/core-sdk/src/types/config.ts
+++ b/packages/core-sdk/src/types/config.ts
@@ -7,7 +7,7 @@ import { SimpleWalletClient } from "../abi/generated";
  *
  * @public
  */
-export type SupportedChainIds = "1315" | "homer";
+export type SupportedChainIds = "1315" | "aeneid";
 
 /**
  * Configuration for the SDK Client.

--- a/packages/core-sdk/src/types/options.ts
+++ b/packages/core-sdk/src/types/options.ts
@@ -1,6 +1,6 @@
 import { WaitForTransactionReceiptParameters } from "viem";
 
-export interface TxOptions extends Omit<WaitForTransactionReceiptParameters, "hash"> {
+export type TxOptions = Omit<WaitForTransactionReceiptParameters, "hash"> & {
   // Whether or not to wait for the transaction so you
   // can receive a transaction receipt in return (which
   // contains data about the transaction and return values).
@@ -9,7 +9,7 @@ export interface TxOptions extends Omit<WaitForTransactionReceiptParameters, "ha
   // not submit and execute, it will only encode the abi and
   // function data and return.
   encodedTxDataOnly?: boolean;
-}
+};
 
 export type WithTxOptions<T> = T & {
   txOptions?: TxOptions;

--- a/packages/core-sdk/src/utils/chain.ts
+++ b/packages/core-sdk/src/utils/chain.ts
@@ -1,18 +1,18 @@
 import { defineChain } from "viem/utils";
 
-export const homer = defineChain({
+export const aeneid = defineChain({
   id: 13_15,
-  name: "homer",
+  name: "aeneid",
   nativeCurrency: { name: "IP", symbol: "IP", decimals: 18 },
   rpcUrls: {
     default: {
-      http: ["https://devnet.storyrpc.io/"],
+      http: ["https://aeneid.storyrpc.io/"],
     },
   },
   blockExplorers: {
     default: {
       name: "Explorer",
-      url: "https://devnet.storyscan.xyz/",
+      url: "https://aeneid.storyscan.xyz/",
     },
   },
   contracts: {

--- a/packages/core-sdk/src/utils/errors.ts
+++ b/packages/core-sdk/src/utils/errors.ts
@@ -1,6 +1,8 @@
 export function handleError(error: unknown, msg: string): never {
   if (error instanceof Error) {
-    throw new Error(`${msg}: ${error.message}`);
+    const newError = new Error(`${msg}: ${error.message}`);
+    newError.stack = error.stack;
+    throw newError;
   }
   throw new Error(`${msg}: Unknown error type`);
 }

--- a/packages/core-sdk/src/utils/utils.ts
+++ b/packages/core-sdk/src/utils/utils.ts
@@ -10,10 +10,11 @@ import {
   isAddress,
   checksumAddress,
   Address,
+  formatEther,
 } from "viem";
 
 import { SupportedChainIds } from "../types/config";
-import { homer } from "./chain";
+import { aeneid } from "./chain";
 
 export async function waitTxAndFilterLog<
   const TAbi extends Abi | readonly unknown[],
@@ -80,18 +81,26 @@ export async function waitTx(
 export function chainStringToViemChain(chainId: SupportedChainIds): Chain {
   switch (chainId.toString()) {
     case "1315":
-    case "homer":
-      return homer;
+    case "aeneid":
+      return aeneid;
     default:
       throw new Error(`ChainId ${chainId as string} not supported`);
   }
 }
 
 export const chain: { [key in SupportedChainIds]: "1315" } = {
-  homer: "1315",
+  aeneid: "1315",
   1315: "1315",
 };
 
+export const validateAddress = (address: string): Address => {
+  if (!isAddress(address, { strict: false })) {
+    throw Error(`Invalid address: ${address}`);
+  }
+  return address;
+};
+
+/** @deprecated use {@link validateAddress} */
 export const getAddress = (address: string, name: string, chainId?: number): Address => {
   if (!isAddress(address, { strict: false })) {
     throw Error(
@@ -100,3 +109,7 @@ export const getAddress = (address: string, name: string, chainId?: number): Add
   }
   return checksumAddress(address, chainId);
 };
+
+export function getIPAmountDisplay(amount: bigint): string {
+  return `${formatEther(amount)}IP`;
+}

--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import { StoryClient } from "../../src";
 import { RaiseDisputeRequest } from "../../src/index";
-import { mockERC721, getStoryClient, getTokenId, homer } from "./utils/util";
+import { mockERC721, getStoryClient, getTokenId, aeneid } from "./utils/util";
 import chaiAsPromised from "chai-as-promised";
 import { Address } from "viem";
 import { MockERC20 } from "./utils/mockERC20";
@@ -17,8 +17,8 @@ describe("Dispute Functions", () => {
   before(async () => {
     clientA = getStoryClient();
     clientB = getStoryClient();
-    const mockERC20 = new MockERC20(erc20TokenAddress[homer]);
-    await mockERC20.approve(arbitrationPolicyUmaAddress[homer]);
+    const mockERC20 = new MockERC20(erc20TokenAddress[aeneid]);
+    await mockERC20.approve(arbitrationPolicyUmaAddress[aeneid]);
     const tokenId = await getTokenId();
     ipIdB = (
       await clientB.ipAsset.register({
@@ -65,7 +65,7 @@ describe("Dispute Functions", () => {
 
   it("should throw error when bond exceeds maximum", async () => {
     const maxBonds = await clientA.dispute.arbitrationPolicyUmaReadOnlyClient.maxBonds({
-      token: erc20TokenAddress[homer],
+      token: erc20TokenAddress[aeneid],
     });
 
     const raiseDisputeRequest: RaiseDisputeRequest = {

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Address, zeroAddress } from "viem";
-import { homer, getStoryClient, mintBySpg } from "./utils/util";
+import { aeneid, getStoryClient, mintBySpg } from "./utils/util";
 import { StoryClient } from "../../src";
 import {
   evenSplitGroupPoolAddress,
@@ -19,7 +19,7 @@ describe("Group Functions", () => {
   let groupId: Address;
   let ipId: Address;
   let licenseTermsId: bigint;
-  const groupPoolAddress = evenSplitGroupPoolAddress[homer];
+  const groupPoolAddress = evenSplitGroupPoolAddress[aeneid];
 
   // Setup - create necessary contracts and initial IP
   before(async () => {
@@ -47,7 +47,7 @@ describe("Group Functions", () => {
         {
           terms: {
             transferable: true,
-            royaltyPolicy: royaltyPolicyLrpAddress[homer],
+            royaltyPolicy: royaltyPolicyLrpAddress[aeneid],
             defaultMintingFee: 0n,
             expiration: BigInt(1000),
             commercialUse: true,
@@ -61,7 +61,7 @@ describe("Group Functions", () => {
             derivativesApproval: false,
             derivativesReciprocal: true,
             derivativeRevCeiling: BigInt(0),
-            currency: mockErc20Address[homer],
+            currency: mockErc20Address[aeneid],
             uri: "test case",
           },
           licensingConfig: {
@@ -86,7 +86,7 @@ describe("Group Functions", () => {
     await client.license.setLicensingConfig({
       ipId,
       licenseTermsId,
-      licenseTemplate: piLicenseTemplateAddress[homer],
+      licenseTemplate: piLicenseTemplateAddress[aeneid],
       licensingConfig: {
         isSet: true,
         mintingFee: 0n,

--- a/packages/core-sdk/test/integration/ipAccount.test.ts
+++ b/packages/core-sdk/test/integration/ipAccount.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { AccessPermission, StoryClient } from "../../src";
-import { mockERC721, getStoryClient, getTokenId, homer } from "./utils/util";
+import { mockERC721, getStoryClient, getTokenId, aeneid } from "./utils/util";
 import { Hex, encodeFunctionData, getAddress, toFunctionSelector } from "viem";
 import {
   accessControllerAbi,
@@ -16,8 +16,8 @@ describe("IPAccount Functions", () => {
   let client: StoryClient;
   let ipId: Hex;
   let data: Hex;
-  const coreMetadataModule = coreMetadataModuleAddress[homer];
-  const permissionAddress = accessControllerAddress[homer];
+  const coreMetadataModule = coreMetadataModuleAddress[aeneid];
+  const permissionAddress = accessControllerAddress[aeneid];
 
   before(async () => {
     client = getStoryClient();

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -8,7 +8,7 @@ import {
   getTokenId,
   mintBySpg,
   approveForLicenseToken,
-  homer,
+  aeneid,
 } from "./utils/util";
 import { MockERC20 } from "./utils/mockERC20";
 import {
@@ -19,11 +19,13 @@ import {
   derivativeWorkflowsAddress,
   royaltyTokenDistributionWorkflowsAddress,
 } from "../../src/abi/generated";
+import { WIP_TOKEN_ADDRESS } from "../../src/constants/common";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-const pool = evenSplitGroupPoolAddress[homer];
+const pool = evenSplitGroupPoolAddress[aeneid];
+const walletAddress = process.env.TEST_WALLET_ADDRESS! as Address;
 
 describe("IP Asset Functions", () => {
   let client: StoryClient;
@@ -126,6 +128,7 @@ describe("IP Asset Functions", () => {
 
   describe("SPG NFT Operations", () => {
     let nftContract: Hex;
+    let nftContractWithMintingFee: Hex;
     let licenseTermsId: bigint;
 
     before(async () => {
@@ -137,7 +140,7 @@ describe("IP Asset Functions", () => {
         isPublicMinting: true,
         mintOpen: true,
         contractURI: "test-uri",
-        mintFeeRecipient: process.env.TEST_WALLET_ADDRESS! as Address,
+        mintFeeRecipient: walletAddress,
         txOptions: { waitForTransaction: true },
       });
       nftContract = txData.spgNftContract!;
@@ -150,7 +153,7 @@ describe("IP Asset Functions", () => {
           {
             terms: {
               transferable: true,
-              royaltyPolicy: royaltyPolicyLapAddress[homer],
+              royaltyPolicy: royaltyPolicyLapAddress[aeneid],
               defaultMintingFee: 0n,
               expiration: 0n,
               commercialUse: true,
@@ -164,7 +167,7 @@ describe("IP Asset Functions", () => {
               derivativesApproval: false,
               derivativesReciprocal: true,
               derivativeRevCeiling: 0n,
-              currency: mockErc20Address[homer],
+              currency: mockErc20Address[aeneid],
               uri: "",
             },
             licensingConfig: {
@@ -187,8 +190,8 @@ describe("IP Asset Functions", () => {
 
       // Setup ERC20
       const mockERC20 = new MockERC20();
-      await mockERC20.approve(derivativeWorkflowsAddress[homer]);
-      await mockERC20.approve(royaltyTokenDistributionWorkflowsAddress[homer]);
+      await mockERC20.approve(derivativeWorkflowsAddress[aeneid]);
+      await mockERC20.approve(royaltyTokenDistributionWorkflowsAddress[aeneid]);
       await mockERC20.mint();
     });
 
@@ -250,7 +253,7 @@ describe("IP Asset Functions", () => {
               derivativesApproval: false,
               derivativesReciprocal: true,
               derivativeRevCeiling: 0n,
-              currency: mockErc20Address[homer],
+              currency: mockErc20Address[aeneid],
               uri: "",
             },
             licensingConfig: {
@@ -267,7 +270,7 @@ describe("IP Asset Functions", () => {
           {
             terms: {
               transferable: true,
-              royaltyPolicy: royaltyPolicyLapAddress[homer],
+              royaltyPolicy: royaltyPolicyLapAddress[aeneid],
               defaultMintingFee: 10000n,
               expiration: 1000n,
               commercialUse: true,
@@ -281,7 +284,7 @@ describe("IP Asset Functions", () => {
               derivativesApproval: false,
               derivativesReciprocal: true,
               derivativeRevCeiling: 0n,
-              currency: mockErc20Address[homer],
+              currency: mockErc20Address[aeneid],
               uri: "test case",
             },
             licensingConfig: {
@@ -317,7 +320,7 @@ describe("IP Asset Functions", () => {
         txOptions: { waitForTransaction: true },
       });
       expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.childIpId).to.be.a("string").and.not.empty;
+      expect(result.ipId).to.be.a("string").and.not.empty;
       expect(result.tokenId).to.be.a("bigint");
     });
 
@@ -357,7 +360,7 @@ describe("IP Asset Functions", () => {
               derivativesApproval: false,
               derivativesReciprocal: true,
               derivativeRevCeiling: 0n,
-              currency: mockErc20Address[homer],
+              currency: mockErc20Address[aeneid],
               uri: "",
             },
             licensingConfig: {
@@ -389,7 +392,7 @@ describe("IP Asset Functions", () => {
       });
 
       await approveForLicenseToken(
-        derivativeWorkflowsAddress[homer],
+        derivativeWorkflowsAddress[aeneid],
         mintLicenseTokensResult.licenseTokenIds![0],
       );
 
@@ -422,7 +425,7 @@ describe("IP Asset Functions", () => {
       });
 
       await approveForLicenseToken(
-        derivativeWorkflowsAddress[homer],
+        derivativeWorkflowsAddress[aeneid],
         mintLicenseTokensResult.licenseTokenIds![0],
       );
 
@@ -454,7 +457,7 @@ describe("IP Asset Functions", () => {
             {
               terms: {
                 transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[homer],
+                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
                 defaultMintingFee: 0n,
                 expiration: 1000n,
                 commercialUse: true,
@@ -468,7 +471,7 @@ describe("IP Asset Functions", () => {
                 derivativesApproval: false,
                 derivativesReciprocal: true,
                 derivativeRevCeiling: 0n,
-                currency: mockErc20Address[homer],
+                currency: mockErc20Address[aeneid],
                 uri: "test case",
               },
               licensingConfig: {
@@ -543,7 +546,7 @@ describe("IP Asset Functions", () => {
             {
               terms: {
                 transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[homer],
+                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
                 defaultMintingFee: 10000n,
                 expiration: 1000n,
                 commercialUse: true,
@@ -557,7 +560,7 @@ describe("IP Asset Functions", () => {
                 derivativesApproval: false,
                 derivativesReciprocal: true,
                 derivativeRevCeiling: 0n,
-                currency: mockErc20Address[homer],
+                currency: mockErc20Address[aeneid],
                 uri: "test case",
               },
               licensingConfig: {
@@ -663,7 +666,7 @@ describe("IP Asset Functions", () => {
               {
                 terms: {
                   transferable: true,
-                  royaltyPolicy: royaltyPolicyLapAddress[homer],
+                  royaltyPolicy: royaltyPolicyLapAddress[aeneid],
                   defaultMintingFee: 8n,
                   expiration: 0n,
                   commercialUse: true,
@@ -677,7 +680,7 @@ describe("IP Asset Functions", () => {
                   derivativesApproval: false,
                   derivativesReciprocal: true,
                   derivativeRevCeiling: 0n,
-                  currency: mockErc20Address[homer],
+                  currency: mockErc20Address[aeneid],
                   uri: "",
                 },
                 licensingConfig: {
@@ -700,7 +703,7 @@ describe("IP Asset Functions", () => {
               {
                 terms: {
                   transferable: true,
-                  royaltyPolicy: royaltyPolicyLapAddress[homer],
+                  royaltyPolicy: royaltyPolicyLapAddress[aeneid],
                   defaultMintingFee: 8n,
                   expiration: 0n,
                   commercialUse: true,
@@ -714,7 +717,7 @@ describe("IP Asset Functions", () => {
                   derivativesApproval: false,
                   derivativesReciprocal: true,
                   derivativeRevCeiling: 0n,
-                  currency: mockErc20Address[homer],
+                  currency: mockErc20Address[aeneid],
                   uri: "",
                 },
                 licensingConfig: {
@@ -859,7 +862,7 @@ describe("IP Asset Functions", () => {
                 derivativesApproval: false,
                 derivativesReciprocal: true,
                 derivativeRevCeiling: 0n,
-                currency: mockErc20Address[homer],
+                currency: mockErc20Address[aeneid],
                 uri: "",
               },
               licensingConfig: {
@@ -889,7 +892,7 @@ describe("IP Asset Functions", () => {
             {
               terms: {
                 transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[homer],
+                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
                 defaultMintingFee: 10000n,
                 expiration: 1000n,
                 commercialUse: true,
@@ -903,7 +906,7 @@ describe("IP Asset Functions", () => {
                 derivativesApproval: false,
                 derivativesReciprocal: true,
                 derivativeRevCeiling: 0n,
-                currency: mockErc20Address[homer],
+                currency: mockErc20Address[aeneid],
                 uri: "test case",
               },
               licensingConfig: {

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -2,14 +2,12 @@ import chai from "chai";
 import { StoryClient } from "../../src";
 import { Hex, zeroAddress } from "viem";
 import chaiAsPromised from "chai-as-promised";
-import { mockERC721, getStoryClient, getTokenId, homer } from "./utils/util";
+import { mockERC721, getStoryClient, getTokenId, aeneid } from "./utils/util";
 import { MockERC20 } from "./utils/mockERC20";
 import {
   licensingModuleAddress,
   mockErc20Address,
   piLicenseTemplateAddress,
-  royaltyPolicyLapAddress,
-  royaltyPolicyLapConfig,
 } from "../../src/abi/generated";
 
 chai.use(chaiAsPromised);
@@ -25,7 +23,7 @@ describe("License Functions", () => {
     it("should register license ", async () => {
       const result = await client.license.registerPILTerms({
         defaultMintingFee: 0,
-        currency: mockErc20Address[homer],
+        currency: mockErc20Address[aeneid],
         transferable: false,
         royaltyPolicy: zeroAddress,
         commercialUse: false,
@@ -58,7 +56,7 @@ describe("License Functions", () => {
     it("should register license with commercial use", async () => {
       const result = await client.license.registerCommercialUsePIL({
         defaultMintingFee: "1",
-        currency: mockErc20Address[homer],
+        currency: mockErc20Address[aeneid],
         txOptions: {
           waitForTransaction: true,
         },
@@ -70,7 +68,7 @@ describe("License Functions", () => {
       const result = await client.license.registerCommercialRemixPIL({
         defaultMintingFee: "1",
         commercialRevShare: 100,
-        currency: mockErc20Address[homer],
+        currency: mockErc20Address[aeneid],
         txOptions: {
           waitForTransaction: true,
         },
@@ -93,12 +91,12 @@ describe("License Functions", () => {
         },
       });
       const mockERC20 = new MockERC20();
-      await mockERC20.approve(licensingModuleAddress[homer]);
+      await mockERC20.approve(licensingModuleAddress[aeneid]);
       ipId = registerResult.ipId!;
       const registerLicenseResult = await client.license.registerCommercialRemixPIL({
         defaultMintingFee: 0,
         commercialRevShare: 100,
-        currency: mockErc20Address[homer],
+        currency: mockErc20Address[aeneid],
         txOptions: {
           waitForTransaction: true,
         },
@@ -150,7 +148,7 @@ describe("License Functions", () => {
       const result = await client.license.setLicensingConfig({
         ipId: ipId,
         licenseTermsId: licenseId,
-        licenseTemplate: piLicenseTemplateAddress[homer],
+        licenseTemplate: piLicenseTemplateAddress[aeneid],
         licensingConfig: {
           mintingFee: 0,
           isSet: true,

--- a/packages/core-sdk/test/integration/permission.test.ts
+++ b/packages/core-sdk/test/integration/permission.test.ts
@@ -1,6 +1,6 @@
 import chai from "chai";
 import { StoryClient } from "../../src";
-import { mockERC721, getStoryClient, getTokenId, homer } from "./utils/util";
+import { mockERC721, getStoryClient, getTokenId, aeneid } from "./utils/util";
 import { Address } from "viem";
 import { AccessPermission } from "../../src/types/resources/permission";
 import chaiAsPromised from "chai-as-promised";
@@ -12,7 +12,7 @@ const expect = chai.expect;
 describe("Permission Functions", () => {
   let client: StoryClient;
   let ipId: Address;
-  const coreMetadataModule = coreMetadataModuleAddress[homer];
+  const coreMetadataModule = coreMetadataModuleAddress[aeneid];
 
   before(async () => {
     client = getStoryClient();

--- a/packages/core-sdk/test/integration/royalty.test.ts
+++ b/packages/core-sdk/test/integration/royalty.test.ts
@@ -2,7 +2,7 @@ import chai from "chai";
 import { StoryClient } from "../../src";
 import { Address, Hex, encodeFunctionData } from "viem";
 import chaiAsPromised from "chai-as-promised";
-import { mockERC721, getTokenId, getStoryClient, homer } from "./utils/util";
+import { mockERC721, getTokenId, getStoryClient, aeneid } from "./utils/util";
 import { MockERC20 } from "./utils/mockERC20";
 import { mockErc20Address } from "../../src/abi/generated";
 
@@ -34,7 +34,7 @@ describe("Royalty Functions", () => {
   const getCommercialPolicyId = async (): Promise<bigint> => {
     const response = await client.license.registerCommercialRemixPIL({
       defaultMintingFee: "100000",
-      currency: mockErc20Address[homer],
+      currency: mockErc20Address[aeneid],
       commercialRevShare: 10,
       txOptions: { waitForTransaction: true },
     });
@@ -107,7 +107,7 @@ describe("Royalty Functions", () => {
       const response = await client.royalty.payRoyaltyOnBehalf({
         receiverIpId: parentIpId,
         payerIpId: childIpId,
-        token: mockErc20Address[homer],
+        token: mockErc20Address[aeneid],
         amount: 10 * 10 ** 2,
         txOptions: { waitForTransaction: true },
       });
@@ -119,7 +119,7 @@ describe("Royalty Functions", () => {
       const response = await client.royalty.payRoyaltyOnBehalf({
         receiverIpId: parentIpId,
         payerIpId: childIpId,
-        token: mockErc20Address[homer],
+        token: mockErc20Address[aeneid],
         amount: 10 * 10 ** 2,
         txOptions: { encodedTxDataOnly: true },
       });
@@ -134,7 +134,7 @@ describe("Royalty Functions", () => {
         client.royalty.payRoyaltyOnBehalf({
           receiverIpId: unregisteredIpId,
           payerIpId: childIpId,
-          token: mockErc20Address[homer],
+          token: mockErc20Address[aeneid],
           amount: 10 * 10 ** 2,
           txOptions: { waitForTransaction: true },
         }),
@@ -147,7 +147,7 @@ describe("Royalty Functions", () => {
       const response = await client.royalty.claimableRevenue({
         royaltyVaultIpId: parentIpId,
         claimer: process.env.TEST_WALLET_ADDRESS as Address,
-        token: mockErc20Address[homer],
+        token: mockErc20Address[aeneid],
       });
 
       expect(response).to.be.a("bigint");
@@ -173,7 +173,7 @@ describe("Royalty Functions", () => {
         client.royalty.payRoyaltyOnBehalf({
           receiverIpId: parentIpId,
           payerIpId: childIpId,
-          token: mockErc20Address[homer],
+          token: mockErc20Address[aeneid],
           amount: -1,
           txOptions: { waitForTransaction: true },
         }),

--- a/packages/core-sdk/test/integration/utils/mockERC20.ts
+++ b/packages/core-sdk/test/integration/utils/mockERC20.ts
@@ -9,16 +9,16 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { chainStringToViemChain, waitTx } from "../../../src/utils/utils";
-import { RPC, homer } from "./util";
+import { RPC, aeneid } from "./util";
 import { mockErc20Address } from "../../../src/abi/generated";
 export class MockERC20 {
   private publicClient: PublicClient;
   private walletClient: WalletClient;
-  public address: Address = mockErc20Address[homer];
+  public address: Address = mockErc20Address[aeneid];
 
   constructor(address?: Address) {
     const baseConfig = {
-      chain: chainStringToViemChain("homer"),
+      chain: chainStringToViemChain("aeneid"),
       transport: http(RPC),
     } as const;
     this.publicClient = createPublicClient(baseConfig);
@@ -26,7 +26,7 @@ export class MockERC20 {
       ...baseConfig,
       account: privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as Hex),
     });
-    this.address = address || mockErc20Address[homer];
+    this.address = address || mockErc20Address[aeneid];
   }
 
   public async approve(contract: Address): Promise<void> {

--- a/packages/core-sdk/test/integration/utils/util.ts
+++ b/packages/core-sdk/test/integration/utils/util.ts
@@ -1,29 +1,22 @@
 import { privateKeyToAccount } from "viem/accounts";
 import { chainStringToViemChain, waitTx } from "../../../src/utils/utils";
-import {
-  http,
-  createPublicClient,
-  createWalletClient,
-  Hex,
-  Address,
-  zeroAddress,
-  zeroHash,
-} from "viem";
+import { http, createPublicClient, createWalletClient, Hex, Address, zeroHash } from "viem";
 import { StoryClient, StoryConfig } from "../../../src";
 import {
   licenseTokenAbi,
   licenseTokenAddress,
   spgnftBeaconAddress,
 } from "../../../src/abi/generated";
-export const RPC = "https://devnet.storyrpc.io";
-export const homer = 1315;
+export const RPC = "https://aeneid.storyrpc.io";
+export const aeneid = 1315;
 
 export const mockERC721 = "0xa1119092ea911202E0a65B743a13AE28C5CF2f21";
-export const licenseToken = licenseTokenAddress[homer];
-export const spgNftBeacon = spgnftBeaconAddress[homer];
+export const licenseToken = licenseTokenAddress[aeneid];
+export const spgNftBeacon = spgnftBeaconAddress[aeneid];
+export const TEST_WALLET_ADDRESS = process.env.TEST_WALLET_ADDRESS! as Address;
 
 const baseConfig = {
-  chain: chainStringToViemChain("homer"),
+  chain: chainStringToViemChain("aeneid"),
   transport: http(RPC),
 } as const;
 export const publicClient = createPublicClient(baseConfig);
@@ -130,7 +123,7 @@ export const approveForLicenseToken = async (address: Address, tokenId: bigint) 
 };
 export const getStoryClient = (): StoryClient => {
   const config: StoryConfig = {
-    chainId: "homer",
+    chainId: "aeneid",
     transport: http(RPC),
     account: privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as Address),
   };

--- a/packages/core-sdk/test/unit/client.test.ts
+++ b/packages/core-sdk/test/unit/client.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createWalletClient, http, Transport } from "viem";
-import { StoryClient, StoryConfig, homer } from "../../src/index";
+import { StoryClient, StoryConfig, aeneid } from "../../src/index";
 const rpc = "http://127.0.0.1:8545";
 
 describe("Test StoryClient", () => {
@@ -36,7 +36,7 @@ describe("Test StoryClient", () => {
         transport: http(rpc),
         wallet: createWalletClient({
           account: privateKeyToAccount(generatePrivateKey()),
-          chain: homer,
+          chain: aeneid,
           transport: http(rpc),
         }),
       });
@@ -49,7 +49,7 @@ describe("Test StoryClient", () => {
         transport: http(rpc),
         wallet: createWalletClient({
           account: privateKeyToAccount(generatePrivateKey()),
-          chain: homer,
+          chain: aeneid,
           transport: http(rpc),
         }),
       });
@@ -69,7 +69,7 @@ describe("Test StoryClient", () => {
     const account = privateKeyToAccount(generatePrivateKey());
     const transport = http(rpc);
     const config: StoryConfig = {
-      chainId: "homer",
+      chainId: "aeneid",
       transport,
       account,
     };

--- a/packages/core-sdk/test/unit/resources/dispute.test.ts
+++ b/packages/core-sdk/test/unit/resources/dispute.test.ts
@@ -16,7 +16,7 @@ describe("Test DisputeClient", () => {
   beforeEach(() => {
     rpcMock = createMock<PublicClient>();
     walletMock = createMock<WalletClient>();
-    disputeClient = new DisputeClient(rpcMock, walletMock, "homer");
+    disputeClient = new DisputeClient(rpcMock, walletMock, "aeneid");
   });
 
   afterEach(() => {

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -259,7 +259,7 @@ describe("Test IpAssetClient", () => {
     it("should throw account error when register given wallet have no signTypedData ", async () => {
       const walletMock = createMock<WalletClient>();
       walletMock.account = createMock<Account>();
-      ipAssetClient = new IPAssetClient(rpcMock, walletMock, "homer");
+      ipAssetClient = new IPAssetClient(rpcMock, walletMock, "aeneid");
       (ipAssetClient.registrationWorkflowsClient as any).address =
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
       (ipAssetClient.coreMetadataModuleClient as any).address =

--- a/packages/core-sdk/test/unit/resources/permission.test.ts
+++ b/packages/core-sdk/test/unit/resources/permission.test.ts
@@ -20,7 +20,7 @@ describe("Test Permission", () => {
     walletMock.signTypedData = sinon
       .stub()
       .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-    permissionClient = new PermissionClient(rpcMock, walletMock, "homer");
+    permissionClient = new PermissionClient(rpcMock, walletMock, "aeneid");
     sinon
       .stub(IpAccountImplClient.prototype, "state")
       .resolves({ result: "0x2e778894d11b5308e4153f094e190496c1e0609652c19f8b87e5176484b9a5e" });

--- a/packages/core-sdk/test/unit/utils/sign.test.ts
+++ b/packages/core-sdk/test/unit/utils/sign.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { getDeadline, getPermissionSignature } from "../../../src/utils/sign";
 import { Hex, WalletClient, createWalletClient, http, zeroAddress } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { homer } from "../../integration/utils/util";
+import { aeneid } from "../../integration/utils/util";
 import { chainStringToViemChain } from "../../../src/utils/utils";
 
 describe("Sign", () => {
@@ -15,7 +15,7 @@ describe("Sign", () => {
           deadline: 1000n,
           permissions: [{ ipId: zeroAddress, signer: zeroAddress, to: zeroAddress, permission: 0 }],
           wallet: {} as WalletClient,
-          chainId: BigInt(homer),
+          chainId: BigInt(aeneid),
         });
       } catch (e) {
         expect((e as Error).message).to.equal(
@@ -32,7 +32,7 @@ describe("Sign", () => {
           deadline: 1000n,
           permissions: [{ ipId: zeroAddress, signer: zeroAddress, to: zeroAddress, permission: 0 }],
           wallet: { signTypedData: () => Promise.resolve("") } as unknown as WalletClient,
-          chainId: BigInt(homer),
+          chainId: BigInt(aeneid),
         });
       } catch (e) {
         expect((e as Error).message).to.equal(
@@ -43,7 +43,7 @@ describe("Sign", () => {
 
     it("should return signature when call getPermissionSignature given account support signTypedData", async () => {
       const walletClient = createWalletClient({
-        chain: chainStringToViemChain("homer"),
+        chain: chainStringToViemChain("aeneid"),
         transport: http(),
         account: privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as Hex),
       });
@@ -61,7 +61,7 @@ describe("Sign", () => {
           },
         ],
         wallet: walletClient,
-        chainId: BigInt(homer),
+        chainId: BigInt(aeneid),
       });
       expect(result.signature).is.a("string").and.not.empty;
       expect(result.nonce).is.a("string").and.not.empty;
@@ -69,7 +69,7 @@ describe("Sign", () => {
 
     it("should return signature when call getPermissionSignature given account support signTypedData and multiple permissions", async () => {
       const walletClient = createWalletClient({
-        chain: chainStringToViemChain("homer"),
+        chain: chainStringToViemChain("aeneid"),
         transport: http(),
         account: privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as Hex),
       });
@@ -88,7 +88,7 @@ describe("Sign", () => {
           },
         ],
         wallet: walletClient,
-        chainId: BigInt(homer),
+        chainId: BigInt(aeneid),
       });
       expect(result.signature).is.a("string").and.not.empty;
       expect(result.nonce).is.a("string").and.not.empty;

--- a/packages/core-sdk/test/unit/utils/utils.test.ts
+++ b/packages/core-sdk/test/unit/utils/utils.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../src/utils/utils";
 import { createMock } from "../testUtils";
 import { licensingModuleAbi } from "../../../src/abi/generated";
-import { homer } from "../../../src";
+import { aeneid } from "../../../src";
 
 describe("Test waitTxAndFilterLog", () => {
   const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
@@ -152,13 +152,13 @@ describe("Test chainStringToViemChain", () => {
     }
   });
 
-  it("should return homer testnet if id is 1315", () => {
+  it("should return aeneid testnet if id is 1315", () => {
     const chain = chainStringToViemChain("1315");
-    expect(chain).to.equal(homer);
+    expect(chain).to.equal(aeneid);
   });
-  it("should return homer testnet if id is iliad", () => {
-    const chain = chainStringToViemChain("homer");
-    expect(chain).to.equal(homer);
+  it("should return aeneid testnet if id is iliad", () => {
+    const chain = chainStringToViemChain("aeneid");
+    expect(chain).to.equal(aeneid);
   });
 });
 

--- a/packages/wagmi-generator/wagmi.config.ts
+++ b/packages/wagmi-generator/wagmi.config.ts
@@ -4,7 +4,7 @@ import type { Evaluate } from "@wagmi/cli/src/types";
 import type { ContractConfig } from "@wagmi/cli/src/config";
 import { resolveProxyContracts } from "./resolveProxyContracts";
 import { optimizedBlockExplorer } from "./optimizedBlockExplorer";
-const homerChainId = 1315;
+const aeneidChainId = 1315;
 import "dotenv/config";
 
 export default defineConfig(async () => {
@@ -12,169 +12,169 @@ export default defineConfig(async () => {
     {
       name: "AccessController",
       address: {
-        [homerChainId]: "0xcCF37d0a503Ee1D4C11208672e622ed3DFB2275a",
+        [aeneidChainId]: "0xcCF37d0a503Ee1D4C11208672e622ed3DFB2275a",
       },
     },
     {
       name: "DisputeModule",
       address: {
-        [homerChainId]: "0x9b7A9c70AFF961C799110954fc06F3093aeb94C5",
+        [aeneidChainId]: "0x9b7A9c70AFF961C799110954fc06F3093aeb94C5",
       },
     },
     {
       name: "IPAccountImpl",
       address: {
-        [homerChainId]: "0x7343646585443F1c3F64E4F08b708788527e1C77",
+        [aeneidChainId]: "0x7343646585443F1c3F64E4F08b708788527e1C77",
       },
     },
     {
       name: "IPAssetRegistry",
       address: {
-        [homerChainId]: "0x77319B4031e6eF1250907aa00018B8B1c67a244b",
+        [aeneidChainId]: "0x77319B4031e6eF1250907aa00018B8B1c67a244b",
       },
     },
     {
       name: "IpRoyaltyVaultImpl",
       address: {
-        [homerChainId]: "0x63cC7611316880213f3A4Ba9bD72b0EaA2010298",
+        [aeneidChainId]: "0x63cC7611316880213f3A4Ba9bD72b0EaA2010298",
       },
     },
     {
       name: "LicenseRegistry",
       address: {
-        [homerChainId]: "0x529a750E02d8E2f15649c13D69a465286a780e24",
+        [aeneidChainId]: "0x529a750E02d8E2f15649c13D69a465286a780e24",
       },
     },
     {
       name: "LicenseToken",
       address: {
-        [homerChainId]: "0xFe3838BFb30B34170F00030B52eA4893d8aAC6bC",
+        [aeneidChainId]: "0xFe3838BFb30B34170F00030B52eA4893d8aAC6bC",
       },
     },
     {
       name: "LicensingModule",
       address: {
-        [homerChainId]: "0x04fbd8a2e56dd85CFD5500A4A4DfA955B9f1dE6f",
+        [aeneidChainId]: "0x04fbd8a2e56dd85CFD5500A4A4DfA955B9f1dE6f",
       },
     },
     {
       name: "PILicenseTemplate",
       address: {
-        [homerChainId]: "0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316",
+        [aeneidChainId]: "0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316",
       },
     },
     {
       name: "ModuleRegistry",
       address: {
-        [homerChainId]: "0x022DBAAeA5D8fB31a0Ad793335e39Ced5D631fa5",
+        [aeneidChainId]: "0x022DBAAeA5D8fB31a0Ad793335e39Ced5D631fa5",
       },
     },
     {
       name: "RoyaltyModule",
       address: {
-        [homerChainId]: "0xD2f60c40fEbccf6311f8B47c4f2Ec6b040400086",
+        [aeneidChainId]: "0xD2f60c40fEbccf6311f8B47c4f2Ec6b040400086",
       },
     },
     {
       name: "RoyaltyPolicyLAP",
       address: {
-        [homerChainId]: "0xBe54FB168b3c982b7AaE60dB6CF75Bd8447b390E",
+        [aeneidChainId]: "0xBe54FB168b3c982b7AaE60dB6CF75Bd8447b390E",
       },
     },
     {
       name: "ArbitrationPolicyUMA",
       address: {
-        [homerChainId]: "0xfFD98c3877B8789124f02C7E8239A4b0Ef11E936",
+        [aeneidChainId]: "0xfFD98c3877B8789124f02C7E8239A4b0Ef11E936",
       },
     },
     {
       name: "RoyaltyPolicyLRP",
       address: {
-        [homerChainId]: "0x9156e603C949481883B1d3355c6f1132D191fC41",
+        [aeneidChainId]: "0x9156e603C949481883B1d3355c6f1132D191fC41",
       },
     },
     {
       name: "SPGNFTBeacon",
       address: {
-        [homerChainId]: "0xD2926B9ecaE85fF59B6FB0ff02f568a680c01218",
+        [aeneidChainId]: "0xD2926B9ecaE85fF59B6FB0ff02f568a680c01218",
       },
     },
     {
       name: "SPGNFTImpl",
       address: {
-        [homerChainId]: "0x6Cfa03Bc64B1a76206d0Ea10baDed31D520449F5",
+        [aeneidChainId]: "0x6Cfa03Bc64B1a76206d0Ea10baDed31D520449F5",
       },
     },
     {
       name: "CoreMetadataModule",
       address: {
-        [homerChainId]: "0x6E81a25C99C6e8430aeC7353325EB138aFE5DC16",
+        [aeneidChainId]: "0x6E81a25C99C6e8430aeC7353325EB138aFE5DC16",
       },
     },
     {
       name: "DerivativeWorkflows",
       address: {
-        [homerChainId]: "0x9e2d496f72C547C2C535B167e06ED8729B374a4f",
+        [aeneidChainId]: "0x9e2d496f72C547C2C535B167e06ED8729B374a4f",
       },
     },
     {
       name: "GroupingWorkflows",
       address: {
-        [homerChainId]: "0xD7c0beb3aa4DCD4723465f1ecAd045676c24CDCd",
+        [aeneidChainId]: "0xD7c0beb3aa4DCD4723465f1ecAd045676c24CDCd",
       },
     },
     {
       name: "RegistrationWorkflows",
       address: {
-        [homerChainId]: "0xbe39E1C756e921BD25DF86e7AAa31106d1eb0424",
+        [aeneidChainId]: "0xbe39E1C756e921BD25DF86e7AAa31106d1eb0424",
       },
     },
     {
       name: "RoyaltyWorkflows",
       address: {
-        [homerChainId]: "0x9515faE61E0c0447C6AC6dEe5628A2097aFE1890",
+        [aeneidChainId]: "0x9515faE61E0c0447C6AC6dEe5628A2097aFE1890",
       },
     },
     {
       name: "LicenseAttachmentWorkflows",
       address: {
-        [homerChainId]: "0xcC2E862bCee5B6036Db0de6E06Ae87e524a79fd8",
+        [aeneidChainId]: "0xcC2E862bCee5B6036Db0de6E06Ae87e524a79fd8",
       },
     },
     {
       name: "RoyaltyTokenDistributionWorkflows",
       address: {
-        [homerChainId]: "0xa38f42B8d33809917f23997B8423054aAB97322C",
+        [aeneidChainId]: "0xa38f42B8d33809917f23997B8423054aAB97322C",
       },
     },
     {
       name: "GroupingModule",
       address: {
-        [homerChainId]: "0x69D3a7aa9edb72Bc226E745A7cCdd50D947b69Ac",
+        [aeneidChainId]: "0x69D3a7aa9edb72Bc226E745A7cCdd50D947b69Ac",
       },
     },
     {
       name: "EvenSplitGroupPool",
       address: {
-        [homerChainId]: "0xf96f2c30b41Cb6e0290de43C8528ae83d4f33F89",
+        [aeneidChainId]: "0xf96f2c30b41Cb6e0290de43C8528ae83d4f33F89",
       },
     },
     {
       name: "MockERC20",
       address: {
-        [homerChainId]: "0xF2104833d386a2734a4eB3B8ad6FC6812F29E38E",
+        [aeneidChainId]: "0xF2104833d386a2734a4eB3B8ad6FC6812F29E38E",
       },
     },
     {
-      name: "ERC20Token",
+      name: "WrappedIP",
       address: {
-        [homerChainId]: "0x1514000000000000000000000000000000000000",
+        [aeneidChainId]: "0x1514000000000000000000000000000000000000",
       },
     },
     {
       name: "Multicall3",
       address: {
-        [homerChainId]: "0xca11bde05977b3631167028862be2a173976ca11",
+        [aeneidChainId]: "0xca11bde05977b3631167028862be2a173976ca11",
       },
     },
   ];
@@ -183,14 +183,15 @@ export default defineConfig(async () => {
     contracts: [],
     plugins: [
       optimizedBlockExplorer({
-        baseUrl: "https://devnet.storyscan.xyz/api",
-        name: "homer",
+        baseUrl: "https://aeneid.storyscan.xyz/api",
+        name: "aeneid",
         getAddress: await resolveProxyContracts({
-          baseUrl: "https://devnet.storyrpc.io",
+          baseUrl: "https://aeneid.storyrpc.io",
           contracts: contracts,
-          chainId: homerChainId,
+          chainId: aeneidChainId,
         }),
         contracts: contracts,
+        cacheDuration: 0,
       }),
       sdk({
         permissionLessSDK: true,
@@ -280,12 +281,7 @@ export default defineConfig(async () => {
             "mintAndRegisterIpAndAttachPILTerms",
             "multicall",
           ],
-          RoyaltyWorkflows: [
-            "transferToVaultAndSnapshotAndClaimByTokenBatch",
-            "transferToVaultAndSnapshotAndClaimBySnapshotBatch",
-            "snapshotAndClaimByTokenBatch",
-            "snapshotAndClaimBySnapshotBatch",
-          ],
+          RoyaltyWorkflows: ["claimAllRevenue"],
           Multicall3: ["aggregate3"],
           RoyaltyTokenDistributionWorkflows: [
             "mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens",


### PR DESCRIPTION
## Description
Update `homer` in supported chains to `aeneid`, chain id remains the same. Explorer and rpc url is also updated.

Resolves #401 