### PR TITLE
Add new methods for nftClient

### DIFF
--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -19,7 +19,7 @@
     "build": "pnpm run fix && preconstruct build",
     "test": "pnpm run test:unit",
     "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
-    "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 300000",
+    "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/nftClient.test.ts' --timeout 300000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -19,7 +19,7 @@
     "build": "pnpm run fix && preconstruct build",
     "test": "pnpm run test:unit",
     "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
-    "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/nftClient.test.ts' --timeout 300000",
+    "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 300000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/packages/core-sdk/src/abi/generated.ts
+++ b/packages/core-sdk/src/abi/generated.ts
@@ -15199,7 +15199,7 @@ export const wrappedIpAbi = [
     inputs: [],
     name: "name",
     outputs: [{ name: "", internalType: "string", type: "string" }],
-    stateMutability: "view",
+    stateMutability: "pure",
   },
   {
     type: "function",
@@ -15228,7 +15228,7 @@ export const wrappedIpAbi = [
     inputs: [],
     name: "symbol",
     outputs: [{ name: "", internalType: "string", type: "string" }],
-    stateMutability: "view",
+    stateMutability: "pure",
   },
   {
     type: "function",

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -44,6 +44,7 @@ import { getFunctionSignature } from "../utils/getFunctionSignature";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
 import { getIpMetadataForWorkflow } from "../utils/getIpMetadataForWorkflow";
 import { getRevenueShare } from "../utils/licenseTermsHelper";
+import { RevShareType } from "../types/common";
 
 export class GroupClient {
   public groupingWorkflowsClient: GroupingWorkflowsClient;
@@ -147,7 +148,9 @@ export class GroupClient {
         spgNftContract: getAddress(spgNftContract, "request.spgNftContract"),
         recipient:
           (recipient && getAddress(recipient, "request.recipient")) || this.wallet.account!.address,
-        maxAllowedRewardShare: BigInt(getRevenueShare(request.maxAllowedRewardShare)),
+        maxAllowedRewardShare: BigInt(
+          getRevenueShare(request.maxAllowedRewardShare, RevShareType.MAX_ALLOWED_REWARD_SHARE),
+        ),
         licensesData: this.getLicenseData(request.licenseData),
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
         sigAddToGroup: {
@@ -257,7 +260,9 @@ export class GroupClient {
         licensesData: this.getLicenseData(request.licenseData),
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
         tokenId: BigInt(request.tokenId),
-        maxAllowedRewardShare: BigInt(getRevenueShare(request.maxAllowedRewardShare)),
+        maxAllowedRewardShare: BigInt(
+          getRevenueShare(request.maxAllowedRewardShare, RevShareType.MAX_ALLOWED_REWARD_SHARE),
+        ),
         sigAddToGroup: {
           signer: getAddress(this.wallet.account!.address, "wallet.account.address"),
           deadline: calculatedDeadline,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -105,7 +105,7 @@ import { AccessPermission } from "../types/resources/permission";
 import { LicenseTerms, RegisterPILTermsRequest } from "../types/resources/license";
 import { MAX_ROYALTY_TOKEN, royaltySharesTotalSupply } from "../constants/common";
 import { getFunctionSignature } from "../utils/getFunctionSignature";
-import { LicensingConfig } from "../types/common";
+import { LicensingConfig, RevShareType } from "../types/common";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
 import { getIpMetadataForWorkflow } from "../utils/getIpMetadataForWorkflow";
 import {
@@ -549,7 +549,7 @@ export class IPAssetClient {
             zeroAddress,
             BigInt(arg.maxMintingFee || 0),
             Number(arg.maxRts || MAX_ROYALTY_TOKEN),
-            getRevenueShare(arg.maxRevenueShare || 100),
+            getRevenueShare(arg.maxRevenueShare || 100, RevShareType.MAX_REVENUE_SHARE),
           ],
         });
         const { result: state } = await ipAccount.state();
@@ -1837,7 +1837,10 @@ export class IPAssetClient {
       royaltyContext: zeroAddress,
       maxMintingFee: BigInt(derivativeData.maxMintingFee || 0),
       maxRts: Number(derivativeData.maxRts || MAX_ROYALTY_TOKEN),
-      maxRevenueShare: getRevenueShare(derivativeData.maxRevenueShare || 100),
+      maxRevenueShare: getRevenueShare(
+        derivativeData.maxRevenueShare || 100,
+        RevShareType.MAX_REVENUE_SHARE,
+      ),
     };
     if (internalDerivativeData.parentIpIds.length === 0) {
       throw new Error("The parent IP IDs must be provided.");

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -477,7 +477,7 @@ export class IPAssetClient {
         const contractCall = () => {
           return this.licensingModuleClient.registerDerivative(object);
         };
-        return this.handleRegistrationTransaction({
+        return this.handleRegistrationWithFees({
           sender: this.walletAddress,
           derivData: object,
           contractCall,
@@ -676,7 +676,7 @@ export class IPAssetClient {
       const contractCall = () => {
         return this.licenseAttachmentWorkflowsClient.mintAndRegisterIpAndAttachPilTerms(object);
       };
-      const rsp = await this.handleRegistrationTransaction({
+      const rsp = await this.handleRegistrationWithFees({
         wipOptions: request.wipOptions,
         sender: this.walletAddress,
         spgNftContract: object.spgNftContract,
@@ -948,7 +948,7 @@ export class IPAssetClient {
       const contractCall = () => {
         return this.derivativeWorkflowsClient.registerIpAndMakeDerivative(object);
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         wipOptions: {
           ...request.wipOptions,
           useMulticallWhenPossible: false,
@@ -994,7 +994,7 @@ export class IPAssetClient {
       const contractCall = () => {
         return this.derivativeWorkflowsClient.mintAndRegisterIpAndMakeDerivative(object);
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         wipOptions: request.wipOptions,
         sender: this.walletAddress,
         spgSpenderAddress: this.derivativeWorkflowsClient.address,
@@ -1095,7 +1095,7 @@ export class IPAssetClient {
       const contractCall = () => {
         return this.registrationWorkflowsClient.mintAndRegisterIp(object);
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         sender: this.walletAddress,
         spgSpenderAddress: this.registrationWorkflowsClient.address,
         encodedTxs: [encodedTxData],
@@ -1241,7 +1241,7 @@ export class IPAssetClient {
           object,
         );
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         wipOptions: {
           ...request.wipOptions,
           // need to disable multicall to avoid needing to transfer the license
@@ -1521,7 +1521,7 @@ export class IPAssetClient {
           object,
         );
       };
-      const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationTransaction({
+      const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationWithFees({
         wipOptions: {
           ...request.wipOptions,
           useMulticallWhenPossible: false,
@@ -1603,7 +1603,7 @@ export class IPAssetClient {
           object,
         );
       };
-      const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationTransaction({
+      const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationWithFees({
         wipOptions: request.wipOptions,
         sender: this.walletAddress,
         spgNftContract: object.spgNftContract,
@@ -1665,7 +1665,7 @@ export class IPAssetClient {
           object,
         );
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         spgNftContract: object.spgNftContract,
         wipOptions: request.wipOptions,
         sender: this.walletAddress,
@@ -1916,7 +1916,7 @@ export class IPAssetClient {
     return { licenseTerms, licenseTermsData: processedLicenseTermsData };
   }
 
-  private async handleRegistrationTransaction({
+  private async handleRegistrationWithFees({
     sender,
     derivData,
     spgNftContract,

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -48,6 +48,7 @@ import { ChainIds } from "../types/config";
 import { calculateLicenseWipMintFee, contractCallWithFees } from "../utils/feeUtils";
 import { Erc20Spender } from "../types/utils/wip";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
+import { RevShareType } from "../types/common";
 
 export class LicenseClient {
   public licenseRegistryClient: LicenseRegistryEventClient;
@@ -390,7 +391,7 @@ export class LicenseClient {
         receiver,
         royaltyContext: zeroAddress,
         maxMintingFee: BigInt(request.maxMintingFee),
-        maxRevenueShare: getRevenueShare(request.maxRevenueShare),
+        maxRevenueShare: getRevenueShare(request.maxRevenueShare, RevShareType.MAX_REVENUE_SHARE),
       } as const;
       if (req.maxMintingFee < 0) {
         throw new Error(`The maxMintingFee must be greater than 0.`);

--- a/packages/core-sdk/src/resources/nftClient.ts
+++ b/packages/core-sdk/src/resources/nftClient.ts
@@ -1,19 +1,21 @@
-import { PublicClient, isAddress, maxUint32, zeroAddress } from "viem";
+import { Address, PublicClient, isAddress, maxUint32, zeroAddress } from "viem";
 
 import {
   RegistrationWorkflowsClient,
   RegistrationWorkflowsCreateCollectionRequest,
   SimpleWalletClient,
+  SpgnftImplReadOnlyClient,
 } from "../abi/generated";
 import {
   CreateNFTCollectionRequest,
   CreateNFTCollectionResponse,
 } from "../types/resources/nftClient";
 import { handleError } from "../utils/errors";
-import { getAddress } from "../utils/utils";
+import { getAddress, validateAddress } from "../utils/utils";
 
 export class NftClient {
   public registrationWorkflowsClient: RegistrationWorkflowsClient;
+
   private readonly rpcClient: PublicClient;
   private readonly wallet: SimpleWalletClient;
 
@@ -95,5 +97,26 @@ export class NftClient {
     } catch (error) {
       handleError(error, "Failed to create a SPG NFT collection");
     }
+  }
+  /**
+   * Returns the current mint token of the collection.
+   */
+  public async getMintFeeToken(spgNftContract: Address): Promise<Address> {
+    const spgNftClient = new SpgnftImplReadOnlyClient(
+      this.rpcClient,
+      validateAddress(spgNftContract),
+    );
+    return spgNftClient.mintFeeToken();
+  }
+
+  /**
+   * Returns the current mint fee of the collection.
+   */
+  public async getMintFee(spgNftContract: Address): Promise<bigint> {
+    const spgNftClient = new SpgnftImplReadOnlyClient(
+      this.rpcClient,
+      validateAddress(spgNftContract),
+    );
+    return spgNftClient.mintFee();
   }
 }

--- a/packages/core-sdk/src/types/common.ts
+++ b/packages/core-sdk/src/types/common.ts
@@ -42,3 +42,21 @@ export type ValidatedLicensingConfig = LicensingConfig & {
  * Will be converted to bigint for contract calls.
  */
 export type TokenAmountInput = bigint | number;
+
+/**
+ * The type of revenue share.
+ */
+export enum RevShareType {
+  /**
+   * The commercial revenue share.
+   */
+  COMMERCIAL_REVENUE_SHARE = "CommercialRevShare",
+  /**
+   * The maximum revenue share.
+   */
+  MAX_REVENUE_SHARE = "MaxRevenueShare",
+  /**
+   * The maximum allowed reward share.
+   */
+  MAX_ALLOWED_REWARD_SHARE = "MaxAllowedRewardShare",
+}

--- a/packages/core-sdk/src/types/common.ts
+++ b/packages/core-sdk/src/types/common.ts
@@ -45,18 +45,10 @@ export type TokenAmountInput = bigint | number;
 
 /**
  * The type of revenue share.
+ * It is used to determine the type of revenue share to be used in the revenue share calculation and throw error when the revenue share is not valid.
  */
 export enum RevShareType {
-  /**
-   * The commercial revenue share.
-   */
   COMMERCIAL_REVENUE_SHARE = "CommercialRevShare",
-  /**
-   * The maximum revenue share.
-   */
   MAX_REVENUE_SHARE = "MaxRevenueShare",
-  /**
-   * The maximum allowed reward share.
-   */
   MAX_ALLOWED_REWARD_SHARE = "MaxAllowedRewardShare",
 }

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -455,7 +455,7 @@ export type CommonRegistrationParams = WithWipOptions & {
 export type RegistrationResponse = {
   txHash?: Hex;
   receipt?: TransactionReceipt;
-  ipId?: Hex;
+  ipId?: Address;
   tokenId?: bigint;
 };
 

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -37,9 +37,9 @@ export type InternalDerivativeData = {
   maxRevenueShare: number;
   licenseTemplate: Address;
 };
-export type RegisterIpResponse = {
+export type RegisterIpResponse = RegistrationResponse & {
   encodedTxData?: EncodedTxData;
-} & CommonRegistrationResponse;
+};
 
 export type RegisterRequest = {
   nftContract: Address;
@@ -59,10 +59,11 @@ export type RegisterDerivativeWithLicenseTokensResponse = {
   encodedTxData?: EncodedTxData;
 };
 
-export type RegisterDerivativeRequest = {
-  txOptions?: TxOptions;
-  childIpId: Address;
-} & DerivativeData;
+export type RegisterDerivativeRequest = WithWipOptions &
+  DerivativeData & {
+    txOptions?: TxOptions;
+    childIpId: Address;
+  };
 
 export type RegisterDerivativeResponse = {
   txHash?: Hex;
@@ -151,9 +152,9 @@ export type MintAndRegisterIpAndMakeDerivativeRequest = {
 } & IpMetadataAndTxOptions &
   WithWipOptions;
 
-export type MintAndRegisterIpAndMakeDerivativeResponse = {
+export type MintAndRegisterIpAndMakeDerivativeResponse = RegistrationResponse & {
   encodedTxData?: EncodedTxData;
-} & CommonRegistrationResponse;
+};
 
 export type IpRelationship = {
   parentIpId: Address;
@@ -247,11 +248,12 @@ export type IpMetadata = {
   [key: string]: unknown;
 };
 
-export type MintAndRegisterIpRequest = {
-  spgNftContract: Address;
-  recipient?: Address;
-  allowDuplicates: boolean;
-} & IpMetadataAndTxOptions;
+export type MintAndRegisterIpRequest = IpMetadataAndTxOptions &
+  WithWipOptions & {
+    spgNftContract: Address;
+    recipient?: Address;
+    allowDuplicates: boolean;
+  };
 export type RegisterPilTermsAndAttachRequest = {
   ipId: Address;
   /** The data of the license and its configuration to be attached to the IP. */
@@ -439,7 +441,7 @@ export type MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensResponse
   tokenId?: bigint;
 };
 
-export type CommonRegistrationHandlerParams = WithWipOptions & {
+export type CommonRegistrationParams = WithWipOptions & {
   contractCall: () => Promise<Hash>;
   encodedTxs: EncodedTxData[];
   spgNftContract?: Address;
@@ -450,9 +452,13 @@ export type CommonRegistrationHandlerParams = WithWipOptions & {
   txOptions?: TxOptions;
 };
 
-export type CommonRegistrationResponse = {
+export type RegistrationResponse = {
   txHash?: Hex;
-  ipId?: Address;
-  tokenId?: bigint;
   receipt?: TransactionReceipt;
+  ipId?: Hex;
+  tokenId?: bigint;
+};
+
+export type CommonRegistrationTxResponse = RegistrationResponse & {
+  txHash: Hex;
 };

--- a/packages/core-sdk/src/utils/licenseTermsHelper.ts
+++ b/packages/core-sdk/src/utils/licenseTermsHelper.ts
@@ -36,6 +36,8 @@ export function getLicenseTermByType(
   };
   if (type === PIL_TYPE.NON_COMMERCIAL_REMIX) {
     licenseTerms.commercializerCheckerData = "0x";
+    licenseTerms.uri =
+      "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/NCSR.json";
     return licenseTerms;
   } else if (type === PIL_TYPE.COMMERCIAL_USE) {
     if (!term || term.defaultMintingFee === undefined || term.currency === undefined) {
@@ -47,6 +49,8 @@ export function getLicenseTermByType(
     licenseTerms.commercialAttribution = true;
     licenseTerms.derivativesReciprocal = false;
     licenseTerms.currency = validateAddress(term.currency);
+    licenseTerms.uri =
+      "https://github.com/piplabs/pil-document/blob/9a1f803fcf8101a8a78f1dcc929e6014e144ab56/off-chain-terms/CommercialUse.json";
     return licenseTerms;
   } else {
     if (
@@ -63,7 +67,8 @@ export function getLicenseTermByType(
     licenseTerms.defaultMintingFee = BigInt(term.defaultMintingFee);
     licenseTerms.commercialUse = true;
     licenseTerms.commercialAttribution = true;
-
+    licenseTerms.uri =
+      "https://github.com/piplabs/pil-document/blob/ad67bb632a310d2557f8abcccd428e4c9c798db1/off-chain-terms/CommercialRemix.json";
     licenseTerms.commercialRevShare = getRevenueShare(term.commercialRevShare);
     licenseTerms.derivativesReciprocal = true;
     licenseTerms.currency = validateAddress(term.currency);

--- a/packages/core-sdk/src/utils/licenseTermsHelper.ts
+++ b/packages/core-sdk/src/utils/licenseTermsHelper.ts
@@ -4,6 +4,7 @@ import { PIL_TYPE, LicenseTerms, RegisterPILTermsRequest } from "../types/resour
 import { validateAddress } from "./utils";
 import { RoyaltyModuleReadOnlyClient } from "../abi/generated";
 import { MAX_ROYALTY_TOKEN } from "../constants/common";
+import { RevShareType } from "../types/common";
 
 export function getLicenseTermByType(
   type: PIL_TYPE,
@@ -163,13 +164,16 @@ const verifyDerivatives = (terms: LicenseTerms) => {
   }
 };
 
-export const getRevenueShare = (revShare: number | string) => {
+export const getRevenueShare = (
+  revShare: number | string,
+  type: RevShareType = RevShareType.COMMERCIAL_REVENUE_SHARE,
+) => {
   const revShareNumber = Number(revShare);
   if (isNaN(revShareNumber)) {
-    throw new Error("CommercialRevShare must be a valid number.");
+    throw new Error(`${type} must be a valid number.`);
   }
   if (revShareNumber < 0 || revShareNumber > 100) {
-    throw new Error("CommercialRevShare should be between 0 and 100.");
+    throw new Error(`${type} must be between 0 and 100.`);
   }
   return (revShareNumber / 100) * MAX_ROYALTY_TOKEN;
 };

--- a/packages/core-sdk/test/integration/nftClient.test.ts
+++ b/packages/core-sdk/test/integration/nftClient.test.ts
@@ -3,6 +3,9 @@ import { getStoryClient } from "./utils/util";
 import { Address } from "viem";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
+import { erc20Address } from "../../src/abi/generated";
+import { aeneid } from "../unit/mockData";
+
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
@@ -32,7 +35,6 @@ describe("nftClient Functions", () => {
       });
       expect(txData.spgNftContract).to.be.a("string").and.not.empty;
       expect(txData.txHash).to.be.a("string").and.not.empty;
-      spgNftContract = txData.spgNftContract!;
     });
 
     it("should successfully create collection with custom mint fee", async () => {
@@ -44,13 +46,14 @@ describe("nftClient Functions", () => {
         mintFeeRecipient: testWalletAddress,
         mintOpen: true,
         contractURI: "test-uri",
-        mintFee: 1000000000000000000n,
-        mintFeeToken: "0x3eD6de5146C3235cC0d15023F3beaD8cb172F63b",
+        mintFee: 10000000n,
+        mintFeeToken: erc20Address[aeneid],
         txOptions: {
           waitForTransaction: true,
         },
       });
       expect(txData.spgNftContract).to.be.a("string").and.not.empty;
+      spgNftContract = txData.spgNftContract!;
     });
 
     it("should successfully create private collection", async () => {
@@ -141,13 +144,15 @@ describe("nftClient Functions", () => {
     });
   });
 
-  it("should successfully get mint fee token", async () => {
-    const mintFeeToken = await client.nftClient.getMintFeeToken(spgNftContract);
-    expect(mintFeeToken).to.be.a("string").and.not.empty;
-  });
+  describe("Mint Fee", () => {
+    it("should successfully get mint fee token", async () => {
+      const mintFeeToken = await client.nftClient.getMintFeeToken(spgNftContract);
+      expect(mintFeeToken).to.equal(erc20Address[aeneid]);
+    });
 
-  it("should successfully get mint fee", async () => {
-    const mintFee = await client.nftClient.getMintFee(spgNftContract);
-    expect(mintFee).to.be.a("bigint");
+    it("should successfully get mint fee", async () => {
+      const mintFee = await client.nftClient.getMintFee(spgNftContract);
+      expect(mintFee).to.equal(10000000n);
+    });
   });
 });

--- a/packages/core-sdk/test/integration/nftClient.test.ts
+++ b/packages/core-sdk/test/integration/nftClient.test.ts
@@ -9,6 +9,7 @@ chai.use(chaiAsPromised);
 describe("nftClient Functions", () => {
   let client: StoryClient;
   let testWalletAddress: Address;
+  let spgNftContract: Address;
 
   before(async () => {
     client = getStoryClient();
@@ -31,6 +32,7 @@ describe("nftClient Functions", () => {
       });
       expect(txData.spgNftContract).to.be.a("string").and.not.empty;
       expect(txData.txHash).to.be.a("string").and.not.empty;
+      spgNftContract = txData.spgNftContract!;
     });
 
     it("should successfully create collection with custom mint fee", async () => {
@@ -137,5 +139,15 @@ describe("nftClient Functions", () => {
         }),
       ).to.be.rejectedWith("Invalid mint fee token address");
     });
+  });
+
+  it("should successfully get mint fee token", async () => {
+    const mintFeeToken = await client.nftClient.getMintFeeToken(spgNftContract);
+    expect(mintFeeToken).to.be.a("string").and.not.empty;
+  });
+
+  it("should successfully get mint fee", async () => {
+    const mintFee = await client.nftClient.getMintFee(spgNftContract);
+    expect(mintFee).to.be.a("bigint");
   });
 });

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -1,3 +1,4 @@
 export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e86ee629cfb";
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const aeneid = 13_15;
+export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -2,4 +2,3 @@ export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e8
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const aeneid = 13_15;
 export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
-export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e86ee629cfb";

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -2,3 +2,4 @@ export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e8
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const aeneid = 13_15;
 export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
+export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e86ee629cfb";

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -661,7 +661,7 @@ describe("Test IpAssetClient", () => {
       sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      // Because registerDerivative doesn't call trigger parseTxIpRegisteredEvent, but the `handleRegistrationTransaction`
+      // Because registerDerivative doesn't call trigger IPRegistered event, but the `handleRegistrationWithFees`
       // will call it, so we need to mock the result of parseTxIpRegisteredEvent to avoid the error.
       sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([]);
 

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -661,6 +661,9 @@ describe("Test IpAssetClient", () => {
       sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
+      // Because registerDerivative doesn't call trigger parseTxIpRegisteredEvent, but the `handleRegistrationTransaction`
+      // will call it, so we need to mock the result of parseTxIpRegisteredEvent to avoid the error.
+      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([]);
 
       const res = await ipAssetClient.registerDerivative({
         childIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -3428,7 +3428,7 @@ describe("Test IpAssetClient", () => {
         });
       } catch (err) {
         expect((err as Error).message).equal(
-          "Failed to mint and register IP and make derivative and distribute royalty tokens: CommercialRevShare should be between 0 and 100.",
+          "Failed to mint and register IP and make derivative and distribute royalty tokens: MaxRevenueShare must be between 0 and 100.",
         );
       }
     });
@@ -3456,7 +3456,7 @@ describe("Test IpAssetClient", () => {
         });
       } catch (err) {
         expect((err as Error).message).equal(
-          "Failed to mint and register IP and make derivative and distribute royalty tokens: CommercialRevShare should be between 0 and 100.",
+          "Failed to mint and register IP and make derivative and distribute royalty tokens: MaxRevenueShare must be between 0 and 100.",
         );
       }
     });

--- a/packages/core-sdk/test/unit/resources/nftClient.test.ts
+++ b/packages/core-sdk/test/unit/resources/nftClient.test.ts
@@ -5,6 +5,8 @@ import { PublicClient, WalletClient } from "viem";
 
 import { NftClient } from "../../../src";
 import { createMock } from "../testUtils";
+import { mockERC20 } from "../mockData";
+import { SpgnftImplReadOnlyClient } from "../../../src/abi/generated";
 
 chai.use(chaiAsPromised);
 
@@ -126,6 +128,22 @@ describe("Test NftClient", () => {
       });
 
       expect(result.encodedTxData?.data).to.be.a("string").and.not.empty;
+    });
+  });
+
+  describe("test for getMintFeeToken", () => {
+    it("should successfully get mint fee token", async () => {
+      sinon.stub(SpgnftImplReadOnlyClient.prototype, "mintFeeToken").resolves(mockERC20);
+      const mintFeeToken = await nftClient.getMintFeeToken(mockERC20);
+      expect(mintFeeToken).equal(mockERC20);
+    });
+  });
+
+  describe("test for getMintFee", () => {
+    it("should successfully get mint fee", async () => {
+      sinon.stub(SpgnftImplReadOnlyClient.prototype, "mintFee").resolves(1n);
+      const mintFee = await nftClient.getMintFee(mockERC20);
+      expect(mintFee).equal(1n);
     });
   });
 });

--- a/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
+++ b/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
@@ -50,7 +50,7 @@ describe("License Terms Helper", () => {
         expiration: 0n,
         defaultMintingFee: 0n,
         royaltyPolicy: "0x0000000000000000000000000000000000000000",
-        uri: "",
+        uri: "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/NCSR.json",
       });
     });
 
@@ -102,7 +102,7 @@ describe("License Terms Helper", () => {
           defaultMintingFee: 1n,
           royaltyPolicy: "0x0000000000000000000000000000000000000000",
           transferable: true,
-          uri: "",
+          uri: "https://github.com/piplabs/pil-document/blob/9a1f803fcf8101a8a78f1dcc929e6014e144ab56/off-chain-terms/CommercialUse.json",
         });
       });
     });
@@ -174,7 +174,7 @@ describe("License Terms Helper", () => {
           defaultMintingFee: 1n,
           royaltyPolicy: "0x0000000000000000000000000000000000000000",
           transferable: true,
-          uri: "",
+          uri: "https://github.com/piplabs/pil-document/blob/ad67bb632a310d2557f8abcccd428e4c9c798db1/off-chain-terms/CommercialRemix.json",
         });
       });
       it("it throw commercialRevShare error when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is less than 0 ", async () => {

--- a/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
+++ b/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
@@ -185,7 +185,7 @@ describe("License Terms Helper", () => {
             currency: zeroAddress,
             commercialRevShare: -8,
           }),
-        ).to.throw(`CommercialRevShare should be between 0 and 100.`);
+        ).to.throw(`CommercialRevShare must be between 0 and 100.`);
       });
 
       it("it throw commercialRevShare error  when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is greater than 100", async () => {
@@ -196,7 +196,7 @@ describe("License Terms Helper", () => {
             currency: zeroAddress,
             commercialRevShare: 105,
           }),
-        ).to.throw(`CommercialRevShare should be between 0 and 100.`);
+        ).to.throw(`CommercialRevShare must be between 0 and 100.`);
       });
 
       it("it get commercialRevShare correct value when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is 10", async () => {
@@ -502,13 +502,11 @@ describe("License Terms Helper", () => {
     });
 
     it("should throw error when call getRevenueShare given revShare is less than 0", async () => {
-      expect(() => getRevenueShare(-1)).to.throw("CommercialRevShare should be between 0 and 100.");
+      expect(() => getRevenueShare(-1)).to.throw("CommercialRevShare must be between 0 and 100.");
     });
 
     it("should throw error when call getRevenueShare given revShare is greater than 100", async () => {
-      expect(() => getRevenueShare(101)).to.throw(
-        "CommercialRevShare should be between 0 and 100.",
-      );
+      expect(() => getRevenueShare(101)).to.throw("CommercialRevShare must be between 0 and 100.");
     });
 
     it("should return correct value when call getRevenueShare given revShare is 10", async () => {

--- a/packages/wagmi-generator/wagmi.config.ts
+++ b/packages/wagmi-generator/wagmi.config.ts
@@ -291,7 +291,7 @@ export default defineConfig(async () => {
           ],
           RoyaltyPolicyLAP: ["onRoyaltyPayment", "getRoyaltyData"],
           LicenseToken: ["ownerOf"],
-          SPG: ["CollectionCreated"],
+          SPG: ["CollectionCreated", "mintFee", "mintFeeToken"],
           GroupingWorkflows: [
             "mintAndRegisterIpAndAttachLicenseAndAddToGroup",
             "registerIpAndAttachLicenseAndAddToGroup",


### PR DESCRIPTION
## Description
### Add Auto Wrapping Support to the following ipAsset functions
  - `mintAndRegisterIp`: Pay nft minting fee
  - `registerDerivative`
### Add following methods to `nftClient`. This is to allow dev to easily to get the mint fee of a SPG collection.
 - `mintFeeToken`: Gets the mint fee token of an spg nft contract
 - `mintFee`: Gets the mint fee of an spg nft contract
### Throw error more specify when call getRevenueShare method

 ### Add `uri` value for each PIL Flavor by default
