### PR TITLE
Fix incorrect address/hex types

### DIFF
--- a/packages/core-sdk/src/types/resources/dispute.ts
+++ b/packages/core-sdk/src/types/resources/dispute.ts
@@ -42,7 +42,7 @@ export type RaiseDisputeResponse = {
 export type CancelDisputeRequest = {
   disputeId: number | string | bigint;
   /** Additional data used in the cancellation process. */
-  data?: Address;
+  data?: Hex;
   txOptions?: TxOptions;
 };
 

--- a/packages/core-sdk/src/types/resources/dispute.ts
+++ b/packages/core-sdk/src/types/resources/dispute.ts
@@ -53,8 +53,11 @@ export type CancelDisputeResponse = {
 
 export type ResolveDisputeRequest = {
   disputeId: number | string | bigint;
-  /** The data to resolve the dispute. */
-  data: Address;
+  /**
+   * The data to resolve the dispute.
+   * Use `"0x"` if no additional data is needed.
+   */
+  data: Hex;
   txOptions?: TxOptions;
 };
 

--- a/packages/core-sdk/src/types/resources/ipAccount.ts
+++ b/packages/core-sdk/src/types/resources/ipAccount.ts
@@ -12,7 +12,7 @@ export type IPAccountExecuteRequest = {
   /** The amount of IP to send. */
   value: number;
   /** The data to send along with the transaction. */
-  data: Address;
+  data: Hex;
   txOptions?: TxOptions;
 };
 
@@ -27,7 +27,7 @@ export type IPAccountExecuteWithSigRequest = {
   /** The recipient of the transaction. */
   to: Address;
   /** The data to send along with the transaction. */
-  data: Address;
+  data: Hex;
   /** The signer of the transaction. */
   signer: Address;
   /** The deadline of the transaction signature in seconds. */

--- a/packages/core-sdk/src/types/resources/nftClient.ts
+++ b/packages/core-sdk/src/types/resources/nftClient.ts
@@ -1,4 +1,4 @@
-import { Address, Hex } from "viem";
+import { Address } from "viem";
 
 import { TxOptions } from "../options";
 import { EncodedTxData } from "../../abi/generated";
@@ -20,9 +20,9 @@ export type CreateNFTCollectionRequest = {
   /** The cost to mint a token. */
   mintFee?: bigint;
   /** The token to mint. */
-  mintFeeToken?: Hex;
+  mintFeeToken?: Address;
   /** The owner of the collection. */
-  owner?: Hex;
+  owner?: Address;
   txOptions?: TxOptions;
 };
 

--- a/packages/core-sdk/src/utils/validateLicenseConfig.ts
+++ b/packages/core-sdk/src/utils/validateLicenseConfig.ts
@@ -1,4 +1,4 @@
-import { zeroAddress } from "viem";
+import { zeroAddress, zeroHash } from "viem";
 
 import { LicensingConfig, ValidatedLicensingConfig } from "../types/common";
 import { getRevenueShare } from "./licenseTermsHelper";
@@ -12,7 +12,7 @@ export const validateLicenseConfig = (
       isSet: false,
       mintingFee: 0n,
       licensingHook: zeroAddress,
-      hookData: zeroAddress,
+      hookData: zeroHash,
       commercialRevShare: 0,
       disabled: false,
       expectMinimumGroupRewardShare: 0,


### PR DESCRIPTION
## Description
 
1. Updated the `data` property in the following types from `Address` to `Hex`
    - `CancelDisputeRequest`, `IPAccountExecuteRequest`, `IPAccountExecuteWithSigRequest`, `ResolveDisputeRequest`
2. Change `mintFeeToken` and `owner` in `CreateNFTCollectionRequest` from `Hex` to `Address` type.