### PR TITLE
Export wip address & approval safety check

### DIFF
--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -1,5 +1,5 @@
 export { StoryClient } from "./client";
-export { AddressZero, HashZero } from "./constants/common";
+export { AddressZero, HashZero, WIP_TOKEN_ADDRESS } from "./constants/common";
 export { aeneid, mainnet } from "./utils/chain";
 export { IPAssetClient } from "./resources/ipAsset";
 export { PermissionClient } from "./resources/permission";

--- a/packages/core-sdk/src/types/utils/wip.ts
+++ b/packages/core-sdk/src/types/utils/wip.ts
@@ -59,6 +59,7 @@ export type WipSpender = {
 export type WipApprovalCall = {
   spenders: WipSpender[];
   client: WrappedIpClient;
+  multicallAddress: Address;
   rpcClient: PublicClient;
   /** owner is the address calling the approval */
   owner: Address;

--- a/packages/core-sdk/src/utils/wipFeeUtils.ts
+++ b/packages/core-sdk/src/utils/wipFeeUtils.ts
@@ -25,9 +25,14 @@ const approvalAllSpenders = async ({
   owner,
   useMultiCall,
   rpcClient,
+  multicallAddress,
 }: WipApprovalCall) => {
   const approvals = await Promise.all(
     spenders.map(async (spender) => {
+      // make sure we never give approval to the multicall contract
+      if (spender.address === multicallAddress) {
+        return;
+      }
       const spenderAmount = spender.amount || maxUint256;
       const { result: allowance } = await client.allowance({
         owner: owner,
@@ -138,6 +143,7 @@ const multiCallWrapIp = async ({
     const approvalCalls = await approvalAllSpenders({
       spenders: wipSpenders,
       client: wipClient,
+      multicallAddress: multicall3Client.address,
       owner: useMultiCall ? multicall3Client.address : wallet.account!.address,
       rpcClient,
       useMultiCall,
@@ -221,6 +227,7 @@ export const contractCallWithWipFees = async ({
         spenders: wipSpenders,
         client: wipClient,
         owner: sender, // sender owns the wip
+        multicallAddress: multicall3Client.address,
         rpcClient,
         // since sender has all wip, if using multicall, we will also need to transfer
         // sender's wip to multicall, which brings more complexity. So in this case,

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -17,6 +17,7 @@ import {
   derivativeWorkflowsAddress,
   royaltyTokenDistributionWorkflowsAddress,
   wrappedIpAddress,
+  mockErc20Address,
 } from "../../src/abi/generated";
 import { MAX_ROYALTY_TOKEN, WIP_TOKEN_ADDRESS } from "../../src/constants/common";
 


### PR DESCRIPTION
## Description

- Export `WIP_TOKEN_ADDRESS`
- Add a safety check for WIP approval logic to ensure we never approve the Multicall contract as a spender.