### PR TITLE
Improve documentation

### DIFF
--- a/packages/core-sdk/src/client.ts
+++ b/packages/core-sdk/src/client.ts
@@ -34,9 +34,6 @@ export class StoryClient {
   private _group: GroupClient | null = null;
   private _wip: WipClient | null = null;
 
-  /**
-   * @param config - the configuration for the SDK client
-   */
   private constructor(config: StoryConfig) {
     this.config = {
       ...config,
@@ -73,8 +70,6 @@ export class StoryClient {
   }
   /**
    * Factory method for creating a SDK client with a signer.
-   *
-   * @param config StoryClient - the configuration for a new SDK client
    */
   static newClient(config: StoryConfig): StoryClient {
     return new StoryClient(config);
@@ -82,8 +77,6 @@ export class StoryClient {
 
   /**
    * Factory method for creating a SDK client with a signer.
-   *
-   * @param config WalletClientConfig - the configuration for a new SDK client
    */
   static newClientUseWallet(config: UseWalletStoryConfig): StoryClient {
     return new StoryClient({
@@ -95,8 +88,6 @@ export class StoryClient {
 
   /**
    * Factory method for creating a SDK client with a signer.
-   *
-   * @param config UseAccountStoryConfig - the configuration for a new SDK client
    */
   static newClientUseAccount(config: UseAccountStoryConfig): StoryClient {
     return new StoryClient({
@@ -109,8 +100,6 @@ export class StoryClient {
   /**
    * Getter for the ip asset client. The client is lazily created when
    * this method is called.
-   *
-   * @returns the IPAssetClient instance
    */
   public get ipAsset(): IPAssetClient {
     if (this._ipAsset === null) {
@@ -123,8 +112,6 @@ export class StoryClient {
   /**
    * Getter for the permission client. The client is lazily created when
    * this method is called.
-   *
-   * @returns the PermissionClient instance
    */
   public get permission(): PermissionClient {
     if (this._permission === null) {
@@ -137,8 +124,6 @@ export class StoryClient {
   /**
    * Getter for the license client. The client is lazily created when
    * this method is called.
-   *
-   * @returns the LicenseClient instance
    */
   public get license(): LicenseClient {
     if (this._license === null) {
@@ -151,8 +136,6 @@ export class StoryClient {
   /**
    * Getter for the dispute client. The client is lazily created when
    * this method is called.
-   *
-   * @returns the DisputeClient instance
    */
   public get dispute(): DisputeClient {
     if (this._dispute === null) {
@@ -165,8 +148,6 @@ export class StoryClient {
   /**
    * Getter for the ip account client. The client is lazily created when
    * this method is called.
-   *
-   * @returns the IPAccountClient instance
    */
   public get ipAccount(): IPAccountClient {
     if (this._ipAccount === null) {
@@ -179,8 +160,6 @@ export class StoryClient {
   /**
    * Getter for the royalty client. The client is lazily created when
    * this method is called.
-   *
-   * @returns the RoyaltyClient instance
    */
   public get royalty(): RoyaltyClient {
     if (this._royalty === null) {
@@ -193,8 +172,6 @@ export class StoryClient {
   /**
    * Getter for the NFT client. The client is lazily created when
    * this method is called.
-   *
-   * @returns the NftClient instance
    */
   public get nftClient(): NftClient {
     if (this._nftClient === null) {
@@ -207,8 +184,6 @@ export class StoryClient {
   /**
    * Getter for the group client. The client is lazily created when
    * this method is called.
-   *
-   * @returns the GroupClient instance
    */
   public get groupClient(): GroupClient {
     if (this._group === null) {

--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -51,8 +51,7 @@ export class DisputeClient {
   /**
    * Raises a dispute on a given ipId.
    *
-   * Emits an on-chain `DisputeRaised` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L64 | IDisputeModule.sol}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L64 | `DisputeRaised`} event.
    */
   public async raiseDispute(request: RaiseDisputeRequest): Promise<RaiseDisputeResponse> {
     try {
@@ -140,8 +139,7 @@ export class DisputeClient {
   /**
    * Cancels an ongoing dispute
    *
-   * Emits an on-chain `DisputeCancelled` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L84 | IDisputeModule.sol}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L84 | `DisputeCancelled`} event.
    */
   public async cancelDispute(request: CancelDisputeRequest): Promise<CancelDisputeResponse> {
     try {
@@ -171,8 +169,7 @@ export class DisputeClient {
   /**
    * Resolves a dispute after it has been judged.
    *
-   * Emits an on-chain `DisputeResolved` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L104 | IDisputeModule.sol}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L104 | `DisputeResolved`} event.
    */
   public async resolveDispute(request: ResolveDisputeRequest): Promise<ResolveDisputeResponse> {
     try {
@@ -202,8 +199,7 @@ export class DisputeClient {
    * Tags a derivative if a parent has been tagged with an infringement tag
    * or a group ip if a group member has been tagged with an infringement tag.
    *
-   * Emits an on-chain `IpTaggedOnRelatedIpInfringement` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L93 | IDisputeModule.sol}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L93 | `IpTaggedOnRelatedIpInfringement`} event.
    */
   public async tagIfRelatedIpInfringed(
     request: TagIfRelatedIpInfringedRequest,

--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -51,11 +51,8 @@ export class DisputeClient {
   /**
    * Raises a dispute on a given ipId.
    *
-   * Submits a {@link DisputeRaised} event.
+   * Emits an on-chain `DisputeRaised` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L64 | IDisputeModule.sol}
-   * for a list of on-chain events emitted when a dispute is raised.
-   *
-   * @remarks `WipOptions.useMulticallWhenPossible` is disabled for this function due to disputeInitiator issue. It will be executed sequentially with several transactions.
    */
   public async raiseDispute(request: RaiseDisputeRequest): Promise<RaiseDisputeResponse> {
     try {
@@ -142,16 +139,9 @@ export class DisputeClient {
 
   /**
    * Cancels an ongoing dispute
-   * @param request - The request object containing details to cancel the dispute.
-   *   @param request.disputeId The ID of the dispute to be cancelled.
-   *   @param request.data [Optional] additional data used in the cancellation process.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a CancelDisputeResponse containing the transaction hash.
-   * @throws NotInDisputeState, if the currentTag of the Dispute is not being disputed
-   * @throws NotDisputeInitiator, if the transaction executor is not the one that initiated the dispute
-   * @throws error if the Dispute's ArbitrationPolicy contract is not valid
-   * @calls cancelDispute(uint256 _disputeId, bytes calldata _data) external nonReentrant {
-   * @emits DisputeCancelled (_disputeId, _data);
+   *
+   * Emits an on-chain `DisputeCancelled` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L84 | IDisputeModule.sol}
    */
   public async cancelDispute(request: CancelDisputeRequest): Promise<CancelDisputeResponse> {
     try {
@@ -179,15 +169,10 @@ export class DisputeClient {
   }
 
   /**
-   * Resolves a dispute after it has been judged
-   * @param request - The request object containing details to resolve the dispute.
-   *   @param request.disputeId The ID of the dispute to be resolved.
-   *   @param request.data The data to resolve the dispute.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a ResolveDisputeResponse.
-   * @throws NotAbleToResolve, if currentTag is still in dispute (i.e still needs a judgement to be set)
-   * @throws NotDisputeInitiator, if the transaction executor is not the one that initiated the dispute
-   * @emits DisputeResolved (_disputeId)
+   * Resolves a dispute after it has been judged.
+   *
+   * Emits an on-chain `DisputeResolved` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L104 | IDisputeModule.sol}
    */
   public async resolveDispute(request: ResolveDisputeRequest): Promise<ResolveDisputeResponse> {
     try {
@@ -217,8 +202,8 @@ export class DisputeClient {
    * Tags a derivative if a parent has been tagged with an infringement tag
    * or a group ip if a group member has been tagged with an infringement tag.
    *
+   * Emits an on-chain `IpTaggedOnRelatedIpInfringement` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/dispute/IDisputeModule.sol#L93 | IDisputeModule.sol}
-   * for a list of on-chain events emitted when a derivative is tagged on an infringement.
    */
   public async tagIfRelatedIpInfringed(
     request: TagIfRelatedIpInfringedRequest,

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -77,8 +77,7 @@ export class GroupClient {
   }
   /** Registers a Group IPA.
    *
-   * Emits an on-chain `IPGroupRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | IGroupingModule}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | `IPGroupRegistered`} event.
    */
   public async registerGroup(request: RegisterGroupRequest): Promise<RegisterGroupResponse> {
     try {
@@ -108,8 +107,7 @@ export class GroupClient {
   }
   /** Mint an NFT from a SPGNFT collection, register it with metadata as an IP, attach license terms to the registered IP, and add it to a group IP.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async mintAndRegisterIpAndAttachLicenseAndAddToGroup(
     request: MintAndRegisterIpAndAttachLicenseAndAddToGroupRequest,
@@ -186,8 +184,7 @@ export class GroupClient {
 
   /** Register an NFT as IP with metadata, attach license terms to the registered IP, and add it to a group IP.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async registerIpAndAttachLicenseAndAddToGroup(
     request: RegisterIpAndAttachLicenseAndAddToGroupRequest,
@@ -299,8 +296,7 @@ export class GroupClient {
   }
   /** Register a group IP with a group reward pool and attach license terms to the group IP.
    *
-   * Emits an on-chain `IPGroupRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | IGroupingModule}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | `IPGroupRegistered`} event.
    */
   public async registerGroupAndAttachLicense(
     request: RegisterGroupAndAttachLicenseRequest,
@@ -332,8 +328,7 @@ export class GroupClient {
   }
   /** Register a group IP with a group reward pool, attach license terms to the group IP, and add individual IPs to the group IP.
    *
-   * Emits an on-chain `IPGroupRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | IGroupingModule}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | `IPGroupRegistered`} event.
    */
   public async registerGroupAndAttachLicenseAndAddIps(
     request: RegisterGroupAndAttachLicenseAndAddIpsRequest,

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -76,11 +76,9 @@ export class GroupClient {
     this.licenseRegistryReadOnlyClient = new LicenseRegistryReadOnlyClient(rpcClient);
   }
   /** Registers a Group IPA.
-   * @param request - The request object containing necessary data to register group.
-   *   @param request.groupPool The address specifying how royalty will be split amongst the pool of IPs in the group.
-   *   @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes group id.
-   * @emits PGroupRegistered (groupId, groupPool);
+   *
+   * Emits an on-chain `IPGroupRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | IGroupingModule}
    */
   public async registerGroup(request: RegisterGroupRequest): Promise<RegisterGroupResponse> {
     try {
@@ -109,8 +107,9 @@ export class GroupClient {
     }
   }
   /** Mint an NFT from a SPGNFT collection, register it with metadata as an IP, attach license terms to the registered IP, and add it to a group IP.
+   *
+   * Emits an on-chain `IPRegistered` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * for a list of on-chain events emitted when an IP is minted and registered, license terms are attached to an IP, and it is added to a group.
    */
   public async mintAndRegisterIpAndAttachLicenseAndAddToGroup(
     request: MintAndRegisterIpAndAttachLicenseAndAddToGroupRequest,
@@ -186,8 +185,9 @@ export class GroupClient {
   }
 
   /** Register an NFT as IP with metadata, attach license terms to the registered IP, and add it to a group IP.
+   *
+   * Emits an on-chain `IPRegistered` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * for a list of on-chain events emitted when an IP is registered, license terms are attached to an IP, and it is added to a group.
    */
   public async registerIpAndAttachLicenseAndAddToGroup(
     request: RegisterIpAndAttachLicenseAndAddToGroupRequest,
@@ -298,8 +298,9 @@ export class GroupClient {
     }
   }
   /** Register a group IP with a group reward pool and attach license terms to the group IP.
+   *
+   * Emits an on-chain `IPGroupRegistered` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | IGroupingModule}
-   * for a list of on-chain events emitted when a group IP is registered, license terms are attached to a group IP .
    */
   public async registerGroupAndAttachLicense(
     request: RegisterGroupAndAttachLicenseRequest,
@@ -330,8 +331,9 @@ export class GroupClient {
     }
   }
   /** Register a group IP with a group reward pool, attach license terms to the group IP, and add individual IPs to the group IP.
+   *
+   * Emits an on-chain `IPGroupRegistered` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | IGroupingModule}
-   * for a list of on-chain events emitted when a group IP is registered, license terms are attached to a group IP, and individual IPs are added to a group.
    */
   public async registerGroupAndAttachLicenseAndAddIps(
     request: RegisterGroupAndAttachLicenseAndAddIpsRequest,

--- a/packages/core-sdk/src/resources/ipAccount.ts
+++ b/packages/core-sdk/src/resources/ipAccount.ts
@@ -39,15 +39,8 @@ export class IPAccountClient {
     this.erc20Client = new Erc20Client(rpcClient, wallet);
   }
 
-  /** Executes a transaction from the IP Account.
-   * @param request - The request object containing necessary data to execute IP Account a transaction.
-   *   @param request.ipId The Ip Id to get ip account.
-   *   @param request.to The recipient of the transaction.
-   *   @param request.value The amount of Ether to send.
-   *   @param request.accountAddress The ipId to send.
-   *   @param request.data The data to send along with the transaction.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns Tx hash for the transaction.
+  /**
+   * Executes a transaction from the IP Account.
    */
   public async execute(request: IPAccountExecuteRequest): Promise<IPAccountExecuteResponse> {
     try {
@@ -81,17 +74,8 @@ export class IPAccountClient {
     }
   }
 
-  /** Executes a transaction from the IP Account.
-   * @param request - The request object containing necessary data to execute IP Account a transaction.
-   *   @param request.ipId The Ip Id to get ip account.
-   *   @param request.to The recipient of the transaction.
-   *   @param request.data The data to send along with the transaction.
-   *   @param request.signer The signer of the transaction.
-   *   @param request.deadline The deadline of the transaction signature.
-   *   @param request.signature The signature of the transaction, EIP-712 encoded.
-   *   @param request.value [Optional] The amount of Ether to send.
-   *   @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns Tx hash for the transaction.
+  /**
+   * Executes a transaction from the IP Account with a signature.
    */
   public async executeWithSig(
     request: IPAccountExecuteWithSigRequest,
@@ -129,9 +113,8 @@ export class IPAccountClient {
     }
   }
 
-  /** Returns the IPAccount's internal nonce for transaction ordering.
-   * @param ipId The IP ID
-   * @returns A Promise that resolves to the IP Account's nonce.
+  /**
+   * Returns the IPAccount's internal nonce for transaction ordering.
    */
   public async getIpAccountNonce(ipId: Address): Promise<IpAccountStateResponse> {
     try {
@@ -149,7 +132,6 @@ export class IPAccountClient {
 
   /**
    * Returns the identifier of the non-fungible token which owns the account
-   * @returns A Promise that resolves to an object containing the chain ID, token contract address, and token ID.
    */
   public async getToken(ipId: Address): Promise<TokenResponse> {
     try {

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -654,10 +654,7 @@ export class IPAssetClient {
             ),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: coreMetadataModuleAbi,
-              methodName: "setAll",
-            }),
+            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
           },
           {
             ipId: ipIdAddress,
@@ -667,20 +664,14 @@ export class IPAssetClient {
             ),
             to: getAddress(this.licensingModuleClient.address, "licensingModuleClient"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "attachLicenseTerms",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "attachLicenseTerms"),
           },
           {
             ipId: ipIdAddress,
             signer: this.licenseAttachmentWorkflowsClient.address,
             to: this.licensingModuleClient.address,
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "setLicensingConfig",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "setLicensingConfig"),
           },
         ],
       });
@@ -753,20 +744,14 @@ export class IPAssetClient {
             signer: getAddress(this.derivativeWorkflowsClient.address, "derivativeWorkflowsClient"),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: coreMetadataModuleAbi,
-              methodName: "setAll",
-            }),
+            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
           },
           {
             ipId: ipIdAddress,
             signer: this.derivativeWorkflowsClient.address,
             to: getAddress(this.licensingModuleClient.address, "licensingModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "registerDerivative",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "registerDerivative"),
           },
         ],
       });
@@ -967,10 +952,7 @@ export class IPAssetClient {
             ),
             to: getAddress(this.licensingModuleClient.address, "licensingModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "attachLicenseTerms",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "attachLicenseTerms"),
           },
           {
             ipId: ipId,
@@ -980,10 +962,7 @@ export class IPAssetClient {
             ),
             to: getAddress(this.licensingModuleClient.address, "licensingModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "setLicensingConfig",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "setLicensingConfig"),
           },
         ],
       });
@@ -1106,20 +1085,14 @@ export class IPAssetClient {
             signer: getAddress(this.derivativeWorkflowsClient.address, "derivativeWorkflowsClient"),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: coreMetadataModuleAbi,
-              methodName: "setAll",
-            }),
+            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
           },
           {
             ipId: ipIdAddress,
             signer: this.derivativeWorkflowsClient.address,
             to: getAddress(this.licensingModuleClient.address, "licensingModuleClient"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "registerDerivativeWithLicenseTokens",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "registerDerivativeWithLicenseTokens"),
           },
         ],
       });
@@ -1202,30 +1175,21 @@ export class IPAssetClient {
             ),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: coreMetadataModuleAbi,
-              methodName: "setAll",
-            }),
+            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
           },
           {
             ipId: ipIdAddress,
             signer: this.royaltyTokenDistributionWorkflowsClient.address,
             to: getAddress(this.licensingModuleClient.address, "licensingModuleClient"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "attachLicenseTerms",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "attachLicenseTerms"),
           },
           {
             ipId: ipIdAddress,
             signer: this.royaltyTokenDistributionWorkflowsClient.address,
             to: this.licensingModuleClient.address,
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "setLicensingConfig",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "setLicensingConfig"),
           },
         ],
       });
@@ -1308,20 +1272,14 @@ export class IPAssetClient {
             ),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: coreMetadataModuleAbi,
-              methodName: "setAll",
-            }),
+            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
           },
           {
             ipId: ipIdAddress,
             signer: this.royaltyTokenDistributionWorkflowsClient.address,
             to: getAddress(this.licensingModuleClient.address, "licensingModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature({
-              abi: licensingModuleAbi,
-              methodName: "registerDerivative",
-            }),
+            func: getFunctionSignature(licensingModuleAbi, "registerDerivative"),
           },
         ],
       });

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -171,8 +171,7 @@ export class IPAssetClient {
   /**
    * Registers an NFT as IP, creating a corresponding IP record.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async register(request: RegisterRequest): Promise<RegisterIpResponse> {
     try {
@@ -261,8 +260,7 @@ export class IPAssetClient {
   /**
    * Batch registers an NFT as IP, creating a corresponding IP record.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async batchRegister(request: BatchRegisterRequest): Promise<BatchRegisterResponse> {
     try {
@@ -510,9 +508,7 @@ export class IPAssetClient {
   /**
    * Mint an NFT from a collection and register it as an IP.
    *
-   * Emits on-chain `IPRegistered` and `LicenseTermsAttached` events.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
+   * Emits on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} and {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | `LicenseTermsAttached`} events.
    */
   public async mintAndRegisterIpAssetWithPilTerms(
     request: MintAndRegisterIpAssetWithPilTermsRequest,
@@ -562,9 +558,7 @@ export class IPAssetClient {
   /**
    * Batch mint an NFT from a collection and register it as an IP.
    *
-   * Emits on-chain `IPRegistered` and `LicenseTermsAttached` events.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
+   * Emits on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} and {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | `LicenseTermsAttached`} events.
    */
   public async batchMintAndRegisterIpAssetWithPilTerms(
     request: BatchMintAndRegisterIpAssetWithPilTermsRequest,
@@ -621,9 +615,7 @@ export class IPAssetClient {
   /**
    * Register a given NFT as an IP and attach Programmable IP License Terms.
    *
-   * Emits on-chain `IPRegistered` and `LicenseTermsAttached` events.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
+   * Emits on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} and {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | `LicenseTermsAttached`} events.
    */
   public async registerIpAndAttachPilTerms(
     request: RegisterIpAndAttachPilTermsRequest,
@@ -718,8 +710,7 @@ export class IPAssetClient {
   /**
    * Register the given NFT as a derivative IP with metadata without using license tokens.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async registerDerivativeIp(
     request: RegisterIpAndMakeDerivativeRequest,
@@ -794,8 +785,7 @@ export class IPAssetClient {
   /**
    * Mint an NFT from a collection and register it as a derivative IP without license tokens.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async mintAndRegisterIpAndMakeDerivative(
     request: MintAndRegisterIpAndMakeDerivativeRequest,
@@ -839,8 +829,7 @@ export class IPAssetClient {
   /**
    * Batch mint an NFT from a collection and register it as a derivative IP without license tokens.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async batchMintAndRegisterIpAndMakeDerivative(
     request: BatchMintAndRegisterIpAndMakeDerivativeRequest,
@@ -881,8 +870,7 @@ export class IPAssetClient {
   /**
    * Mint an NFT from a SPGNFT collection and register it with metadata as an IP.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async mintAndRegisterIp(request: MintAndRegisterIpRequest): Promise<RegisterIpResponse> {
     try {
@@ -919,8 +907,7 @@ export class IPAssetClient {
   /**
    * Register Programmable IP License Terms (if unregistered) and attach it to IP.
    *
-   * Emits an on-chain `LicenseTermsAttached` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | `LicenseTermsAttached`} event.
    */
   public async registerPilTermsAndAttach(
     request: RegisterPilTermsAndAttachRequest,
@@ -1003,8 +990,7 @@ export class IPAssetClient {
    * Mint an NFT from a collection and register it as a derivative IP using license tokens.
    * Requires caller to have the minter role or the SPG NFT to allow public minting. Caller must own the license tokens and have approved DerivativeWorkflows to transfer them.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
     request: MintAndRegisterIpAndMakeDerivativeWithLicenseTokensRequest,
@@ -1058,8 +1044,7 @@ export class IPAssetClient {
   /**
    * Register the given NFT as a derivative IP using license tokens.
    *
-   * Emits an on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async registerIpAndMakeDerivativeWithLicenseTokens(
     request: RegisterIpAndMakeDerivativeWithLicenseTokensRequest,
@@ -1136,12 +1121,11 @@ export class IPAssetClient {
   }
 
   /**
-   * Register the given NFT and attach license terms and distribute royalty tokens. In order to successfully distribute royalty tokens, the first license terms attached to the IP must be
-   * a commercial license.
+   * Register the given NFT and attach license terms and distribute royalty
+   * tokens. In order to successfully distribute royalty tokens, the first
+   * license terms attached to the IP must be a commercial license.
    *
-   * Emits on-chain `IPRegistered`, and `IpRoyaltyVaultDeployed` events.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88 | IRoyaltyModule}
+   * Emits on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} and {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88 | `IpRoyaltyVaultDeployed`} events.
    */
   public async registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens(
     request: RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest,
@@ -1247,9 +1231,7 @@ export class IPAssetClient {
    * Register the given NFT as a derivative IP and attach license terms and distribute royalty tokens.  In order to successfully distribute royalty tokens, the license terms attached to the IP must be
    * a commercial license.
    *
-   * Emits on-chain `IPRegistered` and `IpRoyaltyVaultDeployed` events.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88| IRoyaltyModule}
+   * Emits on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} and {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88| `IpRoyaltyVaultDeployed`} events.
    */
   public async registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens(
     request: RegisterDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest,
@@ -1361,9 +1343,7 @@ export class IPAssetClient {
   /**
    * Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
    *
-   * Emits on-chain `IPRegistered` and `IpRoyaltyVaultDeployed` events.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88| IRoyaltyModule}
+   * Emits on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} and {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88| `IpRoyaltyVaultDeployed`} events.
    */
   public async mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens(
     request: MintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokensRequest,
@@ -1425,8 +1405,7 @@ export class IPAssetClient {
   /**
    * Mint an NFT and register the IP, make a derivative, and distribute royalty tokens.
    *
-   * Emits on-chain `IPRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * Emits on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
    */
   public async mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens(
     request: MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensRequest,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -3,11 +3,11 @@ import {
   PublicClient,
   zeroAddress,
   Address,
+  zeroHash,
   WalletClient,
   toHex,
   encodeFunctionData,
   TransactionReceipt,
-  zeroHash,
 } from "viem";
 
 import { chain, getAddress } from "../utils/utils";
@@ -38,6 +38,7 @@ import {
   RegisterIpResponse,
   RegisterPilTermsAndAttachRequest,
   RegisterPilTermsAndAttachResponse,
+  RegisterRequest,
   MintAndRegisterIpAndMakeDerivativeResponse,
   RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest,
   DistributeRoyaltyTokens,
@@ -57,7 +58,6 @@ import {
   CommonRegistrationTxResponse,
   CommonRegistrationParams,
   ValidatedLicenseTermsData,
-  RegisterRequest,
 } from "../types/resources/ipAsset";
 import {
   AccessControllerClient,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -3,11 +3,11 @@ import {
   PublicClient,
   zeroAddress,
   Address,
-  zeroHash,
   WalletClient,
   toHex,
   encodeFunctionData,
   TransactionReceipt,
+  zeroHash,
 } from "viem";
 
 import { chain, getAddress } from "../utils/utils";
@@ -38,7 +38,6 @@ import {
   RegisterIpResponse,
   RegisterPilTermsAndAttachRequest,
   RegisterPilTermsAndAttachResponse,
-  RegisterRequest,
   MintAndRegisterIpAndMakeDerivativeResponse,
   RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest,
   DistributeRoyaltyTokens,
@@ -58,6 +57,7 @@ import {
   CommonRegistrationTxResponse,
   CommonRegistrationParams,
   ValidatedLicenseTermsData,
+  RegisterRequest,
 } from "../types/resources/ipAsset";
 import {
   AccessControllerClient,
@@ -170,18 +170,8 @@ export class IPAssetClient {
 
   /**
    * Registers an NFT as IP, creating a corresponding IP record.
-   * @param request - The request object that contains all data needed to register IP.
-   *   @param request.nftContract The address of the NFT.
-   *   @param request.tokenId The token identifier of the NFT.
-   *   @param {Object} request.ipMetadata - [Optional] The desired metadata for the newly minted NFT and newly registered IP.
-   *     @param request.ipMetadata.ipMetadataURI [Optional] The URI of the metadata for the IP.
-   *     @param request.ipMetadata.ipMetadataHash [Optional] The hash of the metadata for the IP.
-   *     @param request.ipMetadata.nftMetadataURI [Optional] The URI of the metadata for the NFT.
-   *     @param request.ipMetadata.nftMetadataHash [Optional] The hash of the metadata for the IP NFT.
-   *   @param request.deadline [Optional] The deadline for the signature in seconds, default is 1000s.
-   *   @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes IP ID, token ID.
-   * @emits IPRegistered (ipId, chainId, tokenContract, tokenId, resolverAddr, metadataProviderAddress, metadata)
+   * Emits an on-chain `IPRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    */
   public async register(request: RegisterRequest): Promise<RegisterIpResponse> {
     try {
@@ -269,18 +259,9 @@ export class IPAssetClient {
 
   /**
    * Batch registers an NFT as IP, creating a corresponding IP record.
-   * @param request - The request object that contains all data needed to batch register IP.
-   *  @param {Array} request.args The array of objects containing the data needed to register IP.
-   *   @param request.args.nftContract The address of the NFT.
-   *   @param request.args.tokenId The token identifier of the NFT.
-   *   @param {Object} request.args.ipMetadata - [Optional] The desired metadata for the newly minted NFT and newly registered IP.
-   *    @param request.args.ipMetadata.ipMetadataURI [Optional] The URI of the metadata for the IP.
-   *    @param request.args.ipMetadata.ipMetadataHash [Optional] The hash of the metadata for the IP.
-   *    @param request.args.ipMetadata.nftMetadataURI [Optional] The URI of the metadata for the NFT.
-   *    @param request.args.ipMetadata.nftMetadataHash [Optional] The hash of the metadata for the IP NFT.
-   *   @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property, without encodedTxDataOnly option.
-   * @returns A Promise that resolves to a transaction hash, if waitForTransaction is true, return an array of containing IP ID, Token ID, NFT Contract.
-   * @emits IPRegistered (ipId, chainId, tokenContract, tokenId, resolverAddr, metadataProviderAddress, metadata)
+   
+  * Emits an on-chain `IPRegistered` event.
+  * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    */
   public async batchRegister(request: BatchRegisterRequest): Promise<BatchRegisterResponse> {
     try {
@@ -395,18 +376,8 @@ export class IPAssetClient {
 
   /**
    * Batch registers a derivative directly with parent IP's license terms.
-   * @param request - The request object that contains all data needed to batch register derivative IP.
-   *  @param {Array} request.args The array of objects containing the data needed to register derivative IP.
-   *    @param request.args.childIpId The derivative IP ID.
-   *    @param {Array} request.args.parentIpIds The parent IP IDs.
-   *    @param {Array} request.args.licenseTermsIds The IDs of the license terms that the parent IP supports.
-   *    @param request.args.maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
-   *    @param request.args.maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000).
-   *    @param request.args.maxRevenueShare The maximum revenue share percentage allowed for minting the License Tokens. Must be between 0 and 100,000,000 (where 100,000,000 represents 100%).
-   *  @param request.deadline [Optional] The deadline for the signature in seconds, default is 1000s.
-   *  @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property, without encodedTxDataOnly option.
-   * @returns A Promise that resolves to a transaction hash.
-   */
+
+  */
   public async batchRegisterDerivative(
     request: BatchRegisterDerivativeRequest,
   ): Promise<BatchRegisterDerivativeResponse> {
@@ -495,12 +466,6 @@ export class IPAssetClient {
    * Registers a derivative with license tokens. The derivative IP is registered with license tokens minted from the parent IP's license terms.
    * The license terms of the parent IPs issued with license tokens are attached to the derivative IP.
    * The caller must be the derivative IP owner or an authorized operator.
-   * @param request - The request object that contains all data needed to register derivative license tokens.
-   *   @param request.childIpId The derivative IP ID.
-   *   @param {Array} request.licenseTokenIds The IDs of the license tokens.
-   *    @param request.args.maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000).
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to an object containing the transaction hash.
    */
   public async registerDerivativeWithLicenseTokens(
     request: RegisterDerivativeWithLicenseTokensRequest,
@@ -544,10 +509,10 @@ export class IPAssetClient {
   }
   /**
    * Mint an NFT from a collection and register it as an IP.
-   * it emits IPRegistered (ipId, chainId, tokenContract, tokenId, name, uri, registrationDate).
+   *
+   * Emits on-chain `IPRegistered` and `LicenseTermsAttached` events.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
-   * for a list of on-chain events emitted when an IP is minted and registered, and license terms are attached to an IP.
    */
   public async mintAndRegisterIpAssetWithPilTerms(
     request: MintAndRegisterIpAssetWithPilTermsRequest,
@@ -596,49 +561,10 @@ export class IPAssetClient {
 
   /**
    * Batch mint an NFT from a collection and register it as an IP.
-   * @param request - The request object that contains all data needed to batch mint and register ip.
-   *   @param {Array} request.args The array of mint and register IP requests.
-   *     @param request.args.spgNftContract The address of the NFT collection.
-   *     @param request.allowDuplicates Indicates whether the license terms can be attached to the same IP ID or not.
-   *     @param {Array} request.args.licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
-   *       @param {Object} request.args.licenseTermsData.terms The PIL terms to be used for the licensing.
-   *         @param request.args.licenseTermsData.terms.transferable Indicates whether the license is transferable or not.
-   *         @param request.args.licenseTermsData.terms.royaltyPolicy The address of the royalty policy contract which required to StoryProtocol in advance.
-   *         @param request.args.licenseTermsData.terms.mintingFee The fee to be paid when minting a license.
-   *         @param request.args.licenseTermsData.terms.expiration The expiration period of the license.
-   *         @param request.args.licenseTermsData.terms.commercialUse Indicates whether the work can be used commercially or not, Commercial use is required to deploy a royalty vault.
-   *         @param request.args.licenseTermsData.terms.commercialAttribution Whether attribution is required when reproducing the work commercially or not.
-   *         @param request.args.licenseTermsData.terms.commercializerChecker Commercializers that are allowed to commercially exploit the work. If zero address, then no restrictions is enforced.
-   *         @param request.args.licenseTermsData.terms.commercializerCheckerData The data to be passed to the commercializer checker contract.
-   *         @param request.args.licenseTermsData.terms.commercialRevShare Percentage of revenue that must be shared with the licensor.
-   *         @param request.args.licenseTermsData.terms.commercialRevCeiling The maximum revenue that can be generated from the commercial use of the work.
-   *         @param request.args.licenseTermsData.terms.derivativesAllowed Indicates whether the licensee can create derivatives of his work or not.
-   *         @param request.args.licenseTermsData.terms.derivativesAttribution Indicates whether attribution is required for derivatives of the work or not.
-   *         @param request.args.licenseTermsData.terms.derivativesApproval Indicates whether the licensor must approve derivatives of the work before they can be linked to the licensor IP ID or not.
-   *         @param request.args.licenseTermsData.terms.derivativesReciprocal Indicates whether the licensee must license derivatives of the work under the same terms or not.
-   *         @param request.args.licenseTermsData.terms.derivativeRevCeiling The maximum revenue that can be generated from the derivative use of the work.
-   *         @param request.args.licenseTermsData.terms.currency The ERC20 token to be used to pay the minting fee. the token must be registered in story protocol.
-   *         @param request.args.licenseTermsData.terms.uri The URI of the license terms, which can be used to fetch the offchain license terms.
-   *       @param {Object} request.args.licenseTermsData.licensingConfig The PIL terms and licensing configuration data to attach to the IP.
-   *         @param request.args.licenseTermsData.licensingConfig.isSet Whether the configuration is set or not.
-   *         @param request.args.licenseTermsData.licensingConfig.mintingFee The minting fee to be paid when minting license tokens.
-   *         @param request.args.licenseTermsData.licensingConfig.licensingHook The hook contract address for the licensing module, or zero address if none
-   *         @param request.args.licenseTermsData.licensingConfig.hookData The data to be used by the licensing hook.
-   *         @param request.args.licenseTermsData.licensingConfig.commercialRevShare The commercial revenue share percentage.
-   *         @param request.args.licenseTermsData.licensingConfig.disabled Whether the licensing is disabled or not.
-   *         @param request.args.licenseTermsData.licensingConfig.expectMinimumGroupRewardShare The minimum percentage of the group's reward share (from 0 to 100%, represented as 100 * 10 ** 6) that can be allocated to the IP when it is added to the group.
-   *         If the remaining reward share in the group is less than the minimumGroupRewardShare,the IP cannot be added to the group.
-   *         @param request.args.licenseTermsData.licensingConfig.expectGroupRewardPool The address of the expected group reward pool. The IP can only be added to a group with this specified reward pool address, or zero address if the IP does not want to be added to any group.
-   *     @param {Object} request.args.ipMetadata - [Optional] The desired metadata for the newly minted NFT and newly registered IP.
-   *       @param request.args.ipMetadata.ipMetadataURI [Optional] The URI of the metadata for the IP.
-   *       @param request.args.ipMetadata.ipMetadataHash [Optional] The hash of the metadata for the IP.
-   *       @param request.args.ipMetadata.nftMetadataURI [Optional] The URI of the metadata for the NFT.
-   *       @param request.args.ipMetadata.nftMetadataHash [Optional] The hash of the metadata for the IP NFT.
-   *     @param request.args.recipient [Optional] The address of the recipient of the minted NFT,default value is your wallet address.
-   *    @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property, without encodedTxData option.
-   * @returns A Promise that resolves to a transaction hash, if waitForTransaction is true, return an array containing IP ID, Token ID, License Terms Ids, SPG NFT Contract.
-   * @emits IPRegistered (ipId, chainId, tokenContract, tokenId, name, uri, registrationDate)
-   * @emits LicenseTermsAttached (caller, ipId, licenseTemplate, licenseTermsId)
+   *
+   * Emits on-chain `IPRegistered` and `LicenseTermsAttached` events.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
    */
   public async batchMintAndRegisterIpAssetWithPilTerms(
     request: BatchMintAndRegisterIpAssetWithPilTermsRequest,
@@ -694,8 +620,10 @@ export class IPAssetClient {
   }
   /**
    * Register a given NFT as an IP and attach Programmable IP License Terms.
+   *
+   * Emits on-chain `IPRegistered` and `LicenseTermsAttached` events.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
-   * for a list of on-chain events emitted when an ip is registered and license terms are attached to it.
    */
   public async registerIpAndAttachPilTerms(
     request: RegisterIpAndAttachPilTermsRequest,
@@ -726,7 +654,10 @@ export class IPAssetClient {
             ),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
+            func: getFunctionSignature({
+              abi: coreMetadataModuleAbi,
+              methodName: "setAll",
+            }),
           },
           {
             ipId: ipIdAddress,
@@ -736,14 +667,20 @@ export class IPAssetClient {
             ),
             to: getAddress(this.licensingModuleClient.address, "licensingModuleClient"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "attachLicenseTerms"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "attachLicenseTerms",
+            }),
           },
           {
             ipId: ipIdAddress,
             signer: this.licenseAttachmentWorkflowsClient.address,
             to: this.licensingModuleClient.address,
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "setLicensingConfig"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "setLicensingConfig",
+            }),
           },
         ],
       });
@@ -789,8 +726,9 @@ export class IPAssetClient {
   }
   /**
    * Register the given NFT as a derivative IP with metadata without using license tokens.
+   *
+   * Emits an on-chain `IPRegistered` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * for a list of on-chain events emitted when a derivative IP is registered.
    */
   public async registerDerivativeIp(
     request: RegisterIpAndMakeDerivativeRequest,
@@ -815,14 +753,20 @@ export class IPAssetClient {
             signer: getAddress(this.derivativeWorkflowsClient.address, "derivativeWorkflowsClient"),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
+            func: getFunctionSignature({
+              abi: coreMetadataModuleAbi,
+              methodName: "setAll",
+            }),
           },
           {
             ipId: ipIdAddress,
             signer: this.derivativeWorkflowsClient.address,
             to: getAddress(this.licensingModuleClient.address, "licensingModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "registerDerivative"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "registerDerivative",
+            }),
           },
         ],
       });
@@ -864,8 +808,9 @@ export class IPAssetClient {
   }
   /**
    * Mint an NFT from a collection and register it as a derivative IP without license tokens.
+   *
+   * Emits an on-chain `IPRegistered` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * for a list of on-chain events emitted when a derivative IP is minted and registered.
    */
   public async mintAndRegisterIpAndMakeDerivative(
     request: MintAndRegisterIpAndMakeDerivativeRequest,
@@ -908,22 +853,9 @@ export class IPAssetClient {
   }
   /**
    * Batch mint an NFT from a collection and register it as a derivative IP without license tokens.
-   * @param request - The request object that contains all data needed to batch mint and register ip and make derivative.
-   *  @param {Array} request.args The array of mint and register IP requests.
-   *   @param request.args.spgNftContract The address of the NFT collection.
-   *   @param {Object} request.args.derivData The derivative data to be used for registerDerivative.
-   *     @param {Array} request.args.derivData.parentIpIds The IDs of the parent IPs to link the registered derivative IP.
-   *     @param {Array} request.args.derivData.licenseTermsIds The IDs of the license terms to be used for the linking.
-   *     @param request.args.derivData.licenseTemplate [Optional] The address of the license template to be used for the linking.
-   *   @param {Object} request.args.ipMetadata - [Optional] The desired metadata for the newly minted NFT and newly registered IP.
-   *     @param request.args.ipMetadata.ipMetadataURI [Optional] The URI of the metadata for the IP.
-   *     @param request.args.ipMetadata.ipMetadataHash [Optional] The hash of the metadata for the IP.
-   *     @param request.args.ipMetadata.nftMetadataURI [Optional] The URI of the metadata for the NFT.
-   *     @param request.args.ipMetadata.nftMetadataHash [Optional] The hash of the metadata for the IP NFT.
-   *   @param request.arg.recipient [Optional] The address of the recipient of the minted NFT,default value is your wallet address.
-   *  @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property, without encodedTxData option.
-   * @returns A Promise that resolves to a transaction hash, if waitForTransaction is true, return an array of containing IP ID and token ID, SPG NFT Contract.
-   * @emits IPRegistered (ipId, chainId, tokenContract, tokenId, name, uri, registrationDate)
+   *
+   * Emits an on-chain `IPRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    */
   public async batchMintAndRegisterIpAndMakeDerivative(
     request: BatchMintAndRegisterIpAndMakeDerivativeRequest,
@@ -963,18 +895,9 @@ export class IPAssetClient {
   }
   /**
    * Mint an NFT from a SPGNFT collection and register it with metadata as an IP.
-   * @param request - The request object that contains all data needed to attach license terms.
-   *   @param request.spgNftContract The address of the SPGNFT collection.
-   *   @param request.recipient The address of the recipient of the minted NFT,default value is your wallet address.
-   *  @param request.allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
-   *   @param {Object} request.ipMetadata - [Optional] The desired metadata for the newly minted NFT and newly registered IP.
-   *     @param request.ipMetadata.ipMetadataURI [Optional] The URI of the metadata for the IP.
-   *     @param request.ipMetadata.ipMetadataHash [Optional] The hash of the metadata for the IP.
-   *     @param request.ipMetadata.nftMetadataURI [Optional] The URI of the metadata for the NFT.
-   *     @param request.ipMetadata.nftMetadataHash [Optional] The hash of the metadata for the IP NFT.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, or if waitForTransaction is true, includes IP ID and Token ID.
-   * @emits IPRegistered (ipId, chainId, tokenContract, tokenId, name, uri, registrationDate)
+   *
+   * Emits an on-chain `IPRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    */
   public async mintAndRegisterIp(request: MintAndRegisterIpRequest): Promise<RegisterIpResponse> {
     try {
@@ -1010,8 +933,9 @@ export class IPAssetClient {
   }
   /**
    * Register Programmable IP License Terms (if unregistered) and attach it to IP.
+   *
+   * Emits an on-chain `LicenseTermsAttached` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L19 | ILicensingModule}
-   * for a list of on-chain events emitted when a license terms is attached to an IP.
    */
   public async registerPilTermsAndAttach(
     request: RegisterPilTermsAndAttachRequest,
@@ -1043,7 +967,10 @@ export class IPAssetClient {
             ),
             to: getAddress(this.licensingModuleClient.address, "licensingModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "attachLicenseTerms"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "attachLicenseTerms",
+            }),
           },
           {
             ipId: ipId,
@@ -1053,7 +980,10 @@ export class IPAssetClient {
             ),
             to: getAddress(this.licensingModuleClient.address, "licensingModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "setLicensingConfig"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "setLicensingConfig",
+            }),
           },
         ],
       });
@@ -1091,22 +1021,11 @@ export class IPAssetClient {
     }
   }
   /**
-   *  Mint an NFT from a collection and register it as a derivative IP using license tokens
+   * Mint an NFT from a collection and register it as a derivative IP using license tokens.
    * Requires caller to have the minter role or the SPG NFT to allow public minting. Caller must own the license tokens and have approved DerivativeWorkflows to transfer them.
-   * @param request - The request object that contains all data needed to mint and register ip and make derivative with license tokens.
-   *   @param request.spgNftContract The address of the NFT collection.
-   *   @param {Array} request.licenseTokenIds The IDs of the license tokens to be burned for linking the IP to parent IPs.
-   *   @param request.allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
-   *   @param request.maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000).
-   *   @param {Object} request.ipMetadata - [Optional] The desired metadata for the newly minted NFT and newly registered IP.
-   *     @param request.ipMetadata.ipMetadataURI [Optional] The URI of the metadata for the IP.
-   *     @param request.ipMetadata.ipMetadataHash [Optional] The hash of the metadata for the IP.
-   *     @param request.ipMetadata.nftMetadataURI [Optional] The URI of the metadata for the NFT.
-   *     @param request.ipMetadata.nftMetadataHash [Optional] The hash of the metadata for the IP NFT.
-   *   @param request.recipient - [Optional] The address to receive the minted NFT,default value is your wallet address.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, or if waitForTransaction is true, includes IP ID and Token ID.
-   * @emits IPRegistered (ipId, chainId, tokenContract, tokenId, name, uri, registrationDate)
+   *
+   * Emits an on-chain `IPRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    */
   public async mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
     request: MintAndRegisterIpAndMakeDerivativeWithLicenseTokensRequest,
@@ -1159,18 +1078,9 @@ export class IPAssetClient {
   }
   /**
    * Register the given NFT as a derivative IP using license tokens.
-   * @param request - The request object that contains all data needed to register ip and make derivative with license tokens.
-   *   @param request.nftContract The address of the NFT collection.
-   *   @param {Array} request.licenseTokenIds The IDs of the license tokens to be burned for linking the IP to parent IPs.
-   *   @param request.tokenId The ID of the NFT.
-   *   @param {Object} request.ipMetadata - [Optional] The desired metadata for the newly minted NFT and newly registered IP.
-   *     @param request.ipMetadata.ipMetadataURI [Optional] The URI of the metadata for the IP.
-   *     @param request.ipMetadata.ipMetadataHash [Optional] The hash of the metadata for the IP.
-   *     @param request.ipMetadata.nftMetadataURI [Optional] The URI of the metadata for the NFT.
-   *     @param request.ipMetadata.nftMetadataHash [Optional] The hash of the metadata for the IP NFT.
-   *   @param request.deadline [Optional] The deadline for the signature in seconds, default is 1000s.
-   *   @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, or if waitForTransaction is true, includes IP ID, Token ID.
+   *
+   * Emits an on-chain `IPRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    */
   public async registerIpAndMakeDerivativeWithLicenseTokens(
     request: RegisterIpAndMakeDerivativeWithLicenseTokensRequest,
@@ -1196,14 +1106,20 @@ export class IPAssetClient {
             signer: getAddress(this.derivativeWorkflowsClient.address, "derivativeWorkflowsClient"),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
+            func: getFunctionSignature({
+              abi: coreMetadataModuleAbi,
+              methodName: "setAll",
+            }),
           },
           {
             ipId: ipIdAddress,
             signer: this.derivativeWorkflowsClient.address,
             to: getAddress(this.licensingModuleClient.address, "licensingModuleClient"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "registerDerivativeWithLicenseTokens"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "registerDerivativeWithLicenseTokens",
+            }),
           },
         ],
       });
@@ -1249,9 +1165,10 @@ export class IPAssetClient {
   /**
    * Register the given NFT and attach license terms and distribute royalty tokens. In order to successfully distribute royalty tokens, the first license terms attached to the IP must be
    * a commercial license.
+   *
+   * Emits on-chain `IPRegistered`, and `IpRoyaltyVaultDeployed` events.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88 | IRoyaltyModule}
-   * for a list of on-chain events emitted when an IP is registered, license terms are attached to an IP, and royalty tokens are distributed.
    */
   public async registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens(
     request: RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest,
@@ -1285,21 +1202,30 @@ export class IPAssetClient {
             ),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
+            func: getFunctionSignature({
+              abi: coreMetadataModuleAbi,
+              methodName: "setAll",
+            }),
           },
           {
             ipId: ipIdAddress,
             signer: this.royaltyTokenDistributionWorkflowsClient.address,
             to: getAddress(this.licensingModuleClient.address, "licensingModuleClient"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "attachLicenseTerms"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "attachLicenseTerms",
+            }),
           },
           {
             ipId: ipIdAddress,
             signer: this.royaltyTokenDistributionWorkflowsClient.address,
             to: this.licensingModuleClient.address,
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "setLicensingConfig"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "setLicensingConfig",
+            }),
           },
         ],
       });
@@ -1356,9 +1282,10 @@ export class IPAssetClient {
   /**
    * Register the given NFT as a derivative IP and attach license terms and distribute royalty tokens.  In order to successfully distribute royalty tokens, the license terms attached to the IP must be
    * a commercial license.
+   *
+   * Emits on-chain `IPRegistered` and `IpRoyaltyVaultDeployed` events.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88| IRoyaltyModule}
-   * for a list of on-chain events emitted when a derivative IP is registered, license terms are attached to an IP, and royalty tokens are distributed.
    */
   public async registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens(
     request: RegisterDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest,
@@ -1381,14 +1308,20 @@ export class IPAssetClient {
             ),
             to: getAddress(this.coreMetadataModuleClient.address, "coreMetadataModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(coreMetadataModuleAbi, "setAll"),
+            func: getFunctionSignature({
+              abi: coreMetadataModuleAbi,
+              methodName: "setAll",
+            }),
           },
           {
             ipId: ipIdAddress,
             signer: this.royaltyTokenDistributionWorkflowsClient.address,
             to: getAddress(this.licensingModuleClient.address, "licensingModuleAddress"),
             permission: AccessPermission.ALLOW,
-            func: getFunctionSignature(licensingModuleAbi, "registerDerivative"),
+            func: getFunctionSignature({
+              abi: licensingModuleAbi,
+              methodName: "registerDerivative",
+            }),
           },
         ],
       });
@@ -1469,9 +1402,10 @@ export class IPAssetClient {
 
   /**
    * Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
+   *
+   * Emits on-chain `IPRegistered` and `IpRoyaltyVaultDeployed` events.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/royalty/IRoyaltyModule.sol#L88| IRoyaltyModule}
-   * for a list of on-chain events emitted when an IP is minted and registered, PIL terms are attached to an IP, and royalty tokens are distributed.
    */
   public async mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens(
     request: MintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokensRequest,
@@ -1532,8 +1466,9 @@ export class IPAssetClient {
   }
   /**
    * Mint an NFT and register the IP, make a derivative, and distribute royalty tokens.
+   *
+   * Emits on-chain `IPRegistered` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
-   * for a list of on-chain events emitted when an IP is minted and registered, a derivative IP is made, and royalty tokens are distributed.
    */
   public async mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens(
     request: MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensRequest,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -170,6 +170,7 @@ export class IPAssetClient {
 
   /**
    * Registers an NFT as IP, creating a corresponding IP record.
+   *
    * Emits an on-chain `IPRegistered` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    */
@@ -259,9 +260,9 @@ export class IPAssetClient {
 
   /**
    * Batch registers an NFT as IP, creating a corresponding IP record.
-   
-  * Emits an on-chain `IPRegistered` event.
-  * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
+   *
+   * Emits an on-chain `IPRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | IIPAssetRegistry}
    */
   public async batchRegister(request: BatchRegisterRequest): Promise<BatchRegisterResponse> {
     try {
@@ -376,8 +377,7 @@ export class IPAssetClient {
 
   /**
    * Batch registers a derivative directly with parent IP's license terms.
-
-  */
+   */
   public async batchRegisterDerivative(
     request: BatchRegisterDerivativeRequest,
   ): Promise<BatchRegisterDerivativeResponse> {

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -82,27 +82,9 @@ export class LicenseClient {
   }
   /**
    * Registers new license terms and return the ID of the newly registered license terms.
-   * @param request - The request object that contains all data needed to register a license term.
-   *   @param request.transferable Indicates whether the license is transferable or not.
-   *   @param request.royaltyPolicy The address of the royalty policy contract which required to StoryProtocol in advance.
-   *   @param request.mintingFee The fee to be paid when minting a license.
-   *   @param request.expiration The expiration period of the license.
-   *   @param request.commercialUse Indicates whether the work can be used commercially or not.
-   *   @param request.commercialAttribution Whether attribution is required when reproducing the work commercially or not.
-   *   @param request.commercializerChecker Commercializers that are allowed to commercially exploit the work. If zero address, then no restrictions is enforced.
-   *   @param request.commercializerCheckerData The data to be passed to the commercializer checker contract.
-   *   @param request.commercialRevShare Percentage of revenue that must be shared with the licensor.
-   *   @param request.commercialRevCeiling The maximum revenue that can be generated from the commercial use of the work.
-   *   @param request.derivativesAllowed Indicates whether the licensee can create derivatives of his work or not.
-   *   @param request.derivativesAttribution Indicates whether attribution is required for derivatives of the work or not.
-   *   @param request.derivativesApproval Indicates whether the licensor must approve derivatives of the work before they can be linked to the licensor IP ID or not.
-   *   @param request.derivativesReciprocal Indicates whether the licensee must license derivatives of the work under the same terms or not.
-   *   @param request.derivativeRevCeiling The maximum revenue that can be generated from the derivative use of the work.
-   *   @param request.currency The ERC20 token to be used to pay the minting fee. the token must be registered in story protocol.
-   *   @param request.uri The URI of the license terms, which can be used to fetch the offchain license terms.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes license terms Id.
-   * @emits LicenseTermsRegistered (licenseTermsId, licenseTemplate, licenseTerms);
+   *
+   * Emits an on-chain `LicenseTermsRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | ILicenseTemplate}
    */
   public async registerPILTerms(request: RegisterPILTermsRequest): Promise<RegisterPILResponse> {
     try {
@@ -139,10 +121,9 @@ export class LicenseClient {
   }
   /**
    * Convenient function to register a PIL non commercial social remix license to the registry
-   * @param request - [Optional] The request object that contains all data needed to register a PIL non commercial social remix license.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes license terms Id.
-   * @emits LicenseTermsRegistered (licenseTermsId, licenseTemplate, licenseTerms);
+   *
+   * Emits an on-chain `LicenseTermsRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | ILicenseTemplate}
    */
   public async registerNonComSocialRemixingPIL(
     request?: RegisterNonComSocialRemixingPILRequest,
@@ -181,13 +162,9 @@ export class LicenseClient {
   }
   /**
    * Convenient function to register a PIL commercial use license to the registry.
-   * @param request - The request object that contains all data needed to register a PIL commercial use license.
-   *   @param request.defaultMintingFee The fee to be paid when minting a license.
-   *   @param request.currency The ERC20 token to be used to pay the minting fee and the token must be registered in story protocol.
-   *   @param request.royaltyPolicyAddress [Optional] The address of the royalty policy contract, default value is LAP.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes license terms Id.
-   * @emits LicenseTermsRegistered (licenseTermsId, licenseTemplate, licenseTerms);
+   *
+   * Emits an on-chain `LicenseTermsRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | ILicenseTemplate}
    */
   public async registerCommercialUsePIL(
     request: RegisterCommercialUsePILRequest,
@@ -233,14 +210,9 @@ export class LicenseClient {
   }
   /**
    * Convenient function to register a PIL commercial Remix license to the registry.
-   * @param request - The request object that contains all data needed to register license.
-   *   @param request.defaultMintingFee The fee to be paid when minting a license.
-   *   @param request.commercialRevShare Percentage of revenue that must be shared with the licensor.
-   *   @param request.currency The ERC20 token to be used to pay the minting fee. the token must be registered in story protocol.
-   *   @param request.royaltyPolicyAddress [Optional] The address of the royalty policy contract, default value is LAP.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes license terms Id.
-   * @emits LicenseTermsRegistered (licenseTermsId, licenseTemplate, licenseTerms);
+   *
+   * Emits an on-chain `LicenseTermsRegistered` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | ILicenseTemplate}
    */
   public async registerCommercialRemixPIL(
     request: RegisterCommercialRemixPILRequest,
@@ -288,13 +260,6 @@ export class LicenseClient {
 
   /**
    * Attaches license terms to an IP.
-   * @param request - The request object that contains all data needed to attach license terms.
-   *   @param request.ipId The address of the IP to which the license terms are attached.
-   *   @param request.licenseTemplate The address of the license template, default value is Programmable IP License.
-   *   @param request.licenseTermsId The ID of the license terms.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes success.
-   * If Ip have attached license terms, success will return false and txhash is empty.
    */
   public async attachLicenseTerms(
     request: AttachLicenseTermsRequest,
@@ -361,17 +326,9 @@ export class LicenseClient {
    * The minting fee is paid in the minting fee token specified in the license terms or configured by the IP owner.
    * IP owners can configure the minting fee of their IPs or
    * configure the minting fee module to determine the minting fee.
-   * @param request - The request object that contains all data needed to mint license tokens.
-   *   @param request.licensorIpId The licensor IP ID.
-   *   @param request.licenseTemplate The address of the license template, default value is Programmable IP License.
-   *   @param request.licenseTermsId The ID of the license terms within the license template.
-   *   @param request.amount The amount of license tokens to mint.
-   *   @param request.receiver The address of the receiver.
-   *   @param request.maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
-   *   @param request.maxRevenueShare The maximum revenue share percentage allowed for minting the License Tokens. Must be between 0 and 100,000,000 (where 100,000,000 represents 100%).
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes license token IDs.
-   * @emits LicenseTokensMinted (msg.sender, licensorIpId, licenseTemplate, licenseTermsId, amount, receiver, startLicenseTokenId);
+   *
+   * Emits an on-chain `LicenseTokensMinted` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L34 | ILicensingModule}
    */
   public async mintLicenseTokens(
     request: MintLicenseTokensRequest,
@@ -476,8 +433,6 @@ export class LicenseClient {
 
   /**
    * Gets license terms of the given ID.
-   * @param selectedLicenseTermsId The ID of the license terms.
-   * @returns A Promise that resolves to an object containing the PILTerms associate with the given ID.
    */
   public async getLicenseTerms(
     selectedLicenseTermsId: LicenseTermsId,
@@ -493,14 +448,6 @@ export class LicenseClient {
 
   /**
    * Pre-compute the minting license fee for the given IP and license terms. The function can be used to calculate the minting license fee before minting license tokens.
-   * @param request - The request object that contains all data needed to predict minting licenses fee.
-   *   @param request.licensorIpId The IP ID of the licensor.
-   *   @param request.licenseTermsId The ID of the license terms.
-   *   @param request.amount The amount of license tokens to mint.
-   *   @param request.licenseTemplate [Optional] The address of the license template, default value is Programmable IP License.
-   *   @param request.receiver [Optional] The address of the receiver,default value is your wallet address.
-   *   @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to an object containing the currency token and token amount.
    */
   public async predictMintingLicenseFee(
     request: PredictMintingLicenseFeeRequest,

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -83,8 +83,7 @@ export class LicenseClient {
   /**
    * Registers new license terms and return the ID of the newly registered license terms.
    *
-   * Emits an on-chain `LicenseTermsRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | ILicenseTemplate}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | `LicenseTermsRegistered`} event.
    */
   public async registerPILTerms(request: RegisterPILTermsRequest): Promise<RegisterPILResponse> {
     try {
@@ -122,8 +121,7 @@ export class LicenseClient {
   /**
    * Convenient function to register a PIL non commercial social remix license to the registry
    *
-   * Emits an on-chain `LicenseTermsRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | ILicenseTemplate}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | `LicenseTermsRegistered`} event.
    */
   public async registerNonComSocialRemixingPIL(
     request?: RegisterNonComSocialRemixingPILRequest,
@@ -163,8 +161,7 @@ export class LicenseClient {
   /**
    * Convenient function to register a PIL commercial use license to the registry.
    *
-   * Emits an on-chain `LicenseTermsRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | ILicenseTemplate}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | `LicenseTermsRegistered`} event.
    */
   public async registerCommercialUsePIL(
     request: RegisterCommercialUsePILRequest,
@@ -211,8 +208,7 @@ export class LicenseClient {
   /**
    * Convenient function to register a PIL commercial Remix license to the registry.
    *
-   * Emits an on-chain `LicenseTermsRegistered` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | ILicenseTemplate}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | `LicenseTermsRegistered`} event.
    */
   public async registerCommercialRemixPIL(
     request: RegisterCommercialRemixPILRequest,
@@ -327,8 +323,7 @@ export class LicenseClient {
    * IP owners can configure the minting fee of their IPs or
    * configure the minting fee module to determine the minting fee.
    *
-   * Emits an on-chain `LicenseTokensMinted` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L34 | ILicensingModule}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicensingModule.sol#L34 | `LicenseTokensMinted`} event.
    */
   public async mintLicenseTokens(
     request: MintLicenseTokensRequest,

--- a/packages/core-sdk/src/resources/nftClient.ts
+++ b/packages/core-sdk/src/resources/nftClient.ts
@@ -27,21 +27,9 @@ export class NftClient {
 
   /**
    * Creates a new SPG NFT Collection.
-   * @param request - The request object containing necessary data to create a SPG NFT Collection.
-   *   @param request.name - The name of the collection.
-   * 	 @param request.symbol - The symbol of the collection.
-   * 	 @param request.isPublicMinting - If true, anyone can mint from the collection. If false, only the addresses with the minter role can mint.
-   * 	 @param request.mintOpen Whether the collection is open for minting on creation.
-   *   @param request.mintFeeRecipient - The address to receive mint fees.
-   *   @param request.contractURI - The contract URI for the collection. Follows ERC-7572 standard. See https://eips.ethereum.org/EIPS/eip-7572
-   * 	 @param request.baseURI - [Optional] The base URI for the collection. If baseURI is not empty, tokenURI will be either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
-   * 	 @param request.maxSupply - [Optional] The maximum supply of the collection.
-   * 	 @param request.mintFee - [Optional] The cost to mint a token.
-   * 	 @param request.mintFeeToken - [Optional] The token to mint.
-   * 	 @param request.owner - [Optional] The owner of the collection.
-   *   @param request.txOptions [Optional] This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to a transaction hash, and if encodedTxDataOnly is true, includes encoded transaction data, and if waitForTransaction is true, includes spg nft contract address.
-   * @emits CollectionCreated (spgNftContract);
+   *
+   * Emits an on-chain `CollectionCreated` event.
+   * @see {@link https://github.com/storyprotocol/protocol-periphery-v1/blob/v1.3.1/contracts/interfaces/workflows/IRegistrationWorkflows.sol#L12 | IRegistrationWorkflows}
    */
   public async createNFTCollection(
     request: CreateNFTCollectionRequest,

--- a/packages/core-sdk/src/resources/permission.ts
+++ b/packages/core-sdk/src/resources/permission.ts
@@ -81,6 +81,7 @@ export class PermissionClient {
   }
   /**
    * Specific permission overrides wildcard permission with signature.
+   * 
    * Emits an on-chain `PermissionSet` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
@@ -150,6 +151,7 @@ export class PermissionClient {
   }
   /**
    * Sets permission to a signer for all functions across all modules.
+   * 
    * Emits an on-chain `PermissionSet` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
@@ -183,6 +185,7 @@ export class PermissionClient {
   }
   /**
    * Sets a batch of permissions in a single transaction.
+   * 
    * Emits an on-chain `PermissionSet` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
@@ -223,6 +226,7 @@ export class PermissionClient {
   }
   /**
    * Sets a batch of permissions in a single transaction with signature.
+   * 
    * Emits an on-chain `PermissionSet` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */

--- a/packages/core-sdk/src/resources/permission.ts
+++ b/packages/core-sdk/src/resources/permission.ts
@@ -40,24 +40,14 @@ export class PermissionClient {
   }
 
   /**
-   * Sets the permission for a specific function call
+   * Sets the permission for a specific function call.
    * Each policy is represented as a mapping from an IP account address to a signer address to a recipient
-   * address to a function selector to a permission level. The permission level can be 0 (ABSTAIN), 1 (ALLOW), or
-   * 2 (DENY).
-   * By default, all policies are set to 0 (ABSTAIN), which means that the permission is not set.
+   * address to a function selector to a permission level. The permission level is an enum of `AccessPermission`.
+   * By default, all policies are set to ABSTAIN, which means that the permission is not set.
    * The owner of ipAccount by default has all permission.
-   * address(0) => wildcard
-   * bytes4(0) => wildcard
-   * Specific permission overrides wildcard permission.
-   * @param request - The request object containing necessary data to set `permission`.
-   *   @param request.ipId The IP ID that grants the permission for `signer`.
-   *   @param request.signer The address that can call `to` on behalf of the `ipAccount`.
-   *   @param request.to The address that can be called by the `signer` (currently only modules can be `to`).
-   *   @param request.permission The new permission level.
-   *   @param request.func [Optional] The function selector string of `to` that can be called by the `signer` on behalf of the `ipAccount`. Be default, it allows all functions.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to an object containing the transaction hash.
-   * @emits PermissionSet (ipAccountOwner, ipAccount, signer, to, func, permission)
+   *
+   * Emits an on-chain `PermissionSet` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
   public async setPermission(request: SetPermissionsRequest): Promise<SetPermissionsResponse> {
     try {
@@ -91,16 +81,8 @@ export class PermissionClient {
   }
   /**
    * Specific permission overrides wildcard permission with signature.
-   * @param request - The request object containing necessary data to set permissions.
-   *   @param request.ipId The IP ID that grants the permission for `signer`
-   *   @param request.signer The address that can call `to` on behalf of the `ipAccount`
-   *   @param request.to The address that can be called by the `signer` (currently only modules can be `to`)
-   *   @param request.permission The new permission level.
-   *   @param request.func [Optional] The function selector string of `to` that can be called by the `signer` on behalf of the `ipAccount`. Be default, it allows all functions.
-   *   @param request.deadline [Optional] The deadline for the signature in seconds, default is 1000s.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to an object containing the transaction hash.
-   * @emits PermissionSet (ipAccountOwner, ipAccount, signer, to, func, permission)
+   * Emits an on-chain `PermissionSet` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
   public async createSetPermissionSignature(
     request: CreateSetPermissionSignatureRequest,
@@ -168,13 +150,8 @@ export class PermissionClient {
   }
   /**
    * Sets permission to a signer for all functions across all modules.
-   * @param request - The request object containing necessary data to set all permissions.
-   *   @param request.ipId The IP ID that grants the permission for `signer`
-   *   @param request.signer The address of the signer receiving the permissions.
-   *   @param request.permission The new permission.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to an object containing the transaction hash
-   * @emits PermissionSet (ipAccountOwner, ipAccount, signer, to, func, permission)
+   * Emits an on-chain `PermissionSet` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
   public async setAllPermissions(
     request: SetAllPermissionsRequest,
@@ -206,17 +183,8 @@ export class PermissionClient {
   }
   /**
    * Sets a batch of permissions in a single transaction.
-   * @param request - The request object containing necessary data to set all permissions.
-   * @param {Array} request.permissions - An array of `Permission` structure, each representing the permission to be set.
-   *   @param request.permissions[].ipId The IP ID that grants the permission for `signer`.
-   *   @param request.permissions[].signer The address that can call `to` on behalf of the `ipAccount`.
-   *   @param request.permissions[].to The address that can be called by the `signer` (currently only modules can be `to`).
-   *   @param request.permissions[].permission The new permission level.
-   *   @param request.permissions[].func [Optional] The function selector string of `to` that can be called by the `signer` on behalf of the `ipAccount`. Be default, it allows all functions.
-   *   @param request.deadline [Optional] The deadline for the signature in milliseconds, default is 1000ms.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to an object containing the transaction hash
-   * @emits PermissionSet (ipAccountOwner, ipAccount, signer, to, func, permission)
+   * Emits an on-chain `PermissionSet` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
   public async setBatchPermissions(
     request: SetBatchPermissionsRequest,
@@ -255,18 +223,8 @@ export class PermissionClient {
   }
   /**
    * Sets a batch of permissions in a single transaction with signature.
-   * @param request - The request object containing necessary data to set permissions.
-   *   @param request.ipId The IP ID that grants the permission for `signer`
-   *   @param {Array} request.permissions - An array of `Permission` structure, each representing the permission to be set.
-   *   @param request.permissions[].ipId The IP ID that grants the permission for `signer`.
-   *   @param request.permissions[].signer The address that can call `to` on behalf of the `ipAccount`.
-   *   @param request.permissions[].to The address that can be called by the `signer` (currently only modules can be `to`).
-   *   @param request.permissions[].permission The new permission level.
-   *   @param request.permissions[].func [Optional] The function selector string of `to` that can be called by the `signer` on behalf of the `ipAccount`. Be default, it allows all functions.
-   *   @param request.deadline [Optional] The deadline for the signature in seconds, default is 1000s.
-   *   @param request.txOptions - [Optional] transaction. This extends `WaitForTransactionReceiptParameters` from the Viem library, excluding the `hash` property.
-   * @returns A Promise that resolves to an object containing the transaction hash.
-   * @emits PermissionSet (ipAccountOwner, ipAccount, signer, to, func, permission)
+   * Emits an on-chain `PermissionSet` event.
+   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
   public async createBatchPermissionSignature(
     request: CreateBatchPermissionSignatureRequest,

--- a/packages/core-sdk/src/resources/permission.ts
+++ b/packages/core-sdk/src/resources/permission.ts
@@ -81,7 +81,7 @@ export class PermissionClient {
   }
   /**
    * Specific permission overrides wildcard permission with signature.
-   * 
+   *
    * Emits an on-chain `PermissionSet` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
@@ -151,7 +151,7 @@ export class PermissionClient {
   }
   /**
    * Sets permission to a signer for all functions across all modules.
-   * 
+   *
    * Emits an on-chain `PermissionSet` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
@@ -185,7 +185,7 @@ export class PermissionClient {
   }
   /**
    * Sets a batch of permissions in a single transaction.
-   * 
+   *
    * Emits an on-chain `PermissionSet` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */
@@ -226,7 +226,7 @@ export class PermissionClient {
   }
   /**
    * Sets a batch of permissions in a single transaction with signature.
-   * 
+   *
    * Emits an on-chain `PermissionSet` event.
    * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
    */

--- a/packages/core-sdk/src/resources/permission.ts
+++ b/packages/core-sdk/src/resources/permission.ts
@@ -46,8 +46,7 @@ export class PermissionClient {
    * By default, all policies are set to ABSTAIN, which means that the permission is not set.
    * The owner of ipAccount by default has all permission.
    *
-   * Emits an on-chain `PermissionSet` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | `PermissionSet`} event.
    */
   public async setPermission(request: SetPermissionsRequest): Promise<SetPermissionsResponse> {
     try {
@@ -82,8 +81,7 @@ export class PermissionClient {
   /**
    * Specific permission overrides wildcard permission with signature.
    *
-   * Emits an on-chain `PermissionSet` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | `PermissionSet`} event.
    */
   public async createSetPermissionSignature(
     request: CreateSetPermissionSignatureRequest,
@@ -152,8 +150,7 @@ export class PermissionClient {
   /**
    * Sets permission to a signer for all functions across all modules.
    *
-   * Emits an on-chain `PermissionSet` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | `PermissionSet`} event.
    */
   public async setAllPermissions(
     request: SetAllPermissionsRequest,
@@ -186,8 +183,7 @@ export class PermissionClient {
   /**
    * Sets a batch of permissions in a single transaction.
    *
-   * Emits an on-chain `PermissionSet` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | `PermissionSet`} event.
    */
   public async setBatchPermissions(
     request: SetBatchPermissionsRequest,
@@ -227,8 +223,7 @@ export class PermissionClient {
   /**
    * Sets a batch of permissions in a single transaction with signature.
    *
-   * Emits an on-chain `PermissionSet` event.
-   * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | IAccessController}
+   * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/access/IAccessController.sol#L13 | `PermissionSet`} event.
    */
   public async createBatchPermissionSignature(
     request: CreateBatchPermissionSignatureRequest,

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -309,11 +309,6 @@ export class RoyaltyClient {
 
   /**
    * Get total amount of revenue token claimable by a royalty token holder.
-   * @param request - The request object that contains all data needed to claim Revenue.
-   *   @param request.royaltyVaultIpId The id of the royalty vault.
-   *   @param request.claimer The address of the royalty token holder
-   *   @param request.token The revenue token to claim.
-   * @returns A Promise that contains the amount of revenue token claimable
    */
   public async claimableRevenue(
     request: ClaimableRevenueRequest,
@@ -334,8 +329,6 @@ export class RoyaltyClient {
 
   /**
    * Get the royalty vault proxy address of given royaltyVaultIpId.
-   * @param royaltyVaultIpId the id of the royalty vault.
-   * @returns A Promise that resolves to an object containing the royalty vault address.
    */
   public async getRoyaltyVaultAddress(royaltyVaultIpId: Hex): Promise<Address> {
     const isRoyaltyVaultIpIdRegistered = await this.ipAssetRegistryClient.isRegistered({

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -319,6 +319,7 @@ export class RoyaltyClient {
 
   /**
    * Get total amount of revenue token claimable by a royalty token holder.
+   * Returns the amount of revenue token claimable by the claimer.
    */
   public async claimableRevenue(
     request: ClaimableRevenueRequest,

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -67,8 +67,8 @@ export class RoyaltyClient {
    * If claimed token is WIP, it will also be converted back to IP.
    *
    * @remarks
-   * Even if there are no child IPs, you must still populate {@link ClaimAllRevenueRequest.currencyTokens}
-   * with the token addresses you wish to claim. This is required for the claim operation to know which
+   * Even if there are no child IPs, you must still populate {@link ClaimAllRevenueRequest.currencyTokens} with
+   * the token addresses you wish to claim. This is required for the claim operation to know which
    * token balances to process.
    */
   public async claimAllRevenue(req: ClaimAllRevenueRequest): Promise<ClaimAllRevenueResponse> {

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -62,9 +62,14 @@ export class RoyaltyClient {
     this.walletAddress = wallet.account!.address;
   }
   /**
-   * Claims all revenue from the child IPs of an ancestor IP, then transfer.
+   * Claims all revenue from the child IPs of an ancestor IP, then transfer
    * all claimed tokens to the wallet if the wallet owns the IP or is the claimer.
    * If claimed token is WIP, it will also be converted back to IP.
+   *
+   * @remarks
+   * Even if there are no child IPs, you must still populate {@link ClaimAllRevenueRequest.currencyTokens}
+   * with the token addresses you wish to claim. This is required for the claim operation to know which
+   * token balances to process.
    */
   public async claimAllRevenue(req: ClaimAllRevenueRequest): Promise<ClaimAllRevenueResponse> {
     try {
@@ -122,6 +127,11 @@ export class RoyaltyClient {
    * if multicall is disabled, it will call @link{claimAllRevenue} for each ancestor IP.
    * Then transfer all claimed tokens to the wallet if the wallet owns the IP or is the claimer.
    * If claimed token is WIP, it will also be converted back to IP.
+   *
+   * @remarks
+   * Even if there are no child IPs, you must still populate `currencyTokens` in each ancestor IP
+   * with the token addresses you wish to claim. This is required for the claim operation to know which
+   * token balances to process.
    */
   public async batchClaimAllRevenue(
     request: BatchClaimAllRevenueRequest,

--- a/packages/core-sdk/src/types/common.ts
+++ b/packages/core-sdk/src/types/common.ts
@@ -12,6 +12,12 @@ export type IpMetadataAndTxOptions = WithTxOptions & {
   /** The desired metadata for the newly minted NFT and newly registered IP. */
   ipMetadata?: Partial<IpMetadataForWorkflow>;
 };
+
+/**
+ * This data used IP owners to define the configuration
+ * when others are minting license tokens of their IP through the LicensingModule.
+ * @see {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/lib/Licensing.sol#L27 | Licensing.sol}
+ */
 export type LicensingConfig = {
   /** Whether the configuration is set or not */
   isSet: boolean;
@@ -19,7 +25,10 @@ export type LicensingConfig = {
   mintingFee: bigint | string | number;
   /** The hook contract address for the licensing module, or zero address if none. */
   licensingHook: Address;
-  /** The data to be used by the licensing hook. */
+  /**
+   * The data to be used by the licensing hook.
+   * Set to a zero hash if no data is provided.
+   */
   hookData: Hex;
   /** The commercial revenue share percentage (from 0 to 100%, represented as 100_000_000). */
   commercialRevShare: number | string;

--- a/packages/core-sdk/src/types/resources/dispute.ts
+++ b/packages/core-sdk/src/types/resources/dispute.ts
@@ -54,7 +54,7 @@ export type CancelDisputeResponse = {
 export type ResolveDisputeRequest = {
   disputeId: number | string | bigint;
   /** The data to resolve the dispute. */
-  data: Hex;
+  data: Address;
   txOptions?: TxOptions;
 };
 

--- a/packages/core-sdk/src/types/resources/dispute.ts
+++ b/packages/core-sdk/src/types/resources/dispute.ts
@@ -41,6 +41,7 @@ export type RaiseDisputeResponse = {
 
 export type CancelDisputeRequest = {
   disputeId: number | string | bigint;
+  /** Additional data used in the cancellation process. */
   data?: Address;
   txOptions?: TxOptions;
 };
@@ -52,7 +53,8 @@ export type CancelDisputeResponse = {
 
 export type ResolveDisputeRequest = {
   disputeId: number | string | bigint;
-  data: Address;
+  /** The data to resolve the dispute. */
+  data: Hex;
   txOptions?: TxOptions;
 };
 

--- a/packages/core-sdk/src/types/resources/dispute.ts
+++ b/packages/core-sdk/src/types/resources/dispute.ts
@@ -54,7 +54,7 @@ export type CancelDisputeResponse = {
 export type ResolveDisputeRequest = {
   disputeId: number | string | bigint;
   /** The data to resolve the dispute. */
-  data: Address;
+  data: Hex;
   txOptions?: TxOptions;
 };
 

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -9,7 +9,7 @@ export type LicenseData = {
   licensingConfig?: LicensingConfig;
   /**
    * The address of the license template.
-   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | PIL} address if not provided.
    */
   licenseTemplate?: Address;
 };

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -7,6 +7,10 @@ import { IpMetadataAndTxOptions, LicensingConfig, ValidatedLicensingConfig } fro
 export type LicenseData = {
   licenseTermsId: string | bigint | number;
   licensingConfig?: LicensingConfig;
+  /**
+   * The address of the license template.
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
+   */
   licenseTemplate?: Address;
 };
 

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -44,6 +44,7 @@ export type MintAndRegisterIpAndAttachLicenseAndAddToGroupResponse = {
   tokenId?: bigint;
 };
 export type RegisterGroupRequest = {
+  /** The address specifying how royalty will be split amongst the pool of IPs in the group. */
   groupPool: Address;
   txOptions?: TxOptions;
 };

--- a/packages/core-sdk/src/types/resources/ipAccount.ts
+++ b/packages/core-sdk/src/types/resources/ipAccount.ts
@@ -5,9 +5,13 @@ import { EncodedTxData } from "../../abi/generated";
 import { TokenAmountInput } from "../common";
 
 export type IPAccountExecuteRequest = {
+  /** The IP ID to get IP Account {@link https://docs.story.foundation/docs/ip-account}. */
   ipId: Address;
+  /** The recipient of the transaction. */
   to: Address;
+  /** The amount of IP to send. */
   value: number;
+  /** The data to send along with the transaction. */
   data: Address;
   txOptions?: TxOptions;
 };
@@ -18,12 +22,19 @@ export type IPAccountExecuteResponse = {
 };
 
 export type IPAccountExecuteWithSigRequest = {
+  /** The IP ID to get IP Account {@link https://docs.story.foundation/docs/ip-account}.*/
   ipId: Address;
+  /** The recipient of the transaction. */
   to: Address;
+  /** The data to send along with the transaction. */
   data: Address;
+  /** The signer of the transaction. */
   signer: Address;
+  /** The deadline of the transaction signature in seconds. */
   deadline: number | bigint | string;
+  /** The signature of the transaction, EIP-712 encoded. The helper method `getPermissionSignature` supports generating the signature. */
   signature: Address;
+  /** The amount of IP to send. */
   value?: number | bigint | string;
   txOptions?: TxOptions;
 };

--- a/packages/core-sdk/src/types/resources/ipAccount.ts
+++ b/packages/core-sdk/src/types/resources/ipAccount.ts
@@ -5,7 +5,7 @@ import { EncodedTxData } from "../../abi/generated";
 import { TokenAmountInput } from "../common";
 
 export type IPAccountExecuteRequest = {
-  /** The IP ID to get IP Account {@link https://docs.story.foundation/docs/ip-account}. */
+  /** The IP ID of the IP Account {@link https://docs.story.foundation/docs/ip-account}. */
   ipId: Address;
   /** The recipient of the transaction. */
   to: Address;

--- a/packages/core-sdk/src/types/resources/ipAccount.ts
+++ b/packages/core-sdk/src/types/resources/ipAccount.ts
@@ -22,7 +22,7 @@ export type IPAccountExecuteResponse = {
 };
 
 export type IPAccountExecuteWithSigRequest = {
-  /** The IP ID to get IP Account {@link https://docs.story.foundation/docs/ip-account}.*/
+  /** The IP ID of the IP Account {@link https://docs.story.foundation/docs/ip-account}.*/
   ipId: Address;
   /** The recipient of the transaction. */
   to: Address;

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -25,7 +25,10 @@ export type DerivativeData = {
    * @default 100
    */
   maxRevenueShare?: number | string;
-  /** The license template address, default value is Programmable IP License. */
+  /**
+   * The address of the license template.
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
+   */
   licenseTemplate?: Address;
 };
 export type InternalDerivativeData = {

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -42,14 +42,23 @@ export type RegisterIpResponse = RegistrationResponse & {
 };
 
 export type RegisterRequest = {
+  /** The address of the NFT. */
   nftContract: Address;
+  /** The token identifier of the NFT. */
   tokenId: string | number | bigint;
+  /**
+   * The deadline of the transaction signature in seconds.
+   * @default 1000
+   */
   deadline?: string | number | bigint;
 } & IpMetadataAndTxOptions;
 
 export type RegisterDerivativeWithLicenseTokensRequest = {
+  /** The derivative IP ID. */
   childIpId: Address;
+  /** The IDs of the license tokens. */
   licenseTokenIds: string[] | bigint[] | number[];
+  /** The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000). */
   maxRts: number | string;
   txOptions?: TxOptions;
 };
@@ -174,6 +183,7 @@ type IPMetadataInfo = {
 export type MintAndRegisterIpRequest = IpMetadataAndTxOptions &
   WithWipOptions & {
     spgNftContract: Address;
+    /** The address of the recipient of the minted NFT. If not provided, the function will use the user's own wallet address. */
     recipient?: Address;
     /**
      * Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -200,8 +210,11 @@ export type RegisterPilTermsAndAttachResponse = {
 
 export type MintAndRegisterIpAndMakeDerivativeWithLicenseTokensRequest = {
   spgNftContract: Address;
+  /** The IDs of the license tokens to be burned for linking the IP to parent IPs. */
   licenseTokenIds: string[] | bigint[] | number[];
+  /** The address of the recipient of the minted NFT. If not provided, the function will use the user's own wallet address. */
   recipient?: Address;
+  /** The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000). */
   maxRts: number | string;
   /**
    * Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -214,9 +227,15 @@ export type MintAndRegisterIpAndMakeDerivativeWithLicenseTokensRequest = {
 export type RegisterIpAndMakeDerivativeWithLicenseTokensRequest = {
   nftContract: Address;
   tokenId: string | number | bigint;
+  /** The IDs of the license tokens to be burned for linking the IP to parent IPs. */
   licenseTokenIds: string[] | bigint[] | number[];
-  deadline?: string | number | bigint;
+  /** The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000). */
   maxRts: number | string;
+  /**
+   * The deadline for the signature in seconds.
+   * @default 1000
+   */
+  deadline?: string | number | bigint;
 } & IpMetadataAndTxOptions &
   WithWipOptions;
 
@@ -237,6 +256,9 @@ export type BatchMintAndRegisterIpAssetWithPilTermsResponse = {
 
 export type BatchRegisterDerivativeRequest = {
   args: RegisterDerivativeRequest[];
+  /** The deadline for the signature in seconds.
+   * @default 1000
+   */
   deadline?: string | number | bigint;
   txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
 };

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -27,7 +27,7 @@ export type DerivativeData = {
   maxRevenueShare?: number | string;
   /**
    * The address of the license template.
-   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} address if not provided.
    */
   licenseTemplate?: Address;
 };

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -102,7 +102,7 @@ export type MintAndRegisterIpAssetWithPilTermsRequest = {
   allowDuplicates?: boolean;
   /** The data of the license and its configuration to be attached to the IP. */
   licenseTermsData: LicenseTermsData[];
-  /** The address to receive the minted NFT. If not provided, the function will use the user's own wallet address. */
+  /** The address to receive the minted NFT. If not provided, the client's own wallet address will be used. */
   recipient?: Address;
 } & IpMetadataAndTxOptions &
   WithWipOptions;
@@ -160,7 +160,7 @@ export type MintAndRegisterIpAndMakeDerivativeRequest = {
   spgNftContract: Address;
   /** The derivative data to be used for register derivative. */
   derivData: DerivativeData;
-  /** The address to receive the minted NFT. If not provided, the function will use the user's own wallet address. */
+  /** The address to receive the minted NFT. If not provided, the client's own wallet address will be used. */
   recipient?: Address;
   /**
    * Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -186,7 +186,7 @@ type IPMetadataInfo = {
 export type MintAndRegisterIpRequest = IpMetadataAndTxOptions &
   WithWipOptions & {
     spgNftContract: Address;
-    /** The address of the recipient of the minted NFT. If not provided, the function will use the user's own wallet address. */
+    /** The address of the recipient of the minted NFT. If not provided, the client's own wallet address will be used. */
     recipient?: Address;
     /**
      * Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -215,7 +215,7 @@ export type MintAndRegisterIpAndMakeDerivativeWithLicenseTokensRequest = {
   spgNftContract: Address;
   /** The IDs of the license tokens to be burned for linking the IP to parent IPs. */
   licenseTokenIds: string[] | bigint[] | number[];
-  /** The address of the recipient of the minted NFT. If not provided, the function will use the user's own wallet address. */
+  /** The address of the recipient of the minted NFT. If not provided, the client's own wallet address will be used. */
   recipient?: Address;
   /** The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000). */
   maxRts: number | string;
@@ -366,7 +366,7 @@ export type MintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokensRequest 
   licenseTermsData: LicenseTermsData[];
   /** Authors of the IP and their shares of the royalty tokens */
   royaltyShares: RoyaltyShare[];
-  /** The address to receive the minted NFT. If not provided, the function will use the user's own wallet address. */
+  /** The address to receive the minted NFT. If not provided, the client's own wallet address will be used. */
   recipient?: Address;
   txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
 } & IPMetadataInfo &
@@ -391,7 +391,7 @@ export type MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensRequest 
    * @default true
    */
   allowDuplicates?: boolean;
-  /** The address to receive the minted NFT. If not provided, the function will use the user's own wallet address. */
+  /** The address to receive the minted NFT. If not provided, the client's own wallet address will be used. */
   recipient?: Address;
   txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
 } & IPMetadataInfo &

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -110,7 +110,7 @@ export type AttachLicenseTermsRequest = {
   licenseTermsId: string | number | bigint;
   /**
    * The address of the license template.
-   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | PIL} address if not provided.
    */
   licenseTemplate?: Address;
   txOptions?: TxOptions;
@@ -127,7 +127,7 @@ export type MintLicenseTokensRequest = {
   licenseTermsId: string | number | bigint;
   /**
    * The address of the license template.
-   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | PIL} address if not provided.
    */
   licenseTemplate?: Address;
   /** The maximum minting fee that the caller is willing to pay. if set to 0 then no limit. */
@@ -166,7 +166,7 @@ export type PredictMintingLicenseFeeRequest = {
   amount: string | number | bigint;
   /**
    * The address of the license template.
-   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | PIL} address if not provided.
    */
   licenseTemplate?: Address;
   receiver?: Address;

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -77,23 +77,41 @@ export type RegisterPILResponse = {
 };
 
 export type RegisterCommercialUsePILRequest = {
+  /** The fee to be paid when minting a license. */
   defaultMintingFee: string | number | bigint;
+  /** The ERC20 token to be used to pay the minting fee and the token must be registered in story protocol. */
   currency: Address;
+  /**
+   * The address of the royalty policy contract.
+   * @default 0xBe54FB168b3c982b7AaE60dB6CF75Bd8447b390E
+   */
   royaltyPolicyAddress?: Address;
   txOptions?: TxOptions;
 };
 
 export type RegisterCommercialRemixPILRequest = {
+  /** The fee to be paid when minting a license. */
   defaultMintingFee: string | number | bigint;
+  /** Percentage of revenue that must be shared with the licensor. Must be between 0 and 100 (where 100% represents 100_000_000). */
   commercialRevShare: number;
+  /** The ERC20 token to be used to pay the minting fee and the token must be registered in story protocol. */
   currency: Address;
+  /**
+   * The address of the royalty policy contract.
+   * @default 0xBe54FB168b3c982b7AaE60dB6CF75Bd8447b390E
+   */
   royaltyPolicyAddress?: Address;
   txOptions?: TxOptions;
 };
 
 export type AttachLicenseTermsRequest = {
+  /** The address of the IP ID to which the license terms are being attached. */
   ipId: Address;
   licenseTermsId: string | number | bigint;
+  /**
+   * The address of the license template.
+   * @default 0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316
+   */
   licenseTemplate?: Address;
   txOptions?: TxOptions;
 };
@@ -107,10 +125,21 @@ export type AttachLicenseTermsResponse = {
 export type MintLicenseTokensRequest = {
   licensorIpId: Address;
   licenseTermsId: string | number | bigint;
+  /**
+   * The address of the license template.
+   * @default 0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316
+   */
   licenseTemplate?: Address;
+  /** The maximum minting fee that the caller is willing to pay. if set to 0 then no limit. */
   maxMintingFee: bigint | string | number;
+  /** The maximum revenue share percentage allowed for minting the License Tokens. Must be between 0 and 100,000,000 (where 100,000,000 represents 100%). */
   maxRevenueShare: number | string;
+  /**
+   * The amount of license tokens to mint.
+   * @default 1
+   */
   amount?: number | string | bigint;
+  /** The address of the receiver. */
   receiver?: Address;
 } & WithTxOptions &
   WithWipOptions;
@@ -133,7 +162,12 @@ export type LicenseTermsId = string | number | bigint;
 export type PredictMintingLicenseFeeRequest = {
   licensorIpId: Address;
   licenseTermsId: LicenseTermsId;
+  /** The amount of license tokens to mint. */
   amount: string | number | bigint;
+  /**
+   * The address of the license template.
+   * @default 0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316
+   */
   licenseTemplate?: Address;
   receiver?: Address;
   txOptions?: TxOptions;

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -83,7 +83,7 @@ export type RegisterCommercialUsePILRequest = {
   currency: Address;
   /**
    * The address of the royalty policy contract.
-   * @default 0xBe54FB168b3c982b7AaE60dB6CF75Bd8447b390E
+   * Defaults to {@link https://docs.story.foundation/docs/liquid-absolute-percentage | LAP|} policy address if not provided.
    */
   royaltyPolicyAddress?: Address;
   txOptions?: TxOptions;

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -19,52 +19,56 @@ export type RegisterNonComSocialRemixingPILRequest = {
 };
 
 /**
- * This structure defines the terms for a Programmable IP License (PIL). These terms can be attached to IP Assets. The legal document of the PIL can be found in this repository.
- * @type LicenseTerms
+ * This structure defines the terms for a Programmable IP License (PIL).
+ * These terms can be attached to IP Assets.
  **/
 export type LicenseTerms = {
-  /*Indicates whether the license is transferable or not.*/
+  /** Indicates whether the license is transferable or not. */
   transferable: boolean;
-  /*The address of the royalty policy contract which required to StoryProtocol in advance.*/
+  /** The address of the royalty policy contract which required to StoryProtocol in advance. */
   royaltyPolicy: Address;
-  /*The default minting fee to be paid when minting a license.*/
+  /** The default minting fee to be paid when minting a license. */
   defaultMintingFee: bigint;
-  /*The expiration period of the license.*/
+  /** The expiration period of the license. */
   expiration: bigint;
-  /*Indicates whether the work can be used commercially or not.*/
+  /** Indicates whether the work can be used commercially or not. */
   commercialUse: boolean;
-  /*Whether attribution is required when reproducing the work commercially or not.*/
+  /** Whether attribution is required when reproducing the work commercially or not. */
   commercialAttribution: boolean;
-  /*Commercializers that are allowed to commercially exploit the work. If zero address, then no restrictions is enforced.*/
+  /** Commercializers that are allowed to commercially exploit the work. If zero address, then no restrictions is enforced. */
   commercializerChecker: Address;
-  /*The data to be passed to the commercializer checker contract.*/
+  /** The data to be passed to the commercializer checker contract. */
   commercializerCheckerData: Address;
-  /**Percentage of revenue that must be shared with the licensor. Must be from 0-100.*/
+  /** *Percentage of revenue that must be shared with the licensor. Must be from 0-100. */
   commercialRevShare: number;
-  /*The maximum revenue that can be generated from the commercial use of the work.*/
+  /** The maximum revenue that can be generated from the commercial use of the work. */
   commercialRevCeiling: bigint;
-  /*Indicates whether the licensee can create derivatives of his work or not.*/
+  /** Indicates whether the licensee can create derivatives of his work or not. */
   derivativesAllowed: boolean;
-  /*Indicates whether attribution is required for derivatives of the work or not.*/
+  /** Indicates whether attribution is required for derivatives of the work or not. */
   derivativesAttribution: boolean;
-  /*Indicates whether the licensor must approve derivatives of the work before they can be linked to the licensor IP ID or not.*/
+  /** Indicates whether the licensor must approve derivatives of the work before they can be linked to the licensor IP ID or not. */
   derivativesApproval: boolean;
-  /*Indicates whether the licensee must license derivatives of the work under the same terms or not.*/
+  /** Indicates whether the licensee must license derivatives of the work under the same terms or not. */
   derivativesReciprocal: boolean;
-  /*The maximum revenue that can be generated from the derivative use of the work.*/
+  /** The maximum revenue that can be generated from the derivative use of the work. */
   derivativeRevCeiling: bigint;
-  /*The ERC20 token to be used to pay the minting fee. the token must be registered in story protocol.*/
+  /** The ERC20 token to be used to pay the minting fee. the token must be registered in story protocol. */
   currency: Address;
-  /*The URI of the license terms, which can be used to fetch the offchain license terms.*/
+  /** The URI of the license terms, which can be used to fetch the offchain license terms. */
   uri: string;
 };
 export type RegisterPILTermsRequest = Omit<
   LicenseTerms,
   "defaultMintingFee" | "expiration" | "commercialRevCeiling" | "derivativeRevCeiling"
 > & {
+  /** The default minting fee to be paid when minting a license. */
   defaultMintingFee: bigint | string | number;
+  /** The expiration period of the license. */
   expiration: bigint | string | number;
+  /** The maximum revenue that can be generated from the commercial use of the work. */
   commercialRevCeiling: bigint | string | number;
+  /** The maximum revenue that can be generated from the derivative use of the work. */
   derivativeRevCeiling: bigint | string | number;
   txOptions?: TxOptions;
 };
@@ -79,7 +83,7 @@ export type RegisterPILResponse = {
 export type RegisterCommercialUsePILRequest = {
   /** The fee to be paid when minting a license. */
   defaultMintingFee: string | number | bigint;
-  /** The ERC20 token to be used to pay the minting fee and the token must be registered in story protocol. */
+  /** The ERC20 token to be used to pay the minting fee */
   currency: Address;
   /**
    * The address of the royalty policy contract.
@@ -92,9 +96,12 @@ export type RegisterCommercialUsePILRequest = {
 export type RegisterCommercialRemixPILRequest = {
   /** The fee to be paid when minting a license. */
   defaultMintingFee: string | number | bigint;
-  /** Percentage of revenue that must be shared with the licensor. Must be between 0 and 100 (where 100% represents 100_000_000). */
+  /**
+   * Percentage of revenue that must be shared with the licensor.
+   * Must be between 0 and 100 (where 100% represents 100_000_000).
+   */
   commercialRevShare: number;
-  /** The ERC20 token to be used to pay the minting fee and the token must be registered in story protocol. */
+  /** The ERC20 token to be used to pay the minting fee */
   currency: Address;
   /**
    * The address of the royalty policy contract.

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -83,7 +83,7 @@ export type RegisterCommercialUsePILRequest = {
   currency: Address;
   /**
    * The address of the royalty policy contract.
-   * Defaults to {@link https://docs.story.foundation/docs/liquid-absolute-percentage | LAP|} policy address if not provided.
+   * Defaults to {@link https://docs.story.foundation/docs/liquid-absolute-percentage | LAP} policy address if not provided.
    */
   royaltyPolicyAddress?: Address;
   txOptions?: TxOptions;
@@ -98,7 +98,7 @@ export type RegisterCommercialRemixPILRequest = {
   currency: Address;
   /**
    * The address of the royalty policy contract.
-   * @default 0xBe54FB168b3c982b7AaE60dB6CF75Bd8447b390E
+   * Defaults to {@link https://docs.story.foundation/docs/liquid-absolute-percentage | LAP} policy address if not provided.
    */
   royaltyPolicyAddress?: Address;
   txOptions?: TxOptions;
@@ -110,7 +110,7 @@ export type AttachLicenseTermsRequest = {
   licenseTermsId: string | number | bigint;
   /**
    * The address of the license template.
-   * @default 0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
    */
   licenseTemplate?: Address;
   txOptions?: TxOptions;
@@ -127,7 +127,7 @@ export type MintLicenseTokensRequest = {
   licenseTermsId: string | number | bigint;
   /**
    * The address of the license template.
-   * @default 0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
    */
   licenseTemplate?: Address;
   /** The maximum minting fee that the caller is willing to pay. if set to 0 then no limit. */
@@ -166,7 +166,7 @@ export type PredictMintingLicenseFeeRequest = {
   amount: string | number | bigint;
   /**
    * The address of the license template.
-   * @default 0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316
+   * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | License Template} if not provided.
    */
   licenseTemplate?: Address;
   receiver?: Address;

--- a/packages/core-sdk/src/types/resources/nftClient.ts
+++ b/packages/core-sdk/src/types/resources/nftClient.ts
@@ -6,11 +6,11 @@ import { EncodedTxData } from "../../abi/generated";
 export type CreateNFTCollectionRequest = {
   name: string;
   symbol: string;
-  /** Whether the minting is public. */
-  isPublicMinting: boolean;
-  /** Whether the minting is open. */
-  mintOpen: boolean;
   /** If true, anyone can mint from the collection. If false, only the addresses with the minter role can mint. */
+  isPublicMinting: boolean;
+  /** Whether the collection is open for minting on creation. */
+  mintOpen: boolean;
+  /** The address to receive mint fees. */
   mintFeeRecipient: Address;
   /** The contract URI for the collection. Follows ERC-7572 standard. See https://eips.ethereum.org/EIPS/eip-7572. */
   contractURI: string;

--- a/packages/core-sdk/src/types/resources/nftClient.ts
+++ b/packages/core-sdk/src/types/resources/nftClient.ts
@@ -6,14 +6,22 @@ import { EncodedTxData } from "../../abi/generated";
 export type CreateNFTCollectionRequest = {
   name: string;
   symbol: string;
+  /** Whether the minting is public. */
   isPublicMinting: boolean;
+  /** Whether the minting is open. */
   mintOpen: boolean;
+  /** If true, anyone can mint from the collection. If false, only the addresses with the minter role can mint. */
   mintFeeRecipient: Address;
+  /** The contract URI for the collection. Follows ERC-7572 standard. See https://eips.ethereum.org/EIPS/eip-7572. */
   contractURI: string;
+  /** The base URI for the collection. If baseURI is not empty, tokenURI will be either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI. */
   baseURI?: string;
   maxSupply?: number;
+  /** The cost to mint a token. */
   mintFee?: bigint;
+  /** The token to mint. */
   mintFeeToken?: Hex;
+  /** The owner of the collection. */
   owner?: Hex;
   txOptions?: TxOptions;
 };

--- a/packages/core-sdk/src/types/resources/permission.ts
+++ b/packages/core-sdk/src/types/resources/permission.ts
@@ -4,10 +4,22 @@ import { TxOptions } from "../options";
 import { EncodedTxData, SimpleWalletClient } from "../../abi/generated";
 
 export type SetPermissionsRequest = {
+  /** The IP ID that grants the permission for `signer`. */
   ipId: Address;
+  /**
+   * The address that will be granted permission to execute transactions.
+   * This address will be able to call functions on `to`
+   * on behalf of the IP Account {@link https://docs.story.foundation/docs/ip-account}.
+   */
   signer: Address;
+  /** The address that can be called by the `signer` (currently only modules can be `to`). */
   to: Address;
+  /** The new permission level of {@link AccessPermission}. */
   permission: AccessPermission;
+  /**
+   * The function selector string of `to` that can be called by the `signer` on behalf of the IP Account {@link https://docs.story.foundation/docs/ip-account}.
+   * Be default, it allows all functions.
+   */
   func?: string;
   txOptions?: TxOptions;
 };
@@ -19,8 +31,11 @@ export type SetPermissionsResponse = {
 };
 
 export type SetAllPermissionsRequest = {
+  /** The IP ID that grants the permission for `signer`. */
   ipId: Address;
+  /** The address of the signer receiving the permissions. */
   signer: Address;
+  /** The new permission level of {@link AccessPermission}. */
   permission: AccessPermission;
   txOptions?: TxOptions;
 };
@@ -29,15 +44,19 @@ export type SetAllPermissionsRequest = {
  * @enum {number}
  **/
 export enum AccessPermission {
-  /* ABSTAIN means having not enough information to make decision at current level, deferred decision to up. */
+  /** ABSTAIN means having not enough information to make decision at current level, deferred decision to up. */
   ABSTAIN,
-  /* ALLOW means the permission is granted to transaction signer to call the function. */
+  /** ALLOW means the permission is granted to transaction signer to call the function. */
   ALLOW,
-  /* DENY means the permission is denied to transaction signer to call the function. */
+  /** DENY means the permission is denied to transaction signer to call the function. */
   DENY,
 }
 
 export type CreateSetPermissionSignatureRequest = {
+  /**
+   * The deadline for the signature in seconds.
+   * @default 1000
+   */
   deadline?: bigint | number | string;
 } & SetPermissionsRequest;
 
@@ -47,16 +66,23 @@ export type SetBatchPermissionsRequest = {
 };
 
 export type CreateBatchPermissionSignatureRequest = {
+  /** The ip id that grants the permission for `signer`. */
   ipId: Address;
+  /**
+   * The deadline for the signature in seconds.
+   * @default 1000
+   */
   deadline?: bigint | number | string;
 } & SetBatchPermissionsRequest;
 
 export type PermissionSignatureRequest = {
   ipId: Address;
   state: Hex;
+  /** The deadline for the signature in seconds. */
   deadline: string | number | bigint;
   wallet: WalletClient;
   chainId: string | number | bigint;
+  /**The permission function,default function is setPermission. */
   permissions: Omit<SetPermissionsRequest, "txOptions">[];
 };
 
@@ -66,6 +92,7 @@ export type SignatureRequest = {
   encodeData: Hex;
   wallet: SimpleWalletClient;
   verifyingContract: Address;
+  /** The deadline for the signature in seconds. */
   deadline: bigint | number | string;
   chainId: number | bigint | string;
 };

--- a/packages/core-sdk/src/types/resources/permission.ts
+++ b/packages/core-sdk/src/types/resources/permission.ts
@@ -18,7 +18,7 @@ export type SetPermissionsRequest = {
   permission: AccessPermission;
   /**
    * The function selector string of `to` that can be called by the `signer` on behalf of the IP Account {@link https://docs.story.foundation/docs/ip-account}.
-   * Be default, it allows all functions.
+   * @default `0x00000000`
    */
   func?: string;
   txOptions?: TxOptions;
@@ -82,7 +82,6 @@ export type PermissionSignatureRequest = {
   deadline: string | number | bigint;
   wallet: WalletClient;
   chainId: string | number | bigint;
-  /**The permission function,default function is setPermission. */
   permissions: Omit<SetPermissionsRequest, "txOptions">[];
 };
 

--- a/packages/core-sdk/src/types/resources/permission.ts
+++ b/packages/core-sdk/src/types/resources/permission.ts
@@ -18,7 +18,8 @@ export type SetPermissionsRequest = {
   permission: AccessPermission;
   /**
    * The function selector string of `to` that can be called by the `signer` on behalf of the IP Account {@link https://docs.story.foundation/docs/ip-account}.
-   * @default `0x00000000`
+   * Be default, it allows all functions.
+   * @default 0x00000000
    */
   func?: string;
   txOptions?: TxOptions;
@@ -41,7 +42,6 @@ export type SetAllPermissionsRequest = {
 };
 /**
  * Permission level
- * @enum {number}
  **/
 export enum AccessPermission {
   /** ABSTAIN means having not enough information to make decision at current level, deferred decision to up. */

--- a/packages/core-sdk/src/types/resources/permission.ts
+++ b/packages/core-sdk/src/types/resources/permission.ts
@@ -42,9 +42,12 @@ export type SetAllPermissionsRequest = {
 };
 /**
  * Permission level
- **/
+ */
 export enum AccessPermission {
-  /** ABSTAIN means having not enough information to make decision at current level, deferred decision to up. */
+  /**
+   * ABSTAIN means having not enough information to make decision at
+   * current level, deferred decision to up.
+   */
   ABSTAIN,
   /** ALLOW means the permission is granted to transaction signer to call the function. */
   ALLOW,

--- a/packages/core-sdk/src/types/resources/royalty.ts
+++ b/packages/core-sdk/src/types/resources/royalty.ts
@@ -17,7 +17,10 @@ export type ClaimableRevenueRequest = {
   /** The revenue token to claim. */
   token: Address;
 };
+
+/** The amount of revenue token claimable. */
 export type ClaimableRevenueResponse = bigint;
+
 export type PayRoyaltyOnBehalfRequest = WithTxOptions &
   WithERC20Options &
   WithWipOptions & {

--- a/packages/core-sdk/src/types/resources/royalty.ts
+++ b/packages/core-sdk/src/types/resources/royalty.ts
@@ -10,8 +10,11 @@ import { WithERC20Options } from "../options";
 import { TokenAmountInput } from "../common";
 
 export type ClaimableRevenueRequest = {
+  /** The IP ID of the royalty vault. */
   royaltyVaultIpId: Address;
+  /** The address of the royalty token holder. */
   claimer: Address;
+  /** The revenue token to claim. */
   token: Address;
 };
 export type ClaimableRevenueResponse = bigint;

--- a/packages/core-sdk/src/utils/getFunctionSignature.ts
+++ b/packages/core-sdk/src/utils/getFunctionSignature.ts
@@ -1,24 +1,13 @@
 import { Abi, AbiFunction, AbiParameter } from "viem";
-
-type FunctionSignature = {
-  /** The contract ABI */
-  abi: Abi;
-  /** The name of the method to get the signature for */
-  methodName: string;
-  /** Optional index for overloaded functions (0-based) */
-  overloadIndex?: number;
-};
 /**
- * Gets the function signature from an ABI for a given method name.
- *
+ * Gets the function signature from an ABI for a given method name
+ * @param abi - The contract ABI
+ * @param methodName - The name of the method to get the signature for
+ * @param overloadIndex - Optional index for overloaded functions (0-based)
  * @returns The function signature in standard format (e.g. "methodName(uint256,address)")
  * @throws Error if method not found or if overloadIndex is required but not provided
  */
-export function getFunctionSignature({
-  abi,
-  methodName,
-  overloadIndex,
-}: FunctionSignature): string {
+export function getFunctionSignature(abi: Abi, methodName: string, overloadIndex?: number): string {
   const functions = abi.filter(
     (x): x is AbiFunction => x.type === "function" && x.name === methodName,
   );

--- a/packages/core-sdk/src/utils/getFunctionSignature.ts
+++ b/packages/core-sdk/src/utils/getFunctionSignature.ts
@@ -1,14 +1,24 @@
 import { Abi, AbiFunction, AbiParameter } from "viem";
 
+type FunctionSignature = {
+  /** The contract ABI */
+  abi: Abi;
+  /** The name of the method to get the signature for */
+  methodName: string;
+  /** Optional index for overloaded functions (0-based) */
+  overloadIndex?: number;
+};
 /**
- * Gets the function signature from an ABI for a given method name
- * @param abi - The contract ABI
- * @param methodName - The name of the method to get the signature for
- * @param overloadIndex - Optional index for overloaded functions (0-based)
+ * Gets the function signature from an ABI for a given method name.
+ *
  * @returns The function signature in standard format (e.g. "methodName(uint256,address)")
  * @throws Error if method not found or if overloadIndex is required but not provided
  */
-export function getFunctionSignature(abi: Abi, methodName: string, overloadIndex?: number): string {
+export function getFunctionSignature({
+  abi,
+  methodName,
+  overloadIndex,
+}: FunctionSignature): string {
   const functions = abi.filter(
     (x): x is AbiFunction => x.type === "function" && x.name === methodName,
   );

--- a/packages/core-sdk/src/utils/getFunctionSignature.ts
+++ b/packages/core-sdk/src/utils/getFunctionSignature.ts
@@ -1,4 +1,5 @@
 import { Abi, AbiFunction, AbiParameter } from "viem";
+
 /**
  * Gets the function signature from an ABI for a given method name
  * @param abi - The contract ABI

--- a/packages/core-sdk/src/utils/sign.ts
+++ b/packages/core-sdk/src/utils/sign.ts
@@ -17,14 +17,6 @@ import {
 
 /**
  * Get the signature for setting permissions.
- * @param param - The parameter object containing necessary data to get the signature.
- * @param param.ipId - The IP ID.
- * @param param.deadline - The deadline.
- * @param param.nonce - The nonce.
- * @param param.wallet - The wallet client.
- * @param param.chainId - The chain ID.
- * @param param.permissionFunc - The permission function,default function is setPermission.
- * @returns A Promise that resolves to the signature.
  */
 export const getPermissionSignature = async (
   param: PermissionSignatureRequest,
@@ -76,15 +68,6 @@ export const getDeadline = (unixTimestamp: bigint, deadline?: bigint | number | 
 
 /**
  * Get the signature.
- * @param param - The parameter object containing necessary data to get the signature.
- * @param param.state - The IP Account's state.
- * @param param.to - The recipient address.
- * @param param.encodeData - The encoded data.
- * @param param.wallet - The wallet client.
- * @param param.verifyingContract - The verifying contract.
- * @param param.deadline - The deadline.
- * @param param.chainId - The chain ID.
- * @returns A Promise that resolves to the signature.
  */
 export const getSignature = async ({
   state,


### PR DESCRIPTION
- Add inline docs to function request types
- Update all method jsdocs that have conflicting typescript tags (ie `@param`, `@return`)
- Update jsdocs for `claimAllRevenue` and `batchClaimAllRevenue`. We need to indicate that if there is no child ips (you are claiming only from the IP’s royalty vault), then you still need to populate `currencyTokens` with the tokens to claim.

## Note
The `getFunctionSignature` used `@param`,`@returns`, and `@throws`.  It's the util method, and the parameter is not an object. Do we need to remove it? @DracoLi 