### PR TITLE
fix: invalid default value for claim options

### DIFF
--- a/packages/core-sdk/src/types/resources/royalty.ts
+++ b/packages/core-sdk/src/types/resources/royalty.ts
@@ -73,7 +73,7 @@ export type WithClaimOptions = {
      * they are transferred.
      * Set this to false to disable this behavior.
      *
-     * @default false
+     * @default true
      */
     autoUnwrapIpTokens?: boolean;
   };


### PR DESCRIPTION
## Description

Update jsdoc to fix the default value for ClaimAllRevenue options