### PR TITLE
feat: Add dispute assertion to dispute client

### DIFF
--- a/packages/core-sdk/src/abi/generated.ts
+++ b/packages/core-sdk/src/abi/generated.ts
@@ -5793,6 +5793,16 @@ export const ipRoyaltyVaultImplAbi = [
   },
   {
     type: "error",
+    inputs: [{ name: "target", internalType: "address", type: "address" }],
+    name: "AddressEmptyCode",
+  },
+  {
+    type: "error",
+    inputs: [{ name: "account", internalType: "address", type: "address" }],
+    name: "AddressInsufficientBalance",
+  },
+  {
+    type: "error",
     inputs: [
       { name: "spender", internalType: "address", type: "address" },
       { name: "allowance", internalType: "uint256", type: "uint256" },
@@ -5829,6 +5839,7 @@ export const ipRoyaltyVaultImplAbi = [
     inputs: [{ name: "spender", internalType: "address", type: "address" }],
     name: "ERC20InvalidSpender",
   },
+  { type: "error", inputs: [], name: "FailedInnerCall" },
   { type: "error", inputs: [], name: "InvalidInitialization" },
   { type: "error", inputs: [], name: "IpRoyaltyVault__EnforcedPause" },
   {
@@ -14470,7 +14481,7 @@ export const spgnftImplAbi = [
   },
   { type: "error", inputs: [], name: "InvalidInitialization" },
   { type: "error", inputs: [], name: "NotInitializing" },
-  { type: "error", inputs: [], name: "SPGNFT__CallerNotFeeRecipientOrAdmin" },
+  { type: "error", inputs: [], name: "SPGNFT__CallerNotFeeRecipient" },
   { type: "error", inputs: [], name: "SPGNFT__CallerNotPeripheryContract" },
   {
     type: "error",
@@ -14486,11 +14497,6 @@ export const spgnftImplAbi = [
   { type: "error", inputs: [], name: "SPGNFT__MintingDenied" },
   { type: "error", inputs: [], name: "SPGNFT__ZeroAddressParam" },
   { type: "error", inputs: [], name: "SPGNFT__ZeroMaxSupply" },
-  {
-    type: "error",
-    inputs: [{ name: "token", internalType: "address", type: "address" }],
-    name: "SafeERC20FailedOperation",
-  },
   {
     type: "event",
     anonymous: false,
@@ -15556,6 +15562,17 @@ export class AccessControllerClient extends AccessControllerEventClient {
 // Contract ArbitrationPolicyUMA =============================================================
 
 /**
+ * ArbitrationPolicyUmaDisputeIdToAssertionIdRequest
+ *
+ * @param disputeId uint256
+ */
+export type ArbitrationPolicyUmaDisputeIdToAssertionIdRequest = {
+  disputeId: bigint;
+};
+
+export type ArbitrationPolicyUmaDisputeIdToAssertionIdResponse = Hex;
+
+/**
  * ArbitrationPolicyUmaMaxBondsRequest
  *
  * @param token address
@@ -15571,6 +15588,17 @@ export type ArbitrationPolicyUmaMaxLivenessResponse = bigint;
 export type ArbitrationPolicyUmaMinLivenessResponse = bigint;
 
 /**
+ * ArbitrationPolicyUmaDisputeAssertionRequest
+ *
+ * @param assertionId bytes32
+ * @param counterEvidenceHash bytes32
+ */
+export type ArbitrationPolicyUmaDisputeAssertionRequest = {
+  assertionId: Hex;
+  counterEvidenceHash: Hex;
+};
+
+/**
  * contract ArbitrationPolicyUMA readonly method
  */
 export class ArbitrationPolicyUmaReadOnlyClient {
@@ -15580,6 +15608,23 @@ export class ArbitrationPolicyUmaReadOnlyClient {
   constructor(rpcClient: PublicClient, address?: Address) {
     this.address = address || getAddress(arbitrationPolicyUmaAddress, rpcClient.chain?.id);
     this.rpcClient = rpcClient;
+  }
+
+  /**
+   * method disputeIdToAssertionId for contract ArbitrationPolicyUMA
+   *
+   * @param request ArbitrationPolicyUmaDisputeIdToAssertionIdRequest
+   * @return Promise<ArbitrationPolicyUmaDisputeIdToAssertionIdResponse>
+   */
+  public async disputeIdToAssertionId(
+    request: ArbitrationPolicyUmaDisputeIdToAssertionIdRequest,
+  ): Promise<ArbitrationPolicyUmaDisputeIdToAssertionIdResponse> {
+    return await this.rpcClient.readContract({
+      abi: arbitrationPolicyUmaAbi,
+      address: this.address,
+      functionName: "disputeIdToAssertionId",
+      args: [request.disputeId],
+    });
   }
 
   /**
@@ -15625,6 +15670,56 @@ export class ArbitrationPolicyUmaReadOnlyClient {
       address: this.address,
       functionName: "minLiveness",
     });
+  }
+}
+
+/**
+ * contract ArbitrationPolicyUMA write method
+ */
+export class ArbitrationPolicyUmaClient extends ArbitrationPolicyUmaReadOnlyClient {
+  protected readonly wallet: SimpleWalletClient;
+
+  constructor(rpcClient: PublicClient, wallet: SimpleWalletClient, address?: Address) {
+    super(rpcClient, address);
+    this.wallet = wallet;
+  }
+
+  /**
+   * method disputeAssertion for contract ArbitrationPolicyUMA
+   *
+   * @param request ArbitrationPolicyUmaDisputeAssertionRequest
+   * @return Promise<WriteContractReturnType>
+   */
+  public async disputeAssertion(
+    request: ArbitrationPolicyUmaDisputeAssertionRequest,
+  ): Promise<WriteContractReturnType> {
+    const { request: call } = await this.rpcClient.simulateContract({
+      abi: arbitrationPolicyUmaAbi,
+      address: this.address,
+      functionName: "disputeAssertion",
+      account: this.wallet.account,
+      args: [request.assertionId, request.counterEvidenceHash],
+    });
+    return await this.wallet.writeContract(call as WriteContractParameters);
+  }
+
+  /**
+   * method disputeAssertion for contract ArbitrationPolicyUMA with only encode
+   *
+   * @param request ArbitrationPolicyUmaDisputeAssertionRequest
+   * @return EncodedTxData
+   */
+  public disputeAssertionEncode(
+    request: ArbitrationPolicyUmaDisputeAssertionRequest,
+  ): EncodedTxData {
+    return {
+      to: this.address,
+      data: encodeFunctionData({
+        abi: arbitrationPolicyUmaAbi,
+        functionName: "disputeAssertion",
+        args: [request.assertionId, request.counterEvidenceHash],
+      }),
+    };
   }
 }
 

--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -235,6 +235,15 @@ export class DisputeClient {
     }
   }
 
+  /**
+   * Counters a dispute that was raised by another party on an IP using counter evidence.
+   *
+   * This method can only be called by the IP's owner to counter a dispute by providing
+   * counter evidence. The counter evidence (e.g., documents, images) should be
+   * uploaded to IPFS, and its corresponding CID is converted to a hash for the request.
+   *
+   * If you only have a `disputeId`, call {@link disputeIdToAssertionId} to get the `assertionId` needed here.
+   */
   public async disputeAssertion(request: DisputeAssertionRequest): Promise<TransactionResponse> {
     try {
       const ipAccount = new IpAccountImplClient(

--- a/packages/core-sdk/src/types/resources/dispute.ts
+++ b/packages/core-sdk/src/types/resources/dispute.ts
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import { Address, Hex } from "viem";
 
 import { TxOptions, WithTxOptions } from "../options";
 import { EncodedTxData } from "../../abi/generated";
@@ -72,4 +72,24 @@ export type TagIfRelatedIpInfringedRequest = {
      */
     useMulticallWhenPossible?: boolean;
   };
+} & WithTxOptions;
+
+export type DisputeAssertionRequest = {
+  /**
+   * The IP ID that is the target of the dispute.
+   */
+  ipId: Address;
+  /**
+   * The identifier of the assertion that was disputed.
+   *
+   * You can get this from the `disputeId` by calling `dispute.disputeIdToAssertionId`.
+   */
+  assertionId: Hex;
+  /**
+   * Content Identifier (CID) for the counter evidence.
+   * This should be obtained by uploading your dispute evidence (documents, images, etc.) to IPFS.
+   *
+   * @example "QmX4zdp8VpzqvtKuEqMo6gfZPdoUx9TeHXCgzKLcFfSUbk"
+   */
+  counterEvidenceCID: string;
 } & WithTxOptions;

--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -81,11 +81,20 @@ describe("Dispute Functions", () => {
     const mockERC20 = new WIPTokenClient(publicClient, walletClient);
     await mockERC20.approve(arbitrationPolicyUmaAddress[aeneid], maxUint256);
 
-    const tokenId = await getTokenId();
+    const txData = await clientA.nftClient.createNFTCollection({
+      name: "test-collection",
+      symbol: "TEST",
+      maxSupply: 100,
+      isPublicMinting: true,
+      mintOpen: true,
+      contractURI: "test-uri",
+      mintFeeRecipient: TEST_WALLET_ADDRESS,
+      txOptions: { waitForTransaction: true },
+    });
+    const nftContract = txData.spgNftContract!;
     ipIdB = (
-      await clientB.ipAsset.register({
-        nftContract: mockERC721,
-        tokenId: tokenId!,
+      await clientB.ipAsset.mintAndRegisterIp({
+        spgNftContract: nftContract,
         txOptions: {
           waitForTransaction: true,
         },
@@ -93,7 +102,8 @@ describe("Dispute Functions", () => {
     ).ipId!;
   });
 
-  describe("raiseDispute", () => {
+  describe("raiseDispute and counter dispute", () => {
+    let disputeId: bigint | undefined;
     it("should raise a dispute", async () => {
       const raiseDisputeRequest: RaiseDisputeRequest = {
         targetIpId: ipIdB,
@@ -108,10 +118,30 @@ describe("Dispute Functions", () => {
       const response = await clientA.dispute.raiseDispute(raiseDisputeRequest);
       expect(response.txHash).to.be.a("string").and.not.empty;
       expect(response.disputeId).to.be.a("bigint");
+      disputeId = response.disputeId;
+    });
+
+    it("should be able to counter existing dispute once", async () => {
+      const assertionId = await clientB.dispute.disputeIdToAssertionId(disputeId!);
+      const counterEvidenceCID = await generateCID();
+      const ret = await clientB.dispute.disputeAssertion({
+        ipId: ipIdB,
+        assertionId,
+        counterEvidenceCID,
+      });
+      expect(ret.txHash).to.be.a("string").and.not.empty;
+
+      // should throw error if attempting to dispute assertion again
+      const secondDispute = clientB.dispute.disputeAssertion({
+        ipId: ipIdB,
+        assertionId,
+        counterEvidenceCID,
+      });
+      await expect(secondDispute).to.be.rejectedWith("Assertion already disputed");
     });
 
     it("should throw error when liveness is out of bounds", async () => {
-      const minLiveness = await clientA.dispute.arbitrationPolicyUmaReadOnlyClient.minLiveness();
+      const minLiveness = await clientA.dispute.arbitrationPolicyUmaClient.minLiveness();
       const raiseDisputeRequest: RaiseDisputeRequest = {
         targetIpId: ipIdB,
         cid: await generateCID(),

--- a/packages/core-sdk/test/unit/resources/dispute.test.ts
+++ b/packages/core-sdk/test/unit/resources/dispute.test.ts
@@ -1,10 +1,11 @@
 import * as sinon from "sinon";
-import { createMock } from "../testUtils";
+import { createMock, generateRandomHash } from "../testUtils";
 import { ipId, txHash } from "../mockData";
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { PublicClient, WalletClient } from "viem";
 import { DisputeClient } from "../../../src";
+import { IpAccountImplClient } from "../../../src/abi/generated";
 
 chai.use(chaiAsPromised);
 
@@ -23,13 +24,11 @@ describe("Test DisputeClient", () => {
     sinon.restore();
   });
 
-  describe("Test raiseDispute", () => {
+  describe("raiseDispute", () => {
     it("throw address error when call raiseDispute with invalid targetIpId", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "minLiveness").resolves(0n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxLiveness")
-        .resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxBonds").resolves(1000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(1000n);
       sinon
         .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
         .resolves({ allowed: true });
@@ -47,10 +46,8 @@ describe("Test DisputeClient", () => {
     });
 
     it("throw liveness error when call raiseDispute given liveness out of range", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "minLiveness").resolves(100n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxLiveness")
-        .resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(100n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
       try {
         await disputeClient.raiseDispute({
           targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -67,11 +64,9 @@ describe("Test DisputeClient", () => {
     });
 
     it("throw bond error when call raiseDispute given bond more than max bonds", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "minLiveness").resolves(0n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxLiveness")
-        .resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxBonds").resolves(1000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(1000n);
       try {
         await disputeClient.raiseDispute({
           targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -88,11 +83,9 @@ describe("Test DisputeClient", () => {
     });
 
     it("should throw tag error when call raiseDispute given tag not whitelisted", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "minLiveness").resolves(0n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxLiveness")
-        .resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxBonds").resolves(1000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(1000n);
       sinon
         .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
         .resolves({ allowed: false });
@@ -111,13 +104,9 @@ describe("Test DisputeClient", () => {
       }
     });
     it("should return txHash when call raiseDispute successfully", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "minLiveness").resolves(0n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxLiveness")
-        .resolves(100000000000n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxBonds")
-        .resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
       sinon
         .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
         .resolves({ allowed: true });
@@ -135,13 +124,9 @@ describe("Test DisputeClient", () => {
     });
 
     it("should return txHash and disputeId when call raiseDispute successfully with waitForTransaction", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "minLiveness").resolves(0n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxLiveness")
-        .resolves(100000000000n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxBonds")
-        .resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
       sinon
         .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
         .resolves({ allowed: true });
@@ -172,13 +157,9 @@ describe("Test DisputeClient", () => {
     });
 
     it("should return encodedTxData when call raiseDispute successfully with encodedTxDataOnly", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "minLiveness").resolves(0n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxLiveness")
-        .resolves(100000000000n);
-      sinon
-        .stub(disputeClient.arbitrationPolicyUmaReadOnlyClient, "maxBonds")
-        .resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
       sinon
         .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
         .resolves({ allowed: true });
@@ -195,7 +176,7 @@ describe("Test DisputeClient", () => {
     });
   });
 
-  describe("Test cancelDispute", () => {
+  describe("cancelDispute", () => {
     it("should throw error when call cancelDispute failed", async () => {
       sinon.stub(disputeClient.disputeModuleClient, "cancelDispute").rejects(new Error("500"));
       try {
@@ -237,7 +218,7 @@ describe("Test DisputeClient", () => {
     });
   });
 
-  describe("Test resolveDispute", () => {
+  describe("resolveDispute", () => {
     it("should throw error when call resolveDispute failed", async () => {
       sinon.stub(disputeClient.disputeModuleClient, "resolveDispute").rejects(new Error("500"));
       try {
@@ -282,7 +263,7 @@ describe("Test DisputeClient", () => {
     });
   });
 
-  describe("Test tagIfRelatedIpInfringed", () => {
+  describe("tagIfRelatedIpInfringed", () => {
     let aggregate3Stub: sinon.SinonStub;
     let tagIfRelatedIpInfringedStub: sinon.SinonStub;
     beforeEach(() => {
@@ -343,6 +324,34 @@ describe("Test DisputeClient", () => {
       expect(result.length).equal(1);
       expect(aggregate3Stub.called).to.be.false;
       expect(tagIfRelatedIpInfringedStub.calledOnce).to.be.true;
+    });
+  });
+
+  describe("disputeAssertion", () => {
+    it("should dispute assertion successfully", async () => {
+      const accountExecuteMock = sinon
+        .stub(IpAccountImplClient.prototype, "execute")
+        .resolves(txHash);
+      const result = await disputeClient.disputeAssertion({
+        ipId,
+        assertionId: generateRandomHash(),
+        counterEvidenceCID: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+      });
+      expect(result.txHash).equal(txHash);
+      expect(accountExecuteMock.calledOnce).to.be.true;
+    });
+  });
+
+  describe("disputeIdToAssertionId", () => {
+    it("should return assertionId", async () => {
+      const mockAssertionId = generateRandomHash();
+      const mock = sinon
+        .stub(disputeClient.arbitrationPolicyUmaClient, "disputeIdToAssertionId")
+        .resolves(mockAssertionId);
+      const disputeId = BigInt(10);
+      const result = await disputeClient.disputeIdToAssertionId(disputeId);
+      expect(result).equal(mockAssertionId);
+      expect(mock.calledOnceWith({ disputeId })).to.be.true;
     });
   });
 });

--- a/packages/wagmi-generator/wagmi.config.ts
+++ b/packages/wagmi-generator/wagmi.config.ts
@@ -328,7 +328,13 @@ export default defineConfig(async () => {
             "distributeRoyaltyTokens",
             "registerIpAndMakeDerivativeAndDeployRoyaltyVault",
           ],
-          ArbitrationPolicyUMA: ["maxBonds", "maxLiveness", "minLiveness"],
+          ArbitrationPolicyUMA: [
+            "maxBonds",
+            "maxLiveness",
+            "minLiveness",
+            "disputeIdToAssertionId",
+            "disputeAssertion",
+          ],
           WrappedIP: [
             "deposit",
             "approve",


### PR DESCRIPTION
## Description
Counters a dispute that was raised by another party on an IP using counter evidence that is uploaded to IPFS.

This method can only be called by the IP's owner to counter a dispute by providing counter evidence. The counter evidence (e.g., documents, images) should be uploaded to IPFS, and its corresponding CID is converted internally to a hash for the request.

### Example

```jsx
const ret = await client.dispute.disputeAssertion({
  ipId, // the ipId of the disputed IP
  assertionId, // the assertionId of the dispute
  counterEvidenceCID, // CID of the counter evidence
});
```