### PR TITLE
Update to IPA Metadata Standard

### DIFF
--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -28,16 +28,6 @@ export type {
   RegisterIpAndAttachPilTermsResponse,
   MintAndRegisterIpAndMakeDerivativeRequest,
   MintAndRegisterIpAndMakeDerivativeResponse,
-  GenerateCreatorMetadataParam,
-  IpCreator,
-  GenerateIpMetadataParam,
-  IpMetadata,
-  IpRelationship,
-  IpAttribute,
-  IpCreatorSocial,
-  IpMedia,
-  IPRobotTerms,
-  StoryProtocolApp,
   MintAndRegisterIpRequest,
   RegisterPilTermsAndAttachRequest,
   RegisterPilTermsAndAttachResponse,
@@ -61,6 +51,8 @@ export type {
   MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensRequest,
   MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensResponse,
 } from "./types/resources/ipAsset";
+
+export * from "./types/resources/ipMetadata";
 
 export type {
   RegisterNonComSocialRemixingPILRequest,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -23,10 +23,6 @@ import {
   BatchRegisterResponse,
   MintAndRegisterIpAssetWithPilTermsRequest,
   MintAndRegisterIpAssetWithPilTermsResponse,
-  GenerateCreatorMetadataParam,
-  GenerateIpMetadataParam,
-  IpCreator,
-  IpMetadata,
   MintAndRegisterIpAndMakeDerivativeRequest,
   MintAndRegisterIpAndMakeDerivativeWithLicenseTokensRequest,
   MintAndRegisterIpRequest,
@@ -115,6 +111,7 @@ import {
 } from "../utils/feeUtils";
 import { Erc20Spender } from "../types/utils/wip";
 import { ChainIds } from "../types/config";
+import { IpCreator, IpMetadata } from "../types/resources/ipMetadata";
 
 export class IPAssetClient {
   public licensingModuleClient: LicensingModuleClient;
@@ -163,111 +160,12 @@ export class IPAssetClient {
     this.walletAddress = this.wallet.account!.address;
   }
 
-  /**
-   * Create a new `IpCreator` object with the specified details.
-   * @param params - The parameters required to create the `IpCreator` object.
-   *   @param params.name The name of the creator.
-   *   @param params.address The wallet address of the creator.
-   *   @param params.description [Optional] A description of the creator.
-   *   @param params.image [Optional] The URL or path to an image representing the creator.
-   *   @param {Array} params.socialMedia [Optional] An array of social media profiles associated with the creator.
-   *     @param params.socialMedia[].platform The name of the social media platform.
-   *     @param params.socialMedia[].url The URL to the creator's profile on the platform.
-   *  @param params.contributionPercent The percentage of contribution by the creator, must add up to 100.
-   *  @param params.role [Optional] The role of the creator in relation to the IP.
-   * @returns An `IpCreator` object containing the provided details.
-   */
-  public generateCreatorMetadata(param: GenerateCreatorMetadataParam): IpCreator {
-    const {
-      name,
-      address,
-      description = "",
-      image = "",
-      socialMedia = [],
-      contributionPercent,
-      role = "",
-    } = param;
-    return {
-      name,
-      address,
-      description,
-      image,
-      socialMedia,
-      contributionPercent,
-      role,
-    };
+  public generateCreatorsMetadata(creator: IpCreator): IpCreator {
+    return creator;
   }
 
-  /**
-   * Create a new `IpMetadata` object with the specified details.
-   * @param params - The parameters required to create the `IpMetadata` object.
-   *   @param params.title [Optional] The title of the IP.
-   *   @param params.description [Optional] A description of the IP.
-   *   @param params.ipType [Optional] The type of the IP asset (e.g., "character", "chapter").
-   *   @param {Array} params.relationships [Optional] An array of relationships between this IP and its parent IPs.
-   *     @param params.relationships[].ipId The ID of the parent IP.
-   *     @param params.relationships[].type The type of relationship (e.g., "APPEARS_IN").
-   *   @param params.createdAt [Optional] The creation date and time of the IP in ISO 8601 format.
-   *   @param params.watermarkImg [Optional] The URL or path to an image used as a watermark for the IP.
-   *   @param {Array} params.creators [Optional] An array of creators associated with the IP.
-   *     @param params.creators[].name The name of the creator.
-   *     @param params.creators[].address The address of the creator.
-   *     @param params.creators[].description [Optional] A description of the creator.
-   *     @param params.creators[].image [Optional] The URL or path to an image representing the creator.
-   *     @param params.creators[].socialMedia [Optional] An array of social media profiles for the creator.
-   *     @param params.creators[].socialMedia[].platform The social media platform name.
-   *     @param params.creators[].socialMedia[].url The URL to the creator's profile.
-   *     @param params.creators[].role [Optional] The role of the creator in relation to the IP.
-   *     @param params.creators[].contributionPercent The percentage of contribution by the creator.
-   *   @param {Array} params.media [Optional] An array of media related to the IP.
-   *     @param params.media[].name The name of the media.
-   *     @param params.media[].url The URL to the media.
-   *     @param params.media[].mimeType The MIME type of the media.
-   *   @param {Array} params.attributes [Optional] An array of key-value pairs providing additional metadata.
-   *     @param params.attributes[].key The key for the attribute.
-   *     @param params.attributes[].value The value for the attribute, can be a string or number.
-   *   @param {Object} params.app [Optional] Information about the application associated with the IP.
-   *     @param params.app.id The ID of the application.
-   *     @param params.app.name The name of the application.
-   *     @param params.app.website The website URL of the application.
-   *   @param {Array} params.tags [Optional] An array of tags associated with the IP.
-   *   @param {Object} params.robotTerms [Optional] Robot terms for the IP, specifying access rules.
-   *     @param params.robotTerms.userAgent The user agent for which the rules apply.
-   *     @param params.robotTerms.allow The rules allowing access.
-   *   @param params.additionalProperties [Optional] Any additional key-value pairs to include in the metadata.
-   * @returns An `IpMetadata` object containing the provided details and any additional properties.
-   */
-  public generateIpMetadata(param: GenerateIpMetadataParam): IpMetadata {
-    const {
-      title = "",
-      description = "",
-      ipType = "",
-      relationships = [],
-      createdAt = "",
-      watermarkImg = "",
-      creators = [],
-      media = [],
-      attributes = [],
-      app,
-      tags = [],
-      robotTerms,
-      ...additionalProperties
-    } = param;
-    return {
-      title,
-      description,
-      ipType,
-      relationships,
-      createdAt,
-      watermarkImg,
-      creators,
-      media,
-      attributes,
-      app,
-      tags,
-      robotTerms,
-      ...additionalProperties,
-    };
+  public generateIpMetadata(metadata: IpMetadata): IpMetadata {
+    return metadata;
   }
 
   /**

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -160,7 +160,7 @@ export class IPAssetClient {
     this.walletAddress = this.wallet.account!.address;
   }
 
-  public generateCreatorsMetadata(creator: IpCreator): IpCreator {
+  public generateCreatorMetadata(creator: IpCreator): IpCreator {
     return creator;
   }
 

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -162,58 +162,6 @@ export type MintAndRegisterIpAndMakeDerivativeResponse = RegistrationResponse & 
   encodedTxData?: EncodedTxData;
 };
 
-export type IpRelationship = {
-  parentIpId: Address;
-  type: string;
-};
-
-export type IpCreator = {
-  name: string;
-  address: Address;
-  description?: string;
-  image?: string;
-  socialMedia?: IpCreatorSocial[];
-  role?: string;
-  contributionPercent: number; // add up to 100
-};
-
-export type IpCreatorSocial = {
-  platform: string;
-  url: string;
-};
-
-export type IpMedia = {
-  name: string;
-  url: string;
-  mimeType: string;
-};
-
-export type IpAttribute = {
-  key: string;
-  value: string | number;
-};
-
-export type StoryProtocolApp = {
-  id: string;
-  name: string;
-  website: string;
-  action?: string;
-};
-
-export type GenerateCreatorMetadataParam = {
-  name: string;
-  address: Address;
-  contributionPercent: number;
-  description?: string;
-  image?: string;
-  socialMedia?: IpCreatorSocial[];
-  role?: string;
-};
-export type IPRobotTerms = {
-  userAgent: string;
-  allow: string;
-};
-
 type IPMetadataInfo = {
   ipMetadata?: {
     ipMetadataURI?: string;
@@ -221,37 +169,6 @@ type IPMetadataInfo = {
     nftMetadataURI?: string;
     nftMetadataHash?: Hex;
   };
-};
-
-export type GenerateIpMetadataParam = {
-  title?: string;
-  description?: string;
-  ipType?: string;
-  relationships?: IpRelationship[];
-  createdAt?: string;
-  watermarkImg?: string;
-  creators?: IpCreator[];
-  media?: IpMedia[];
-  attributes?: IpAttribute[];
-  app?: StoryProtocolApp;
-  tags?: string[];
-  robotTerms?: IPRobotTerms;
-  additionalProperties?: { [key: string]: unknown };
-};
-export type IpMetadata = {
-  title?: string;
-  description?: string;
-  ipType?: string;
-  relationships?: IpRelationship[];
-  createdAt?: string;
-  watermarkImg?: string;
-  creators?: IpCreator[];
-  media?: IpMedia[];
-  attributes?: IpAttribute[];
-  appInfo?: StoryProtocolApp[];
-  tags?: string[];
-  robotTerms?: IPRobotTerms;
-  [key: string]: unknown;
 };
 
 export type MintAndRegisterIpRequest = IpMetadataAndTxOptions &

--- a/packages/core-sdk/src/types/resources/ipMetadata.ts
+++ b/packages/core-sdk/src/types/resources/ipMetadata.ts
@@ -1,0 +1,285 @@
+import { Address, Hash } from "viem";
+
+export type AIMetadata = {
+  /**
+   * Url to the character file.
+   *
+   * @example https://github.com/elizaOS/characterfile/blob/main/examples/example.character.json
+   */
+  characterFileUrl: string;
+  /**
+   * Hash of the character file using SHA-256 hashing algorithm.
+   */
+  characterFileHash: Hash;
+};
+
+/**
+ * IPA Metadata Standard Parameters
+ *
+ * This is the metadata that is associated with an IP Asset,
+ * and gets stored inside of an IP Account.
+ *
+ * @see {@link https://docs.story.foundation/docs/ipa-metadata-standard|IPA Metadata Standard Docs}
+ */
+export type IpMetadata = {
+  /** Title of the IP. Required for Story Explorer. */
+  title?: string;
+  /** Description of the IP. Required for Story Explorer. */
+  description?: string;
+  /**
+   * Date/Time that the IP was created (either ISO8601 or unix format).
+   *
+   * This field can be used to specify historical dates that aren’t on-chain.
+   * For example, Harry Potter was published on June 26.
+   *
+   * Required for Story Explorer.
+   *
+   * @example "1728401700"
+   */
+  createdAt?: string;
+  /** An image for the IP. Required for Story Explorer. */
+  image?: string;
+  /**
+   * Hash of your `image` using SHA-256 hashing algorithm.
+   * See {@link https://docs.story.foundation/docs/ipa-metadata-standard#hashing-content|here} for how that is done.
+   *
+   * Required for Story Explorer.
+   */
+  imageHash?: Hash;
+  /**
+   * An array of information about the creators.
+   *
+   * Required for Story Explorer.
+   */
+  creators?: IpCreator[];
+  /**
+   * Url to the actual media file (ex video, audio, image, etc).
+   * Used for infringement checking.
+   *
+   * Required for Commercial Infringement Check
+   *
+   * @example https://ipfs.io/ipfs/QmSamy4zqP91X42k6wS7kLJQVzuYJuW2EN94couPaq82A8
+   */
+  mediaUrl?: string;
+  /**
+   * Hashed string of the media using SHA-256 hashing algorithm.
+   *
+   * Required for Commercial Infringement Check
+   *
+   * @example 0x21937ba9d821cb0306c7f1a1a2cc5a257509f228ea6abccc9af1a67dd754af6e
+   */
+  mediaHash?: Hash;
+  /**
+   * Type of media (audio, video, image), based on mimeType.
+   *
+   * See {@link https://docs.story.foundation/docs/ipa-metadata-standard#media-types|here}
+   * for all the allowed media types.
+   *
+   * Required for Commercial Infringement Check
+   */
+  mediaType?: string;
+  /**
+   * Used for registering & displaying AI Agent Metadata.
+   *
+   * Required for AI Agents
+   */
+  aiMetadata?: AIMetadata;
+
+  /**
+   * Any other fields can be included in the metadata.
+   */
+  [key: string]: unknown;
+} & IpMetadataExperimentalAttributes;
+
+/**
+ * Experimental ip metadata fields that are not required but may be
+ * considered for future use.
+ */
+export type IpMetadataExperimentalAttributes = {
+  /**
+   * **Experimental**: Type of the IP Asset, can be defined arbitrarily by the
+   * creator. I.e. “character”, “chapter”, “location”, “items”, "music", etc
+   */
+  ipType?: string;
+  /**
+   * **Experimental**: The detailed relationship info with the IPA’s direct parent asset,
+   * such as APPEARS_IN, FINETUNED_FROM, etc
+   */
+  relationships?: IpRelationship[];
+  /**
+   * **Experimental**: A separate image with your watermark already applied.
+   * This way apps choosing to use it can render this version of the image (with watermark applied).
+   */
+  watermarkImg?: string;
+  /**
+   * **Experimental**: An array of supporting media
+   */
+  media?: IpMedia[];
+  /**
+   * **Experimental**: This is assigned to verified application from
+   * Story Protocol directly (on a request basis so far).
+   */
+  app?: StoryProtocolApp;
+  /**
+   * **Experimental**: Any tags that can help surface this IPA
+   */
+  tags?: string[];
+  /**
+   * **Experimental**: Allows you to set Do Not Train for a specific agent
+   */
+  robotTerms?: IPRobotTerms;
+};
+
+export type IPRobotTerms = {
+  userAgent: string;
+  allow: string;
+};
+
+export type StoryProtocolApp = {
+  id: string;
+  name: string;
+  website: string;
+  action?: string;
+};
+
+export type IpMedia = {
+  name: string;
+  url: string;
+  mimeType: string;
+};
+
+export type IpRelationship = {
+  parentIpId: Address;
+  /**
+   * Type of relationship between the parent and child IP.
+   *
+   * @see {@link https://docs.story.foundation/docs/ipa-metadata-standard#relationship-types|Relationship Types} for all relationship types.
+   *
+   * @example StoryRelationship.APPEARS_IN
+   */
+  type: StoryRelationship | AIRelationship;
+};
+
+export type IpCreator = {
+  /**
+   * Name of the creator.
+   *
+   * @example "Story Foundation"
+   */
+  name: string;
+  address: Address;
+  description?: string;
+  image?: string;
+  socialMedia?: IpCreatorSocial[];
+  role?: string;
+  /**
+   * Contribution percent of the creator.
+   *
+   * Total contribution percent of all creators should add up to 100.
+   */
+  contributionPercent: number;
+};
+
+export type IpCreatorSocial = {
+  /**
+   * Social media platform.
+   *
+   * @example "Discord"
+   */
+  platform: string;
+  url: string;
+};
+
+/**
+ * Enum representing the various relationship types in a story narrative.
+ */
+export enum StoryRelationship {
+  /** A character appears in a chapter. */
+  APPEARS_IN = "APPEARS_IN",
+  /** A chapter belongs to a book. */
+  BELONGS_TO = "BELONGS_TO",
+  /** A book is part of a series. */
+  PART_OF = "PART_OF",
+  /** A chapter continues from the previous one. */
+  CONTINUES_FROM = "CONTINUES_FROM",
+  /** An event leads to a consequence. */
+  LEADS_TO = "LEADS_TO",
+  /** An event foreshadows future developments. */
+  FORESHADOWS = "FORESHADOWS",
+  /** A character conflicts with another character. */
+  CONFLICTS_WITH = "CONFLICTS_WITH",
+  /** A decision results in a significant change. */
+  RESULTS_IN = "RESULTS_IN",
+  /** A subplot depends on the main plot. */
+  DEPENDS_ON = "DEPENDS_ON",
+  /** A prologue sets up the story. */
+  SETS_UP = "SETS_UP",
+  /** A chapter follows from the previous one. */
+  FOLLOWS_FROM = "FOLLOWS_FROM",
+  /** A twist reveals that something unexpected occurred. */
+  REVEALS_THAT = "REVEALS_THAT",
+  /** A character develops over the course of the story. */
+  DEVELOPS_OVER = "DEVELOPS_OVER",
+  /** A chapter introduces a new character or element. */
+  INTRODUCES = "INTRODUCES",
+  /** A conflict resolves in a particular outcome. */
+  RESOLVES_IN = "RESOLVES_IN",
+  /** A theme connects to the main narrative. */
+  CONNECTS_TO = "CONNECTS_TO",
+  /** A subplot relates to the central theme. */
+  RELATES_TO = "RELATES_TO",
+  /** A scene transitions from one setting to another. */
+  TRANSITIONS_FROM = "TRANSITIONS_FROM",
+  /** A character interacted with another character. */
+  INTERACTED_WITH = "INTERACTED_WITH",
+  /** An event leads into the climax. */
+  LEADS_INTO = "LEADS_INTO",
+  /** Story happening in parallel or around the same timeframe. */
+  PARALLEL = "PARALLEL",
+}
+
+/**
+ * Enum representing the different relationship types for AI-related metadata.
+ */
+export enum AIRelationship {
+  /** A model is trained on a dataset. */
+  TRAINED_ON = "TRAINED_ON",
+  /** A model is finetuned from a base model. */
+  FINETUNED_FROM = "FINETUNED_FROM",
+  /** An image is generated from a fine-tuned model. */
+  GENERATED_FROM = "GENERATED_FROM",
+  /** A model requires data for training. */
+  REQUIRES_DATA = "REQUIRES_DATA",
+  /** A remix is based on a specific workflow. */
+  BASED_ON = "BASED_ON",
+  /** Sample data influences model output. */
+  INFLUENCES = "INFLUENCES",
+  /** A pipeline creates a fine-tuned model. */
+  CREATES = "CREATES",
+  /** A workflow utilizes a base model. */
+  UTILIZES = "UTILIZES",
+  /** A fine-tuned model is derived from a base model. */
+  DERIVED_FROM = "DERIVED_FROM",
+  /** A model produces generated images. */
+  PRODUCES = "PRODUCES",
+  /** A remix modifies the base workflow. */
+  MODIFIES = "MODIFIES",
+  /** An AI-generated image references original data. */
+  REFERENCES = "REFERENCES",
+  /** A model is optimized by specific algorithms. */
+  OPTIMIZED_BY = "OPTIMIZED_BY",
+  /** A fine-tuned model inherits features from the base model. */
+  INHERITS = "INHERITS",
+  /** A fine-tuning process applies to a model. */
+  APPLIES_TO = "APPLIES_TO",
+  /** A remix combines elements from multiple datasets. */
+  COMBINES = "COMBINES",
+  /** A model generates variants of an image. */
+  GENERATES_VARIANTS = "GENERATES_VARIANTS",
+  /** A fine-tuning process expands on base capabilities. */
+  EXPANDS_ON = "EXPANDS_ON",
+  /** A workflow configures a model’s parameters. */
+  CONFIGURES = "CONFIGURES",
+  /** A fine-tuned model adapts to new data. */
+  ADAPTS_TO = "ADAPTS_TO",
+}

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -152,9 +152,9 @@ describe("Test IpAssetClient", () => {
       customField2: 42,
     };
 
-    describe("generateCreatorsMetadata", function () {
+    describe("generateCreatorMetadata", function () {
       it("should create an IpCreator object with the provided details", function () {
-        const creator = ipAssetClient.generateCreatorsMetadata([sampleCreatorData]);
+        const creator = ipAssetClient.generateCreatorMetadata(sampleCreatorData);
 
         expect(creator).to.be.an("object");
         expect(creator).to.have.property("name", "Jane Doe");

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
 import { createMock } from "../testUtils";
 import * as sinon from "sinon";
-import { IPAssetClient, LicenseTerms } from "../../../src";
+import { IPAssetClient, LicenseTerms, StoryRelationship } from "../../../src";
 import {
   PublicClient,
   WalletClient,
@@ -136,7 +136,7 @@ describe("Test IpAssetClient", () => {
       relationships: [
         {
           parentIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512" as Address,
-          type: "APPEARS_IN",
+          type: StoryRelationship.APPEARS_IN,
         },
       ],
       createdAt: "2024-08-22T10:20:30Z",
@@ -145,10 +145,6 @@ describe("Test IpAssetClient", () => {
       media: [
         { name: "Cover Image", url: "https://example.com/cover.jpg", mimeType: "image/jpeg" },
       ],
-      attributes: [
-        { key: "Genre", value: "Adventure" },
-        { key: "Pages", value: 350 },
-      ],
       app: { id: "app_001", name: "Story Protocol", website: "https://story.foundation" },
       tags: ["Adventure", "Thriller"],
       robotTerms: { userAgent: "*", allow: "/" },
@@ -156,9 +152,9 @@ describe("Test IpAssetClient", () => {
       customField2: 42,
     };
 
-    describe("generateCreatorMetadata", function () {
+    describe("generateCreatorsMetadata", function () {
       it("should create an IpCreator object with the provided details", function () {
-        const creator = ipAssetClient.generateCreatorMetadata(sampleCreatorData);
+        const creator = ipAssetClient.generateCreatorsMetadata([sampleCreatorData]);
 
         expect(creator).to.be.an("object");
         expect(creator).to.have.property("name", "Jane Doe");
@@ -186,7 +182,10 @@ describe("Test IpAssetClient", () => {
           .to.have.property("relationships")
           .that.is.an("array")
           .that.deep.equals([
-            { parentIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512", type: "APPEARS_IN" },
+            {
+              parentIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+              type: StoryRelationship.APPEARS_IN,
+            },
           ]);
         expect(metadata).to.have.property("createdAt", "2024-08-22T10:20:30Z");
         expect(metadata).to.have.property("watermarkImg", "https://example.com/watermark.png");


### PR DESCRIPTION
## Description

The following updates have been made to comply with the latest IPA Metadata Standard, as documented [here](https://docs.story.foundation/docs/ipa-metadata-standard):

- `generateCreatorMetadata` no longer sets the following properties to empty default values if not provided:
    - `description`
    - `image`
    - `socialMedia`
    - `role`
- The request type for `generateIpMetadata` has been updated to align with the latest IPA Metadata Standard, with inline documentation added to each property for better clarity.
- The `type` property in `IpRelationship` has been changed from a string to an enum, with all supported values now explicitly defined.