### PR TITLE
Refactor claim all revenue

### DIFF
--- a/packages/core-sdk/src/abi/generated.ts
+++ b/packages/core-sdk/src/abi/generated.ts
@@ -20457,6 +20457,21 @@ export type IpAccountImplExecute2Request = {
 };
 
 /**
+ * IpAccountImplExecuteBatchRequest
+ *
+ * @param calls tuple[]
+ * @param operation uint8
+ */
+export type IpAccountImplExecuteBatchRequest = {
+  calls: {
+    target: Address;
+    value: bigint;
+    data: Hex;
+  }[];
+  operation: number;
+};
+
+/**
  * IpAccountImplExecuteWithSigRequest
  *
  * @param to address
@@ -20608,6 +20623,42 @@ export class IpAccountImplClient extends IpAccountImplReadOnlyClient {
         abi: ipAccountImplAbi,
         functionName: "execute",
         args: [request.to, request.value, request.data],
+      }),
+    };
+  }
+
+  /**
+   * method executeBatch for contract IPAccountImpl
+   *
+   * @param request IpAccountImplExecuteBatchRequest
+   * @return Promise<WriteContractReturnType>
+   */
+  public async executeBatch(
+    request: IpAccountImplExecuteBatchRequest,
+  ): Promise<WriteContractReturnType> {
+    const { request: call } = await this.rpcClient.simulateContract({
+      abi: ipAccountImplAbi,
+      address: this.address,
+      functionName: "executeBatch",
+      account: this.wallet.account,
+      args: [request.calls, request.operation],
+    });
+    return await this.wallet.writeContract(call as WriteContractParameters);
+  }
+
+  /**
+   * method executeBatch for contract IPAccountImpl with only encode
+   *
+   * @param request IpAccountImplExecuteBatchRequest
+   * @return EncodedTxData
+   */
+  public executeBatchEncode(request: IpAccountImplExecuteBatchRequest): EncodedTxData {
+    return {
+      to: this.address,
+      data: encodeFunctionData({
+        abi: ipAccountImplAbi,
+        functionName: "executeBatch",
+        args: [request.calls, request.operation],
       }),
     };
   }

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -389,7 +389,7 @@ export class RoyaltyClient {
   private async unwrapWipTokens(claimedTokens: IpRoyaltyVaultImplRevenueTokenClaimedEvent[]) {
     const wipTokens = claimedTokens.filter((token) => token.token === WIP_TOKEN_ADDRESS);
     if (wipTokens.length > 1) {
-      throw new Error("Multiple WIP tokens found in the claimed tokens");
+      throw new Error("Multiple WIP tokens found in the claimed tokens.");
     }
     const wipToken = wipTokens[0];
     if (!wipToken || wipToken.amount <= 0n) {

--- a/packages/wagmi-generator/wagmi.config.ts
+++ b/packages/wagmi-generator/wagmi.config.ts
@@ -249,6 +249,7 @@ export default defineConfig(async () => {
             "state",
             "token",
             "owner",
+            "executeBatch",
           ],
           IPAssetRegistry: [
             "IPRegistered",


### PR DESCRIPTION
## Description
- Add `executeBatch` instead of `execute` to batch all currency tokens
- Move out loop for `unwrapWipTokens` method
- Fix unit tests
