### PR TITLE
Add new methods for nftClient

### DIFF
--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -19,7 +19,7 @@
     "build": "pnpm run fix && preconstruct build",
     "test": "pnpm run test:unit",
     "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
-    "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 300000",
+    "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/nftClient.test.ts' --timeout 300000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "pnpm run fix && preconstruct build",
     "test": "pnpm run test:unit",
-    "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
+    "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/ipAsset.test.ts'",
     "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 300000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",
     "format": "prettier --check .",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "pnpm run fix && preconstruct build",
     "test": "pnpm run test:unit",
-    "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/ipAsset.test.ts'",
+    "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
     "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 300000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",
     "format": "prettier --check .",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -19,7 +19,7 @@
     "build": "pnpm run fix && preconstruct build",
     "test": "pnpm run test:unit",
     "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
-    "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/nftClient.test.ts' --timeout 300000",
+    "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 300000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/packages/core-sdk/src/abi/generated.ts
+++ b/packages/core-sdk/src/abi/generated.ts
@@ -15199,7 +15199,7 @@ export const wrappedIpAbi = [
     inputs: [],
     name: "name",
     outputs: [{ name: "", internalType: "string", type: "string" }],
-    stateMutability: "view",
+    stateMutability: "pure",
   },
   {
     type: "function",
@@ -15228,7 +15228,7 @@ export const wrappedIpAbi = [
     inputs: [],
     name: "symbol",
     outputs: [{ name: "", internalType: "string", type: "string" }],
-    stateMutability: "view",
+    stateMutability: "pure",
   },
   {
     type: "function",

--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -43,7 +43,7 @@ export class DisputeClient {
    * Raises a dispute on a given ipId.
    *
    * Submits a {@link DisputeRaised} event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/dispute/IDisputeModule.sol | IDisputeModule.sol}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L64 | IDisputeModule.sol}
    * for a list of on-chain events emitted when a dispute is raised.
    */
   public async raiseDispute(request: RaiseDisputeRequest): Promise<RaiseDisputeResponse> {
@@ -187,7 +187,7 @@ export class DisputeClient {
    * Tags a derivative if a parent has been tagged with an infringement tag
    * or a group ip if a group member has been tagged with an infringement tag.
    *
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/dispute/IDisputeModule.sol | IDisputeModule.sol}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L93 | IDisputeModule.sol}
    * for a list of on-chain events emitted when a derivative is tagged on an infringement.
    */
   public async tagIfRelatedIpInfringed(

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -109,7 +109,7 @@ export class GroupClient {
     }
   }
   /** Mint an NFT from a SPGNFT collection, register it with metadata as an IP, attach license terms to the registered IP, and add it to a group IP.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * for a list of on-chain events emitted when an IP is minted and registered, license terms are attached to an IP, and it is added to a group.
    */
   public async mintAndRegisterIpAndAttachLicenseAndAddToGroup(
@@ -186,7 +186,7 @@ export class GroupClient {
   }
 
   /** Register an NFT as IP with metadata, attach license terms to the registered IP, and add it to a group IP.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * for a list of on-chain events emitted when an IP is registered, license terms are attached to an IP, and it is added to a group.
    */
   public async registerIpAndAttachLicenseAndAddToGroup(
@@ -298,7 +298,7 @@ export class GroupClient {
     }
   }
   /** Register a group IP with a group reward pool and attach license terms to the group IP.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/grouping/IGroupingModule.sol | IGroupingModule}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | IGroupingModule}
    * for a list of on-chain events emitted when a group IP is registered, license terms are attached to a group IP .
    */
   public async registerGroupAndAttachLicense(
@@ -330,7 +330,7 @@ export class GroupClient {
     }
   }
   /** Register a group IP with a group reward pool, attach license terms to the group IP, and add individual IPs to the group IP.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/grouping/IGroupingModule.sol | IGroupingModule}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | IGroupingModule}
    * for a list of on-chain events emitted when a group IP is registered, license terms are attached to a group IP, and individual IPs are added to a group.
    */
   public async registerGroupAndAttachLicenseAndAddIps(

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -145,6 +145,7 @@ export class GroupClient {
       });
       const object: GroupingWorkflowsMintAndRegisterIpAndAttachLicenseAndAddToGroupRequest = {
         ...request,
+        allowDuplicates: request.allowDuplicates || true,
         spgNftContract: getAddress(spgNftContract, "request.spgNftContract"),
         recipient:
           (recipient && getAddress(recipient, "request.recipient")) || this.wallet.account!.address,

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -44,6 +44,7 @@ import { getFunctionSignature } from "../utils/getFunctionSignature";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
 import { getIpMetadataForWorkflow } from "../utils/getIpMetadataForWorkflow";
 import { getRevenueShare } from "../utils/licenseTermsHelper";
+import { RevShareType } from "../types/common";
 
 export class GroupClient {
   public groupingWorkflowsClient: GroupingWorkflowsClient;
@@ -147,7 +148,9 @@ export class GroupClient {
         spgNftContract: getAddress(spgNftContract, "request.spgNftContract"),
         recipient:
           (recipient && getAddress(recipient, "request.recipient")) || this.wallet.account!.address,
-        maxAllowedRewardShare: BigInt(getRevenueShare(request.maxAllowedRewardShare)),
+        maxAllowedRewardShare: BigInt(
+          getRevenueShare(request.maxAllowedRewardShare, RevShareType.MAX_ALLOWED_REWARD_SHARE),
+        ),
         licensesData: this.getLicenseData(request.licenseData),
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
         sigAddToGroup: {
@@ -257,7 +260,9 @@ export class GroupClient {
         licensesData: this.getLicenseData(request.licenseData),
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
         tokenId: BigInt(request.tokenId),
-        maxAllowedRewardShare: BigInt(getRevenueShare(request.maxAllowedRewardShare)),
+        maxAllowedRewardShare: BigInt(
+          getRevenueShare(request.maxAllowedRewardShare, RevShareType.MAX_ALLOWED_REWARD_SHARE),
+        ),
         sigAddToGroup: {
           signer: getAddress(this.wallet.account!.address, "wallet.account.address"),
           deadline: calculatedDeadline,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -104,7 +104,7 @@ import { AccessPermission } from "../types/resources/permission";
 import { LicenseTerms, RegisterPILTermsRequest } from "../types/resources/license";
 import { MAX_ROYALTY_TOKEN, royaltySharesTotalSupply } from "../constants/common";
 import { getFunctionSignature } from "../utils/getFunctionSignature";
-import { LicensingConfig } from "../types/common";
+import { LicensingConfig, ValidatedLicensingConfig } from "../types/common";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
 import { getIpMetadataForWorkflow } from "../utils/getIpMetadataForWorkflow";
 import {

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -664,7 +664,7 @@ export class IPAssetClient {
           (request.recipient && getAddress(request.recipient, "request.recipient")) ||
           this.wallet.account!.address,
         licenseTermsData,
-        allowDuplicates: request.allowDuplicates,
+        allowDuplicates: request.allowDuplicates || true,
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
       };
 
@@ -983,7 +983,7 @@ export class IPAssetClient {
         derivData,
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
         recipient,
-        allowDuplicates: request.allowDuplicates,
+        allowDuplicates: request.allowDuplicates || true,
         spgNftContract,
       };
       const encodedTxData =
@@ -1086,7 +1086,7 @@ export class IPAssetClient {
           (request.recipient && getAddress(request.recipient, "request.recipient")) ||
           this.wallet.account!.address,
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
-        allowDuplicates: request.allowDuplicates,
+        allowDuplicates: request.allowDuplicates || true,
       };
       const encodedTxData = this.registrationWorkflowsClient.mintAndRegisterIpEncode(object);
       if (request.txOptions?.encodedTxDataOnly) {
@@ -1225,7 +1225,7 @@ export class IPAssetClient {
           licenseTokenIds: licenseTokenIds,
           royaltyContext: zeroAddress,
           maxRts: Number(request.maxRts),
-          allowDuplicates: request.allowDuplicates,
+          allowDuplicates: request.allowDuplicates || true,
         };
       this.validateMaxRts(object.maxRts);
 
@@ -1592,7 +1592,7 @@ export class IPAssetClient {
           ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
           licenseTermsData,
           royaltyShares,
-          allowDuplicates: request.allowDuplicates,
+          allowDuplicates: request.allowDuplicates || true,
         };
       const encodedTxData =
         this.royaltyTokenDistributionWorkflowsClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensEncode(
@@ -1653,7 +1653,7 @@ export class IPAssetClient {
           ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
           derivData,
           royaltyShares: royaltyShares,
-          allowDuplicates: request.allowDuplicates,
+          allowDuplicates: request.allowDuplicates || true,
         };
 
       const encodedTxData =

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -104,7 +104,7 @@ import { AccessPermission } from "../types/resources/permission";
 import { LicenseTerms, RegisterPILTermsRequest } from "../types/resources/license";
 import { MAX_ROYALTY_TOKEN, royaltySharesTotalSupply } from "../constants/common";
 import { getFunctionSignature } from "../utils/getFunctionSignature";
-import { LicensingConfig, ValidatedLicensingConfig } from "../types/common";
+import { LicensingConfig } from "../types/common";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
 import { getIpMetadataForWorkflow } from "../utils/getIpMetadataForWorkflow";
 import {

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -105,7 +105,7 @@ import { AccessPermission } from "../types/resources/permission";
 import { LicenseTerms, RegisterPILTermsRequest } from "../types/resources/license";
 import { MAX_ROYALTY_TOKEN, royaltySharesTotalSupply } from "../constants/common";
 import { getFunctionSignature } from "../utils/getFunctionSignature";
-import { LicensingConfig } from "../types/common";
+import { LicensingConfig, RevShareType } from "../types/common";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
 import { getIpMetadataForWorkflow } from "../utils/getIpMetadataForWorkflow";
 import {
@@ -549,7 +549,7 @@ export class IPAssetClient {
             zeroAddress,
             BigInt(arg.maxMintingFee || 0),
             Number(arg.maxRts || MAX_ROYALTY_TOKEN),
-            getRevenueShare(arg.maxRevenueShare || 100),
+            getRevenueShare(arg.maxRevenueShare || 100, RevShareType.MAX_REVENUE_SHARE),
           ],
         });
         const { result: state } = await ipAccount.state();
@@ -1837,7 +1837,10 @@ export class IPAssetClient {
       royaltyContext: zeroAddress,
       maxMintingFee: BigInt(derivativeData.maxMintingFee || 0),
       maxRts: Number(derivativeData.maxRts || MAX_ROYALTY_TOKEN),
-      maxRevenueShare: getRevenueShare(derivativeData.maxRevenueShare || 100),
+      maxRevenueShare: getRevenueShare(
+        derivativeData.maxRevenueShare || 100,
+        RevShareType.MAX_REVENUE_SHARE,
+      ),
     };
     if (internalDerivativeData.parentIpIds.length === 0) {
       throw new Error("The parent IP IDs must be provided.");

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -477,7 +477,7 @@ export class IPAssetClient {
         const contractCall = () => {
           return this.licensingModuleClient.registerDerivative(object);
         };
-        return this.handleRegistrationTransaction({
+        return this.handleRegistrationWithFees({
           sender: this.walletAddress,
           derivData: object,
           contractCall,
@@ -676,7 +676,7 @@ export class IPAssetClient {
       const contractCall = () => {
         return this.licenseAttachmentWorkflowsClient.mintAndRegisterIpAndAttachPilTerms(object);
       };
-      const rsp = await this.handleRegistrationTransaction({
+      const rsp = await this.handleRegistrationWithFees({
         wipOptions: request.wipOptions,
         sender: this.walletAddress,
         spgNftContract: object.spgNftContract,
@@ -948,7 +948,7 @@ export class IPAssetClient {
       const contractCall = () => {
         return this.derivativeWorkflowsClient.registerIpAndMakeDerivative(object);
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         wipOptions: {
           ...request.wipOptions,
           useMulticallWhenPossible: false,
@@ -994,7 +994,7 @@ export class IPAssetClient {
       const contractCall = () => {
         return this.derivativeWorkflowsClient.mintAndRegisterIpAndMakeDerivative(object);
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         wipOptions: request.wipOptions,
         sender: this.walletAddress,
         spgSpenderAddress: this.derivativeWorkflowsClient.address,
@@ -1095,7 +1095,7 @@ export class IPAssetClient {
       const contractCall = () => {
         return this.registrationWorkflowsClient.mintAndRegisterIp(object);
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         sender: this.walletAddress,
         spgSpenderAddress: this.registrationWorkflowsClient.address,
         encodedTxs: [encodedTxData],
@@ -1241,7 +1241,7 @@ export class IPAssetClient {
           object,
         );
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         wipOptions: {
           ...request.wipOptions,
           // need to disable multicall to avoid needing to transfer the license
@@ -1521,7 +1521,7 @@ export class IPAssetClient {
           object,
         );
       };
-      const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationTransaction({
+      const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationWithFees({
         wipOptions: {
           ...request.wipOptions,
           useMulticallWhenPossible: false,
@@ -1603,7 +1603,7 @@ export class IPAssetClient {
           object,
         );
       };
-      const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationTransaction({
+      const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationWithFees({
         wipOptions: request.wipOptions,
         sender: this.walletAddress,
         spgNftContract: object.spgNftContract,
@@ -1665,7 +1665,7 @@ export class IPAssetClient {
           object,
         );
       };
-      return this.handleRegistrationTransaction({
+      return this.handleRegistrationWithFees({
         spgNftContract: object.spgNftContract,
         wipOptions: request.wipOptions,
         sender: this.walletAddress,
@@ -1916,7 +1916,7 @@ export class IPAssetClient {
     return { licenseTerms, licenseTermsData: processedLicenseTermsData };
   }
 
-  private async handleRegistrationTransaction({
+  private async handleRegistrationWithFees({
     sender,
     derivData,
     spgNftContract,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -647,8 +647,8 @@ export class IPAssetClient {
   /**
    * Mint an NFT from a collection and register it as an IP.
    * it emits IPRegistered (ipId, chainId, tokenContract, tokenId, name, uri, registrationDate).
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/licensing/ILicensingModule.sol | ILicensingModule}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
    * for a list of on-chain events emitted when an IP is minted and registered, and license terms are attached to an IP.
    */
   public async mintAndRegisterIpAssetWithPilTerms(
@@ -796,7 +796,7 @@ export class IPAssetClient {
   }
   /**
    * Register a given NFT as an IP and attach Programmable IP License Terms.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/licensing/ILicensingModule.sol | ILicensingModule}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
    * for a list of on-chain events emitted when an ip is registered and license terms are attached to it.
    */
   public async registerIpAndAttachPilTerms(
@@ -891,7 +891,7 @@ export class IPAssetClient {
   }
   /**
    * Register the given NFT as a derivative IP with metadata without using license tokens.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * for a list of on-chain events emitted when a derivative IP is registered.
    */
   public async registerDerivativeIp(
@@ -966,7 +966,7 @@ export class IPAssetClient {
   }
   /**
    * Mint an NFT from a collection and register it as a derivative IP without license tokens.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * for a list of on-chain events emitted when a derivative IP is minted and registered.
    */
   public async mintAndRegisterIpAndMakeDerivative(
@@ -1112,7 +1112,7 @@ export class IPAssetClient {
   }
   /**
    * Register Programmable IP License Terms (if unregistered) and attach it to IP.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/licensing/ILicensingModule.sol | ILicensingModule}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
    * for a list of on-chain events emitted when a license terms is attached to an IP.
    */
   public async registerPilTermsAndAttach(
@@ -1351,8 +1351,8 @@ export class IPAssetClient {
   /**
    * Register the given NFT and attach license terms and distribute royalty tokens. In order to successfully distribute royalty tokens, the first license terms attached to the IP must be
    * a commercial license.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/royalty/IRoyaltyModule.sol| IRoyaltyModule}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88 | IRoyaltyModule}
    * for a list of on-chain events emitted when an IP is registered, license terms are attached to an IP, and royalty tokens are distributed.
    */
   public async registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens(
@@ -1458,8 +1458,8 @@ export class IPAssetClient {
   /**
    * Register the given NFT as a derivative IP and attach license terms and distribute royalty tokens.  In order to successfully distribute royalty tokens, the license terms attached to the IP must be
    * a commercial license.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/royalty/IRoyaltyModule.sol| IRoyaltyModule}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88| IRoyaltyModule}
    * for a list of on-chain events emitted when a derivative IP is registered, license terms are attached to an IP, and royalty tokens are distributed.
    */
   public async registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens(
@@ -1571,8 +1571,8 @@ export class IPAssetClient {
 
   /**
    * Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/modules/royalty/IRoyaltyModule.sol| IRoyaltyModule}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88| IRoyaltyModule}
    * for a list of on-chain events emitted when an IP is minted and registered, PIL terms are attached to an IP, and royalty tokens are distributed.
    */
   public async mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens(
@@ -1634,7 +1634,7 @@ export class IPAssetClient {
   }
   /**
    * Mint an NFT and register the IP, make a derivative, and distribute royalty tokens.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/interfaces/registries/IIPAssetRegistry.sol | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * for a list of on-chain events emitted when an IP is minted and registered, a derivative IP is made, and royalty tokens are distributed.
    */
   public async mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens(

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -48,6 +48,7 @@ import { ChainIds } from "../types/config";
 import { calculateLicenseWipMintFee, contractCallWithFees } from "../utils/feeUtils";
 import { Erc20Spender } from "../types/utils/wip";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
+import { RevShareType } from "../types/common";
 
 export class LicenseClient {
   public licenseRegistryClient: LicenseRegistryEventClient;
@@ -390,7 +391,7 @@ export class LicenseClient {
         receiver,
         royaltyContext: zeroAddress,
         maxMintingFee: BigInt(request.maxMintingFee),
-        maxRevenueShare: getRevenueShare(request.maxRevenueShare),
+        maxRevenueShare: getRevenueShare(request.maxRevenueShare, RevShareType.MAX_REVENUE_SHARE),
       } as const;
       if (req.maxMintingFee < 0) {
         throw new Error(`The maxMintingFee must be greater than 0.`);

--- a/packages/core-sdk/src/resources/nftClient.ts
+++ b/packages/core-sdk/src/resources/nftClient.ts
@@ -1,19 +1,21 @@
-import { PublicClient, isAddress, maxUint32, zeroAddress } from "viem";
+import { Address, PublicClient, isAddress, maxUint32, zeroAddress } from "viem";
 
 import {
   RegistrationWorkflowsClient,
   RegistrationWorkflowsCreateCollectionRequest,
   SimpleWalletClient,
+  SpgnftImplReadOnlyClient,
 } from "../abi/generated";
 import {
   CreateNFTCollectionRequest,
   CreateNFTCollectionResponse,
 } from "../types/resources/nftClient";
 import { handleError } from "../utils/errors";
-import { getAddress } from "../utils/utils";
+import { getAddress, validateAddress } from "../utils/utils";
 
 export class NftClient {
   public registrationWorkflowsClient: RegistrationWorkflowsClient;
+
   private readonly rpcClient: PublicClient;
   private readonly wallet: SimpleWalletClient;
 
@@ -95,5 +97,26 @@ export class NftClient {
     } catch (error) {
       handleError(error, "Failed to create a SPG NFT collection");
     }
+  }
+  /**
+   * Returns the current mint token of the collection.
+   */
+  public async getMintFeeToken(spgNftContract: Address): Promise<Address> {
+    const spgNftClient = new SpgnftImplReadOnlyClient(
+      this.rpcClient,
+      validateAddress(spgNftContract),
+    );
+    return spgNftClient.mintFeeToken();
+  }
+
+  /**
+   * Returns the current mint fee of the collection.
+   */
+  public async getMintFee(spgNftContract: Address): Promise<bigint> {
+    const spgNftClient = new SpgnftImplReadOnlyClient(
+      this.rpcClient,
+      validateAddress(spgNftContract),
+    );
+    return spgNftClient.mintFee();
   }
 }

--- a/packages/core-sdk/src/types/common.ts
+++ b/packages/core-sdk/src/types/common.ts
@@ -42,7 +42,3 @@ export type ValidatedLicensingConfig = LicensingConfig & {
  * Will be converted to bigint for contract calls.
  */
 export type TokenAmountInput = bigint | number;
-// Make all properties in T required
-export type MakeRequired<T> = {
-  [P in keyof T]-?: T[P];
-};

--- a/packages/core-sdk/src/types/common.ts
+++ b/packages/core-sdk/src/types/common.ts
@@ -42,3 +42,7 @@ export type ValidatedLicensingConfig = LicensingConfig & {
  * Will be converted to bigint for contract calls.
  */
 export type TokenAmountInput = bigint | number;
+// Make all properties in T required
+export type MakeRequired<T> = {
+  [P in keyof T]-?: T[P];
+};

--- a/packages/core-sdk/src/types/common.ts
+++ b/packages/core-sdk/src/types/common.ts
@@ -42,3 +42,21 @@ export type ValidatedLicensingConfig = LicensingConfig & {
  * Will be converted to bigint for contract calls.
  */
 export type TokenAmountInput = bigint | number;
+
+/**
+ * The type of revenue share.
+ */
+export enum RevShareType {
+  /**
+   * The commercial revenue share.
+   */
+  COMMERCIAL_REVENUE_SHARE = "CommercialRevShare",
+  /**
+   * The maximum revenue share.
+   */
+  MAX_REVENUE_SHARE = "MaxRevenueShare",
+  /**
+   * The maximum allowed reward share.
+   */
+  MAX_ALLOWED_REWARD_SHARE = "MaxAllowedRewardShare",
+}

--- a/packages/core-sdk/src/types/common.ts
+++ b/packages/core-sdk/src/types/common.ts
@@ -45,18 +45,10 @@ export type TokenAmountInput = bigint | number;
 
 /**
  * The type of revenue share.
+ * It is used to determine the type of revenue share to be used in the revenue share calculation and throw error when the revenue share is not valid.
  */
 export enum RevShareType {
-  /**
-   * The commercial revenue share.
-   */
   COMMERCIAL_REVENUE_SHARE = "CommercialRevShare",
-  /**
-   * The maximum revenue share.
-   */
   MAX_REVENUE_SHARE = "MaxRevenueShare",
-  /**
-   * The maximum allowed reward share.
-   */
   MAX_ALLOWED_REWARD_SHARE = "MaxAllowedRewardShare",
 }

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -19,8 +19,11 @@ export type MintAndRegisterIpAndAttachLicenseAndAddToGroupRequest = {
   spgNftContract: Address;
   /** The ID of the group IP to add the newly registered IP. */
   groupId: Address;
-  /** Set to true to allow minting an NFT with a duplicate metadata hash. */
-  allowDuplicates: boolean;
+  /**
+   * Set to true to allow minting an NFT with a duplicate metadata hash.
+   * @default true
+   */
+  allowDuplicates?: boolean;
   /** The maximum reward share percentage that can be allocated to each member IP. */
   maxAllowedRewardShare: number | string;
   /** The data of the license and its configuration to be attached to the new group IP. */

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -455,7 +455,7 @@ export type CommonRegistrationParams = WithWipOptions & {
 export type RegistrationResponse = {
   txHash?: Hex;
   receipt?: TransactionReceipt;
-  ipId?: Hex;
+  ipId?: Address;
   tokenId?: bigint;
 };
 

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -83,8 +83,11 @@ export type ValidatedLicenseTermsData = Omit<
 
 export type MintAndRegisterIpAssetWithPilTermsRequest = {
   spgNftContract: Address;
-  /** Indicates whether the license terms can be attached to the same IP ID or not. */
-  allowDuplicates: boolean;
+  /**
+   * Set to true to allow minting an NFT with a duplicate metadata hash.
+   * @default true
+   */
+  allowDuplicates?: boolean;
   /** The data of the license and its configuration to be attached to the IP. */
   licenseTermsData: LicenseTermsData[];
   /** The address to receive the minted NFT. If not provided, the function will use the user's own wallet address. */
@@ -147,8 +150,11 @@ export type MintAndRegisterIpAndMakeDerivativeRequest = {
   derivData: DerivativeData;
   /** The address to receive the minted NFT. If not provided, the function will use the user's own wallet address. */
   recipient?: Address;
-  /** Set to true to allow minting an NFT with a duplicate metadata hash. */
-  allowDuplicates: boolean;
+  /**
+   * Set to true to allow minting an NFT with a duplicate metadata hash.
+   * @default true
+   */
+  allowDuplicates?: boolean;
 } & IpMetadataAndTxOptions &
   WithWipOptions;
 
@@ -252,7 +258,11 @@ export type MintAndRegisterIpRequest = IpMetadataAndTxOptions &
   WithWipOptions & {
     spgNftContract: Address;
     recipient?: Address;
-    allowDuplicates: boolean;
+    /**
+     * Set to true to allow minting an NFT with a duplicate metadata hash.
+     * @default true
+     */
+    allowDuplicates?: boolean;
   };
 export type RegisterPilTermsAndAttachRequest = {
   ipId: Address;
@@ -276,7 +286,11 @@ export type MintAndRegisterIpAndMakeDerivativeWithLicenseTokensRequest = {
   licenseTokenIds: string[] | bigint[] | number[];
   recipient?: Address;
   maxRts: number | string;
-  allowDuplicates: boolean;
+  /**
+   * Set to true to allow minting an NFT with a duplicate metadata hash.
+   * @default true
+   */
+  allowDuplicates?: boolean;
 } & IpMetadataAndTxOptions &
   WithWipOptions;
 
@@ -401,8 +415,11 @@ export type RegisterDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokensRes
 export type MintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokensRequest = {
   /** The address of the SPG NFT contract. */
   spgNftContract: Address;
-  /** Set to true to allow minting an NFT with a duplicate metadata hash. */
-  allowDuplicates: boolean;
+  /**
+   * Set to true to allow minting an NFT with a duplicate metadata hash.
+   * @default true
+   */
+  allowDuplicates?: boolean;
   /** The data of the license and its configuration to be attached to the new group IP. */
   licenseTermsData: LicenseTermsData[];
   /** Authors of the IP and their shares of the royalty tokens */
@@ -427,8 +444,11 @@ export type MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensRequest 
   derivData: DerivativeData;
   /** Authors of the IP and their shares of the royalty tokens. */
   royaltyShares: RoyaltyShare[];
-  /** Set to true to allow minting an NFT with a duplicate metadata hash. */
-  allowDuplicates: boolean;
+  /**
+   * Set to true to allow minting an NFT with a duplicate metadata hash.
+   * @default true
+   */
+  allowDuplicates?: boolean;
   /** The address to receive the minted NFT. If not provided, the function will use the user's own wallet address. */
   recipient?: Address;
   txOptions?: Omit<TxOptions, "encodedTxDataOnly">;

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -37,9 +37,9 @@ export type InternalDerivativeData = {
   maxRevenueShare: number;
   licenseTemplate: Address;
 };
-export type RegisterIpResponse = {
+export type RegisterIpResponse = RegistrationResponse & {
   encodedTxData?: EncodedTxData;
-} & CommonRegistrationResponse;
+};
 
 export type RegisterRequest = {
   nftContract: Address;
@@ -59,10 +59,11 @@ export type RegisterDerivativeWithLicenseTokensResponse = {
   encodedTxData?: EncodedTxData;
 };
 
-export type RegisterDerivativeRequest = {
-  txOptions?: TxOptions;
-  childIpId: Address;
-} & DerivativeData;
+export type RegisterDerivativeRequest = WithWipOptions &
+  DerivativeData & {
+    txOptions?: TxOptions;
+    childIpId: Address;
+  };
 
 export type RegisterDerivativeResponse = {
   txHash?: Hex;
@@ -151,9 +152,9 @@ export type MintAndRegisterIpAndMakeDerivativeRequest = {
 } & IpMetadataAndTxOptions &
   WithWipOptions;
 
-export type MintAndRegisterIpAndMakeDerivativeResponse = {
+export type MintAndRegisterIpAndMakeDerivativeResponse = RegistrationResponse & {
   encodedTxData?: EncodedTxData;
-} & CommonRegistrationResponse;
+};
 
 export type IpRelationship = {
   parentIpId: Address;
@@ -247,11 +248,12 @@ export type IpMetadata = {
   [key: string]: unknown;
 };
 
-export type MintAndRegisterIpRequest = {
-  spgNftContract: Address;
-  recipient?: Address;
-  allowDuplicates: boolean;
-} & IpMetadataAndTxOptions;
+export type MintAndRegisterIpRequest = IpMetadataAndTxOptions &
+  WithWipOptions & {
+    spgNftContract: Address;
+    recipient?: Address;
+    allowDuplicates: boolean;
+  };
 export type RegisterPilTermsAndAttachRequest = {
   ipId: Address;
   /** The data of the license and its configuration to be attached to the IP. */
@@ -439,7 +441,7 @@ export type MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensResponse
   tokenId?: bigint;
 };
 
-export type CommonRegistrationHandlerParams = WithWipOptions & {
+export type CommonRegistrationParams = WithWipOptions & {
   contractCall: () => Promise<Hash>;
   encodedTxs: EncodedTxData[];
   spgNftContract?: Address;
@@ -450,9 +452,13 @@ export type CommonRegistrationHandlerParams = WithWipOptions & {
   txOptions?: TxOptions;
 };
 
-export type CommonRegistrationResponse = {
+export type RegistrationResponse = {
   txHash?: Hex;
-  ipId?: Address;
-  tokenId?: bigint;
   receipt?: TransactionReceipt;
+  ipId?: Hex;
+  tokenId?: bigint;
+};
+
+export type CommonRegistrationTxResponse = RegistrationResponse & {
+  txHash: Hex;
 };

--- a/packages/core-sdk/src/utils/licenseTermsHelper.ts
+++ b/packages/core-sdk/src/utils/licenseTermsHelper.ts
@@ -36,6 +36,8 @@ export function getLicenseTermByType(
   };
   if (type === PIL_TYPE.NON_COMMERCIAL_REMIX) {
     licenseTerms.commercializerCheckerData = "0x";
+    licenseTerms.uri =
+      "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/NCSR.json";
     return licenseTerms;
   } else if (type === PIL_TYPE.COMMERCIAL_USE) {
     if (!term || term.defaultMintingFee === undefined || term.currency === undefined) {
@@ -47,6 +49,8 @@ export function getLicenseTermByType(
     licenseTerms.commercialAttribution = true;
     licenseTerms.derivativesReciprocal = false;
     licenseTerms.currency = validateAddress(term.currency);
+    licenseTerms.uri =
+      "https://github.com/piplabs/pil-document/blob/9a1f803fcf8101a8a78f1dcc929e6014e144ab56/off-chain-terms/CommercialUse.json";
     return licenseTerms;
   } else {
     if (
@@ -63,7 +67,8 @@ export function getLicenseTermByType(
     licenseTerms.defaultMintingFee = BigInt(term.defaultMintingFee);
     licenseTerms.commercialUse = true;
     licenseTerms.commercialAttribution = true;
-
+    licenseTerms.uri =
+      "https://github.com/piplabs/pil-document/blob/ad67bb632a310d2557f8abcccd428e4c9c798db1/off-chain-terms/CommercialRemix.json";
     licenseTerms.commercialRevShare = getRevenueShare(term.commercialRevShare);
     licenseTerms.derivativesReciprocal = true;
     licenseTerms.currency = validateAddress(term.currency);

--- a/packages/core-sdk/src/utils/licenseTermsHelper.ts
+++ b/packages/core-sdk/src/utils/licenseTermsHelper.ts
@@ -4,6 +4,7 @@ import { PIL_TYPE, LicenseTerms, RegisterPILTermsRequest } from "../types/resour
 import { validateAddress } from "./utils";
 import { RoyaltyModuleReadOnlyClient } from "../abi/generated";
 import { MAX_ROYALTY_TOKEN } from "../constants/common";
+import { RevShareType } from "../types/common";
 
 export function getLicenseTermByType(
   type: PIL_TYPE,
@@ -163,13 +164,16 @@ const verifyDerivatives = (terms: LicenseTerms) => {
   }
 };
 
-export const getRevenueShare = (revShare: number | string) => {
+export const getRevenueShare = (
+  revShare: number | string,
+  type: RevShareType = RevShareType.COMMERCIAL_REVENUE_SHARE,
+) => {
   const revShareNumber = Number(revShare);
   if (isNaN(revShareNumber)) {
-    throw new Error("CommercialRevShare must be a valid number.");
+    throw new Error(`${type} must be a valid number.`);
   }
   if (revShareNumber < 0 || revShareNumber > 100) {
-    throw new Error("CommercialRevShare should be between 0 and 100.");
+    throw new Error(`${type} must be between 0 and 100.`);
   }
   return (revShareNumber / 100) * MAX_ROYALTY_TOKEN;
 };

--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -273,7 +273,6 @@ describe("Dispute Functions", () => {
           maxRts: 5 * 10 ** 6,
           maxRevenueShare: 100,
         },
-        allowDuplicates: true,
         txOptions: { waitForTransaction: true },
       });
       childIpId = derivativeIpIdResponse1.ipId!;
@@ -288,7 +287,6 @@ describe("Dispute Functions", () => {
           maxRts: 5 * 10 ** 6,
           maxRevenueShare: 100,
         },
-        allowDuplicates: true,
         txOptions: { waitForTransaction: true },
       });
       childIpId2 = derivativeIpIdResponse2.ipId!;

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -167,7 +167,6 @@ describe("Group Functions", () => {
             },
           },
         ],
-        allowDuplicates: true,
         maxAllowedRewardShare: 5,
         txOptions: { waitForTransaction: true },
       });

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -419,7 +419,6 @@ describe("IP Asset Functions", () => {
           maxRts: 5 * 10 ** 6,
           maxRevenueShare: 100,
         },
-        allowDuplicates: true,
         txOptions: { waitForTransaction: true },
       });
       expect(result.txHash).to.be.a("string").and.not.empty;
@@ -503,7 +502,6 @@ describe("IP Asset Functions", () => {
         spgNftContract: nftContract,
         licenseTokenIds: [mintLicenseTokensResult.licenseTokenIds![0]],
         maxRts: 5 * 10 ** 6,
-        allowDuplicates: true,
         ipMetadata: {
           ipMetadataURI: "test-uri",
           ipMetadataHash: toHex("test-metadata-hash", { size: 32 }),
@@ -938,7 +936,6 @@ describe("IP Asset Functions", () => {
       const result =
         await client.ipAsset.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens({
           spgNftContract: nftContract,
-          allowDuplicates: true,
           licenseTermsData: [
             {
               terms: {
@@ -1009,7 +1006,6 @@ describe("IP Asset Functions", () => {
         // create parent ip with minting fee
         const result = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
           spgNftContract: nftContractWithMintingFee,
-          allowDuplicates: true,
           licenseTermsData: [
             {
               terms: {
@@ -1066,7 +1062,6 @@ describe("IP Asset Functions", () => {
             nftMetadataURI: "test",
             nftMetadataHash: zeroHash,
           },
-          allowDuplicates: true,
           txOptions: { waitForTransaction: true },
         });
         expect(rsp.txHash).to.be.a("string").and.not.empty;
@@ -1098,7 +1093,6 @@ describe("IP Asset Functions", () => {
             spgNftContract: nftContractWithMintingFee,
             licenseTokenIds: licenseTokenIds!,
             maxRts: MAX_ROYALTY_TOKEN,
-            allowDuplicates: true,
             ipMetadata: {
               ipMetadataURI: "test",
               ipMetadataHash: zeroHash,
@@ -1144,7 +1138,6 @@ describe("IP Asset Functions", () => {
             maxRts: MAX_ROYALTY_TOKEN,
             maxRevenueShare: 100,
           },
-          allowDuplicates: true,
           ipMetadata: {
             ipMetadataURI: "test",
             ipMetadataHash: zeroHash,
@@ -1211,7 +1204,6 @@ describe("IP Asset Functions", () => {
               maxRts: MAX_ROYALTY_TOKEN,
               maxRevenueShare: 100,
             },
-            allowDuplicates: true,
             ipMetadata: {
               ipMetadataURI: "test",
               ipMetadataHash: zeroHash,
@@ -1336,7 +1328,6 @@ describe("IP Asset Functions", () => {
                 },
               },
             ],
-            allowDuplicates: true,
           },
           {
             spgNftContract: nftContract,
@@ -1373,7 +1364,6 @@ describe("IP Asset Functions", () => {
                 },
               },
             ],
-            allowDuplicates: true,
           },
         ],
         txOptions: { waitForTransaction: true },
@@ -1397,7 +1387,6 @@ describe("IP Asset Functions", () => {
               maxRts: 5 * 10 ** 6,
               maxRevenueShare: "0",
             },
-            allowDuplicates: true,
           },
           {
             spgNftContract: nftContract,
@@ -1408,7 +1397,6 @@ describe("IP Asset Functions", () => {
               maxRts: 5 * 10 ** 6,
               maxRevenueShare: "0",
             },
-            allowDuplicates: true,
           },
         ],
         txOptions: { waitForTransaction: true },

--- a/packages/core-sdk/test/integration/nftClient.test.ts
+++ b/packages/core-sdk/test/integration/nftClient.test.ts
@@ -3,6 +3,9 @@ import { getStoryClient } from "./utils/util";
 import { Address } from "viem";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
+import { erc20Address } from "../../src/abi/generated";
+import { aeneid } from "../unit/mockData";
+
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
@@ -32,7 +35,6 @@ describe("nftClient Functions", () => {
       });
       expect(txData.spgNftContract).to.be.a("string").and.not.empty;
       expect(txData.txHash).to.be.a("string").and.not.empty;
-      spgNftContract = txData.spgNftContract!;
     });
 
     it("should successfully create collection with custom mint fee", async () => {
@@ -44,13 +46,14 @@ describe("nftClient Functions", () => {
         mintFeeRecipient: testWalletAddress,
         mintOpen: true,
         contractURI: "test-uri",
-        mintFee: 1000000000000000000n,
-        mintFeeToken: "0x3eD6de5146C3235cC0d15023F3beaD8cb172F63b",
+        mintFee: 10000000n,
+        mintFeeToken: erc20Address[aeneid],
         txOptions: {
           waitForTransaction: true,
         },
       });
       expect(txData.spgNftContract).to.be.a("string").and.not.empty;
+      spgNftContract = txData.spgNftContract!;
     });
 
     it("should successfully create private collection", async () => {
@@ -141,13 +144,15 @@ describe("nftClient Functions", () => {
     });
   });
 
-  it("should successfully get mint fee token", async () => {
-    const mintFeeToken = await client.nftClient.getMintFeeToken(spgNftContract);
-    expect(mintFeeToken).to.be.a("string").and.not.empty;
-  });
+  describe("Mint Fee", () => {
+    it("should successfully get mint fee token", async () => {
+      const mintFeeToken = await client.nftClient.getMintFeeToken(spgNftContract);
+      expect(mintFeeToken).to.equal(erc20Address[aeneid]);
+    });
 
-  it("should successfully get mint fee", async () => {
-    const mintFee = await client.nftClient.getMintFee(spgNftContract);
-    expect(mintFee).to.be.a("bigint");
+    it("should successfully get mint fee", async () => {
+      const mintFee = await client.nftClient.getMintFee(spgNftContract);
+      expect(mintFee).to.equal(10000000n);
+    });
   });
 });

--- a/packages/core-sdk/test/integration/nftClient.test.ts
+++ b/packages/core-sdk/test/integration/nftClient.test.ts
@@ -9,6 +9,7 @@ chai.use(chaiAsPromised);
 describe("nftClient Functions", () => {
   let client: StoryClient;
   let testWalletAddress: Address;
+  let spgNftContract: Address;
 
   before(async () => {
     client = getStoryClient();
@@ -31,6 +32,7 @@ describe("nftClient Functions", () => {
       });
       expect(txData.spgNftContract).to.be.a("string").and.not.empty;
       expect(txData.txHash).to.be.a("string").and.not.empty;
+      spgNftContract = txData.spgNftContract!;
     });
 
     it("should successfully create collection with custom mint fee", async () => {
@@ -137,5 +139,15 @@ describe("nftClient Functions", () => {
         }),
       ).to.be.rejectedWith("Invalid mint fee token address");
     });
+  });
+
+  it("should successfully get mint fee token", async () => {
+    const mintFeeToken = await client.nftClient.getMintFeeToken(spgNftContract);
+    expect(mintFeeToken).to.be.a("string").and.not.empty;
+  });
+
+  it("should successfully get mint fee", async () => {
+    const mintFee = await client.nftClient.getMintFee(spgNftContract);
+    expect(mintFee).to.be.a("bigint");
   });
 });

--- a/packages/core-sdk/test/integration/royalty.test.ts
+++ b/packages/core-sdk/test/integration/royalty.test.ts
@@ -240,7 +240,6 @@ describe("Royalty Functions", () => {
 
       const retA = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
         spgNftContract,
-        allowDuplicates: true,
         licenseTermsData: [
           {
             terms: {
@@ -281,7 +280,6 @@ describe("Royalty Functions", () => {
 
       const retB = await client.ipAsset.mintAndRegisterIpAndMakeDerivative({
         spgNftContract,
-        allowDuplicates: true,
         derivData: {
           parentIpIds: [ipA!],
           licenseTermsIds: [licenseTermsId!],
@@ -295,7 +293,6 @@ describe("Royalty Functions", () => {
 
       const retC = await client.ipAsset.mintAndRegisterIpAndMakeDerivative({
         spgNftContract,
-        allowDuplicates: true,
         derivData: {
           parentIpIds: [ipB!],
           licenseTermsIds: [licenseTermsId!],
@@ -309,7 +306,6 @@ describe("Royalty Functions", () => {
 
       const retD = await client.ipAsset.mintAndRegisterIpAndMakeDerivative({
         spgNftContract,
-        allowDuplicates: true,
         derivData: {
           parentIpIds: [ipC!],
           licenseTermsIds: [licenseTermsId!],

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -1,3 +1,4 @@
 export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e86ee629cfb";
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const aeneid = 13_15;
+export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -2,4 +2,3 @@ export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e8
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const aeneid = 13_15;
 export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
-export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e86ee629cfb";

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -2,3 +2,4 @@ export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e8
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const aeneid = 13_15;
 export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
+export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e86ee629cfb";

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -2,3 +2,4 @@ export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e8
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const aeneid = 13_15;
 export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
+export const walletAddress = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -1,10 +1,11 @@
 import chai from "chai";
 import { createMock } from "../testUtils";
 import * as sinon from "sinon";
-import { PublicClient, WalletClient, Account, zeroAddress } from "viem";
+import { PublicClient, WalletClient, Account, zeroAddress, toHex, zeroHash, zeroHash } from "viem";
 import chaiAsPromised from "chai-as-promised";
 import { GroupClient } from "../../../src";
 import { LicenseData } from "../../../src/types/resources/group";
+import { walletAddress } from "../mockData";
 const { IpAccountImplClient } = require("../../../src/abi/generated");
 
 chai.use(chaiAsPromised);
@@ -375,6 +376,34 @@ describe("Test IpAssetClient", () => {
         },
       });
       expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+    });
+
+    it("should call with default values when mintAndRegisterIpAndAttachLicenseAndAddToGroup without providing allowDuplicates, ipMetadata, recipient", async () => {
+      sinon.stub(groupClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      const mintAndRegisterIpAndAttachLicenseAndAddToGroupStub = sinon
+        .stub(groupClient.groupingWorkflowsClient, "mintAndRegisterIpAndAttachLicenseAndAddToGroup")
+        .resolves(txHash);
+      await groupClient.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
+        groupId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        maxAllowedRewardShare: 5,
+        spgNftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        licenseData: [mockLicenseData],
+      });
+
+      expect(
+        mintAndRegisterIpAndAttachLicenseAndAddToGroupStub.args[0][0].allowDuplicates,
+      ).to.equal(true);
+      expect(
+        mintAndRegisterIpAndAttachLicenseAndAddToGroupStub.args[0][0].ipMetadata,
+      ).to.deep.equal({
+        ipMetadataURI: "",
+        ipMetadataHash: zeroHash,
+        nftMetadataURI: "",
+        nftMetadataHash: zeroHash,
+      });
+      expect(mintAndRegisterIpAndAttachLicenseAndAddToGroupStub.args[0][0].recipient).to.equal(
+        walletAddress,
+      );
     });
   });
 

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -661,7 +661,7 @@ describe("Test IpAssetClient", () => {
       sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      // Because registerDerivative doesn't call trigger parseTxIpRegisteredEvent, but the `handleRegistrationTransaction`
+      // Because registerDerivative doesn't call trigger IPRegistered event, but the `handleRegistrationWithFees`
       // will call it, so we need to mock the result of parseTxIpRegisteredEvent to avoid the error.
       sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([]);
 

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -661,6 +661,9 @@ describe("Test IpAssetClient", () => {
       sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
+      // Because registerDerivative doesn't call trigger parseTxIpRegisteredEvent, but the `handleRegistrationTransaction`
+      // will call it, so we need to mock the result of parseTxIpRegisteredEvent to avoid the error.
+      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([]);
 
       const res = await ipAssetClient.registerDerivative({
         childIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -17,6 +17,7 @@ import { LicenseRegistryReadOnlyClient } from "../../../src/abi/generated";
 import { MAX_ROYALTY_TOKEN, royaltySharesTotalSupply } from "../../../src/constants/common";
 import { LicensingConfig } from "../../../src/types/common";
 import { DerivativeData } from "../../../src/types/resources/ipAsset";
+import { txHash, walletAddress } from "../mockData";
 const {
   RoyaltyModuleReadOnlyClient,
   IpRoyaltyVaultImplReadOnlyClient,
@@ -24,7 +25,6 @@ const {
   SpgnftImplReadOnlyClient,
   LicensingModuleClient,
 } = require("../../../src/abi/generated");
-const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 const licenseTerms: LicenseTerms = {
@@ -1055,7 +1055,6 @@ describe("Test IpAssetClient", () => {
             licensingConfig,
           },
         ],
-        allowDuplicates: false,
         recipient: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
         ipMetadata: {
           ipMetadataURI: "",
@@ -1067,6 +1066,29 @@ describe("Test IpAssetClient", () => {
       });
 
       expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+    });
+
+    it("should call with default values when createIpAssetWithPilTerms without providing allowDuplicates, ipMetadata, recipient", async () => {
+      const mintAndRegisterIpAndAttachPilTermsStub = sinon
+        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "mintAndRegisterIpAndAttachPilTerms")
+        .resolves(txHash);
+      await ipAssetClient.mintAndRegisterIpAssetWithPilTerms({
+        spgNftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        licenseTermsData: [
+          {
+            terms: licenseTerms,
+            licensingConfig,
+          },
+        ],
+      });
+      expect(mintAndRegisterIpAndAttachPilTermsStub.args[0][0].allowDuplicates).to.equal(true);
+      expect(mintAndRegisterIpAndAttachPilTermsStub.args[0][0].ipMetadata).to.deep.equal({
+        ipMetadataURI: "",
+        ipMetadataHash: zeroHash,
+        nftMetadataURI: "",
+        nftMetadataHash: zeroHash,
+      });
+      expect(mintAndRegisterIpAndAttachPilTermsStub.args[0][0].recipient).to.equal(walletAddress);
     });
   });
 
@@ -1520,7 +1542,6 @@ describe("Test IpAssetClient", () => {
       const res = await ipAssetClient.mintAndRegisterIpAndMakeDerivative({
         spgNftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         derivData,
-        allowDuplicates: false,
         ipMetadata: {
           ipMetadataURI: "https://",
           nftMetadataHash: toHex("nftMetadata", { size: 32 }),
@@ -1531,6 +1552,53 @@ describe("Test IpAssetClient", () => {
       });
 
       expect(res.encodedTxData!.data).to.be.a("string").and.not.empty;
+    });
+
+    it("should call with default values when mintAndRegisterIpAndMakeDerivative without providing allowDuplicates, ipMetadata", async () => {
+      sinon
+        .stub(ipAssetClient.ipAssetRegistryClient, "ipId")
+        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
+      sinon
+        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+        .onFirstCall()
+        .resolves(true)
+        .onSecondCall()
+        .resolves(false);
+      sinon
+        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
+        .resolves(true);
+      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+        royaltyPercent: 100,
+      });
+      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+        {
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          chainId: 0n,
+          tokenContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          tokenId: 1n,
+          name: "",
+          uri: "",
+          registrationDate: 0n,
+        },
+      ]);
+
+      const mintAndRegisterIpAndMakeDerivativeStub = sinon
+        .stub(ipAssetClient.derivativeWorkflowsClient, "mintAndRegisterIpAndMakeDerivative")
+        .resolves(txHash);
+
+      await ipAssetClient.mintAndRegisterIpAndMakeDerivative({
+        spgNftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        derivData,
+      });
+
+      expect(mintAndRegisterIpAndMakeDerivativeStub.args[0][0].allowDuplicates).to.equal(true);
+      expect(mintAndRegisterIpAndMakeDerivativeStub.args[0][0].ipMetadata).to.deep.equal({
+        ipMetadataURI: "",
+        ipMetadataHash: zeroHash,
+        nftMetadataURI: "",
+        nftMetadataHash: zeroHash,
+      });
+      expect(mintAndRegisterIpAndMakeDerivativeStub.args[0][0].recipient).to.equal(walletAddress);
     });
   });
   describe("Test ipAssetClient.mintAndRegisterIp", async () => {
@@ -1630,6 +1698,25 @@ describe("Test IpAssetClient", () => {
       });
 
       expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+    });
+
+    it("should call with default values when mintAndRegisterIp without providing allowDuplicates, ipMetadata, recipient", async () => {
+      const mintAndRegisterIpStub = sinon
+        .stub(ipAssetClient.registrationWorkflowsClient, "mintAndRegisterIp")
+        .resolves(txHash);
+
+      await ipAssetClient.mintAndRegisterIp({
+        spgNftContract,
+      });
+
+      expect(mintAndRegisterIpStub.args[0][0].allowDuplicates).to.equal(true);
+      expect(mintAndRegisterIpStub.args[0][0].ipMetadata).to.deep.equal({
+        ipMetadataURI: "",
+        ipMetadataHash: zeroHash,
+        nftMetadataURI: "",
+        nftMetadataHash: zeroHash,
+      });
+      expect(mintAndRegisterIpStub.args[0][0].recipient).to.equal(walletAddress);
     });
   });
 
@@ -1896,6 +1983,42 @@ describe("Test IpAssetClient", () => {
       });
 
       expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+    });
+
+    it("should call with default values when mintAndRegisterIpAndMakeDerivativeWithLicenseTokens without providing allowDuplicates, ipMetadata, royaltyContext, recipient", async () => {
+      sinon
+        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
+        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
+      const mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub = sinon
+        .stub(
+          ipAssetClient.derivativeWorkflowsClient,
+          "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
+        )
+        .resolves(txHash);
+
+      await ipAssetClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
+        spgNftContract,
+        licenseTokenIds: ["0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"],
+        maxRts: 0,
+      });
+
+      expect(
+        mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub.args[0][0].allowDuplicates,
+      ).to.equal(true);
+      expect(
+        mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub.args[0][0].ipMetadata,
+      ).to.deep.equal({
+        ipMetadataURI: "",
+        ipMetadataHash: zeroHash,
+        nftMetadataURI: "",
+        nftMetadataHash: zeroHash,
+      });
+      expect(
+        mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub.args[0][0].royaltyContext,
+      ).to.equal(zeroAddress);
+      expect(mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub.args[0][0].recipient).to.equal(
+        walletAddress,
+      );
     });
   });
 
@@ -3118,8 +3241,7 @@ describe("Test IpAssetClient", () => {
           tokenId: "1",
         });
       expect(result).to.deep.equal({
-        registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokensTxHash:
-          "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
+        registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokensTxHash: txHash,
         distributeRoyaltyTokensTxHash: txHash,
         ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -3199,8 +3321,7 @@ describe("Test IpAssetClient", () => {
           },
         });
       expect(result).to.deep.equal({
-        registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokensTxHash:
-          "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
+        registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokensTxHash: txHash,
         distributeRoyaltyTokensTxHash: txHash,
         ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -3342,6 +3463,43 @@ describe("Test IpAssetClient", () => {
         licenseTermsIds: [5n],
         ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       });
+    });
+
+    it("should call with default values when mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens without providing allowDuplicates, ipMetadata, recipient", async () => {
+      const mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub = sinon
+        .stub(
+          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+          "mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens",
+        )
+        .resolves(txHash);
+
+      await ipAssetClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens({
+        spgNftContract,
+        licenseTermsData: [
+          {
+            terms: licenseTerms,
+            licensingConfig,
+          },
+        ],
+        royaltyShares: [
+          { recipient: "0x73fcb515cee99e4991465ef586cfe2b072ebb512", percentage: 100 },
+        ],
+      });
+
+      expect(
+        mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub.args[0][0].allowDuplicates,
+      ).to.equal(true);
+      expect(
+        mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub.args[0][0].ipMetadata,
+      ).to.deep.equal({
+        ipMetadataURI: "",
+        ipMetadataHash: zeroHash,
+        nftMetadataHash: zeroHash,
+        nftMetadataURI: "",
+      });
+      expect(
+        mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub.args[0][0].recipient,
+      ).to.equal(walletAddress);
     });
   });
 
@@ -3566,6 +3724,54 @@ describe("Test IpAssetClient", () => {
         ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         tokenId: 0n,
       });
+    });
+
+    it("should call with default values when mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens without providing allowDuplicates, ipMetadata, recipient", async () => {
+      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+        royaltyPercent: 100,
+      });
+      sinon
+        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
+        .resolves(true);
+      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      sinon.stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
+        terms: licenseTerms,
+      });
+      const mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub = sinon
+        .stub(
+          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+          "mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens",
+        )
+        .resolves(txHash);
+
+      await ipAssetClient.mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens({
+        spgNftContract,
+        derivData: {
+          parentIpIds: ["0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"],
+          licenseTermsIds: [1n],
+          maxMintingFee: 100,
+          maxRts: 100,
+          maxRevenueShare: 100,
+        },
+        royaltyShares: [
+          { recipient: "0x73fcb515cee99e4991465ef586cfe2b072ebb512", percentage: 100 },
+        ],
+      });
+
+      expect(
+        mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub.args[0][0].allowDuplicates,
+      ).to.equal(true);
+      expect(
+        mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub.args[0][0].ipMetadata,
+      ).to.deep.equal({
+        ipMetadataURI: "",
+        ipMetadataHash: zeroHash,
+        nftMetadataHash: zeroHash,
+        nftMetadataURI: "",
+      });
+      expect(
+        mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub.args[0][0].recipient,
+      ).to.equal(walletAddress);
     });
   });
 });

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -3428,7 +3428,7 @@ describe("Test IpAssetClient", () => {
         });
       } catch (err) {
         expect((err as Error).message).equal(
-          "Failed to mint and register IP and make derivative and distribute royalty tokens: CommercialRevShare should be between 0 and 100.",
+          "Failed to mint and register IP and make derivative and distribute royalty tokens: MaxRevenueShare must be between 0 and 100.",
         );
       }
     });
@@ -3456,7 +3456,7 @@ describe("Test IpAssetClient", () => {
         });
       } catch (err) {
         expect((err as Error).message).equal(
-          "Failed to mint and register IP and make derivative and distribute royalty tokens: CommercialRevShare should be between 0 and 100.",
+          "Failed to mint and register IP and make derivative and distribute royalty tokens: MaxRevenueShare must be between 0 and 100.",
         );
       }
     });

--- a/packages/core-sdk/test/unit/resources/nftClient.test.ts
+++ b/packages/core-sdk/test/unit/resources/nftClient.test.ts
@@ -5,6 +5,8 @@ import { PublicClient, WalletClient } from "viem";
 
 import { NftClient } from "../../../src";
 import { createMock } from "../testUtils";
+import { mockERC20 } from "../mockData";
+import { SpgnftImplReadOnlyClient } from "../../../src/abi/generated";
 
 chai.use(chaiAsPromised);
 
@@ -126,6 +128,22 @@ describe("Test NftClient", () => {
       });
 
       expect(result.encodedTxData?.data).to.be.a("string").and.not.empty;
+    });
+  });
+
+  describe("test for getMintFeeToken", () => {
+    it("should successfully get mint fee token", async () => {
+      sinon.stub(SpgnftImplReadOnlyClient.prototype, "mintFeeToken").resolves(mockERC20);
+      const mintFeeToken = await nftClient.getMintFeeToken(mockERC20);
+      expect(mintFeeToken).equal(mockERC20);
+    });
+  });
+
+  describe("test for getMintFee", () => {
+    it("should successfully get mint fee", async () => {
+      sinon.stub(SpgnftImplReadOnlyClient.prototype, "mintFee").resolves(1n);
+      const mintFee = await nftClient.getMintFee(mockERC20);
+      expect(mintFee).equal(1n);
     });
   });
 });

--- a/packages/core-sdk/test/unit/testUtils.ts
+++ b/packages/core-sdk/test/unit/testUtils.ts
@@ -2,11 +2,12 @@ import { randomBytes } from "crypto";
 import sinon from "sinon";
 import { Address, Hex, keccak256 } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { walletAddress } from "./mockData";
 
 export function createMock<T>(obj = {}): T {
   const mockObj: any = obj;
   mockObj.waitForTransactionReceipt = sinon.stub().resolves({});
-  mockObj.address = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
+  mockObj.address = walletAddress;
   mockObj.multicall = sinon.stub().returns([{ error: "", status: "success" }]);
   mockObj.getBlock = sinon.stub().resolves({ timestamp: 1629820800n });
   return mockObj;

--- a/packages/core-sdk/test/unit/utils/feeUtils.test.ts
+++ b/packages/core-sdk/test/unit/utils/feeUtils.test.ts
@@ -6,8 +6,8 @@ import {
   royaltyModuleAddress,
   derivativeWorkflowsAddress,
   wrappedIpAddress,
-  multicall3Address,
   erc20Address,
+  multicall3Address,
 } from "../../../src/abi/generated";
 import { createMock, generateRandomAddress, generateRandomHash } from "../testUtils";
 import { aeneid, txHash } from "../mockData";
@@ -15,7 +15,11 @@ import { contractCallWithFees } from "../../../src/utils/feeUtils";
 import { TEST_WALLET_ADDRESS } from "../../integration/utils/util";
 import { WIP_TOKEN_ADDRESS } from "../../../src/constants/common";
 import { ContractCallWithFees } from "../../../src/types/utils/wip";
+import { TEST_WALLET_ADDRESS } from "../../integration/utils/util";
+import { WIP_TOKEN_ADDRESS } from "../../../src/constants/common";
 import { ERC20Client, WIPTokenClient } from "../../../src/utils/token";
+import { aeneid, txHash } from "../mockData";
+import { contractCallWithFees } from "../../../src/utils/feeUtils";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;

--- a/packages/core-sdk/test/unit/utils/feeUtils.test.ts
+++ b/packages/core-sdk/test/unit/utils/feeUtils.test.ts
@@ -6,8 +6,8 @@ import {
   royaltyModuleAddress,
   derivativeWorkflowsAddress,
   wrappedIpAddress,
-  erc20Address,
   multicall3Address,
+  erc20Address,
 } from "../../../src/abi/generated";
 import { createMock, generateRandomAddress, generateRandomHash } from "../testUtils";
 import { aeneid, txHash } from "../mockData";
@@ -20,6 +20,10 @@ import { WIP_TOKEN_ADDRESS } from "../../../src/constants/common";
 import { ERC20Client, WIPTokenClient } from "../../../src/utils/token";
 import { aeneid, txHash } from "../mockData";
 import { contractCallWithFees } from "../../../src/utils/feeUtils";
+import { TEST_WALLET_ADDRESS } from "../../integration/utils/util";
+import { WIP_TOKEN_ADDRESS } from "../../../src/constants/common";
+import { ContractCallWithFees } from "../../../src/types/utils/wip";
+import { ERC20Client, WIPTokenClient } from "../../../src/utils/token";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;

--- a/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
+++ b/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
@@ -50,7 +50,7 @@ describe("License Terms Helper", () => {
         expiration: 0n,
         defaultMintingFee: 0n,
         royaltyPolicy: "0x0000000000000000000000000000000000000000",
-        uri: "",
+        uri: "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/NCSR.json",
       });
     });
 
@@ -102,7 +102,7 @@ describe("License Terms Helper", () => {
           defaultMintingFee: 1n,
           royaltyPolicy: "0x0000000000000000000000000000000000000000",
           transferable: true,
-          uri: "",
+          uri: "https://github.com/piplabs/pil-document/blob/9a1f803fcf8101a8a78f1dcc929e6014e144ab56/off-chain-terms/CommercialUse.json",
         });
       });
     });
@@ -174,7 +174,7 @@ describe("License Terms Helper", () => {
           defaultMintingFee: 1n,
           royaltyPolicy: "0x0000000000000000000000000000000000000000",
           transferable: true,
-          uri: "",
+          uri: "https://github.com/piplabs/pil-document/blob/ad67bb632a310d2557f8abcccd428e4c9c798db1/off-chain-terms/CommercialRemix.json",
         });
       });
       it("it throw commercialRevShare error when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is less than 0 ", async () => {

--- a/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
+++ b/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
@@ -185,7 +185,7 @@ describe("License Terms Helper", () => {
             currency: zeroAddress,
             commercialRevShare: -8,
           }),
-        ).to.throw(`CommercialRevShare should be between 0 and 100.`);
+        ).to.throw(`CommercialRevShare must be between 0 and 100.`);
       });
 
       it("it throw commercialRevShare error  when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is greater than 100", async () => {
@@ -196,7 +196,7 @@ describe("License Terms Helper", () => {
             currency: zeroAddress,
             commercialRevShare: 105,
           }),
-        ).to.throw(`CommercialRevShare should be between 0 and 100.`);
+        ).to.throw(`CommercialRevShare must be between 0 and 100.`);
       });
 
       it("it get commercialRevShare correct value when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is 10", async () => {
@@ -502,13 +502,11 @@ describe("License Terms Helper", () => {
     });
 
     it("should throw error when call getRevenueShare given revShare is less than 0", async () => {
-      expect(() => getRevenueShare(-1)).to.throw("CommercialRevShare should be between 0 and 100.");
+      expect(() => getRevenueShare(-1)).to.throw("CommercialRevShare must be between 0 and 100.");
     });
 
     it("should throw error when call getRevenueShare given revShare is greater than 100", async () => {
-      expect(() => getRevenueShare(101)).to.throw(
-        "CommercialRevShare should be between 0 and 100.",
-      );
+      expect(() => getRevenueShare(101)).to.throw("CommercialRevShare must be between 0 and 100.");
     });
 
     it("should return correct value when call getRevenueShare given revShare is 10", async () => {

--- a/packages/wagmi-generator/wagmi.config.ts
+++ b/packages/wagmi-generator/wagmi.config.ts
@@ -291,7 +291,7 @@ export default defineConfig(async () => {
           ],
           RoyaltyPolicyLAP: ["onRoyaltyPayment", "getRoyaltyData"],
           LicenseToken: ["ownerOf"],
-          SPG: ["CollectionCreated"],
+          SPG: ["CollectionCreated", "mintFee", "mintFeeToken"],
           GroupingWorkflows: [
             "mintAndRegisterIpAndAttachLicenseAndAddToGroup",
             "registerIpAndAttachLicenseAndAddToGroup",


### PR DESCRIPTION
## Description
### 1. Add Auto Wrapping Support to the following ipAsset functions
  - `mintAndRegisterIp`: Pay nft minting fee
  - `registerDerivative`
### 2. Add following methods to `nftClient`. This is to allow dev to easily to get the mint fee of a SPG collection.
 - `mintFeeToken`: Gets the mint fee token of an spg nft contract
 - 3. `mintFee`: Gets the mint fee of an spg nft contract
### Throw error more specify when call getRevenueShare method

 ### 4. Add `uri` value for each PIL Flavor by default
### 5. Make allowDuplicates optional
### 6. Bind link with v1.3.1