### PR TITLE
feat: add transferToVault to royalty client

### DIFF
--- a/packages/core-sdk/src/abi/generated.ts
+++ b/packages/core-sdk/src/abi/generated.ts
@@ -24913,6 +24913,70 @@ export class RoyaltyModuleClient extends RoyaltyModuleReadOnlyClient {
 
 // Contract RoyaltyPolicyLAP =============================================================
 
+/**
+ * RoyaltyPolicyLapTransferToVaultRequest
+ *
+ * @param ipId address
+ * @param ancestorIpId address
+ * @param token address
+ */
+export type RoyaltyPolicyLapTransferToVaultRequest = {
+  ipId: Address;
+  ancestorIpId: Address;
+  token: Address;
+};
+
+/**
+ * contract RoyaltyPolicyLAP write method
+ */
+export class RoyaltyPolicyLapClient {
+  protected readonly wallet: SimpleWalletClient;
+  protected readonly rpcClient: PublicClient;
+  public readonly address: Address;
+
+  constructor(rpcClient: PublicClient, wallet: SimpleWalletClient, address?: Address) {
+    this.address = address || getAddress(royaltyPolicyLapAddress, rpcClient.chain?.id);
+    this.rpcClient = rpcClient;
+    this.wallet = wallet;
+  }
+
+  /**
+   * method transferToVault for contract RoyaltyPolicyLAP
+   *
+   * @param request RoyaltyPolicyLapTransferToVaultRequest
+   * @return Promise<WriteContractReturnType>
+   */
+  public async transferToVault(
+    request: RoyaltyPolicyLapTransferToVaultRequest,
+  ): Promise<WriteContractReturnType> {
+    const { request: call } = await this.rpcClient.simulateContract({
+      abi: royaltyPolicyLapAbi,
+      address: this.address,
+      functionName: "transferToVault",
+      account: this.wallet.account,
+      args: [request.ipId, request.ancestorIpId, request.token],
+    });
+    return await this.wallet.writeContract(call as WriteContractParameters);
+  }
+
+  /**
+   * method transferToVault for contract RoyaltyPolicyLAP with only encode
+   *
+   * @param request RoyaltyPolicyLapTransferToVaultRequest
+   * @return EncodedTxData
+   */
+  public transferToVaultEncode(request: RoyaltyPolicyLapTransferToVaultRequest): EncodedTxData {
+    return {
+      to: this.address,
+      data: encodeFunctionData({
+        abi: royaltyPolicyLapAbi,
+        functionName: "transferToVault",
+        args: [request.ipId, request.ancestorIpId, request.token],
+      }),
+    };
+  }
+}
+
 // Contract RoyaltyPolicyLRP =============================================================
 
 /**

--- a/packages/core-sdk/src/client.ts
+++ b/packages/core-sdk/src/client.ts
@@ -184,7 +184,7 @@ export class StoryClient {
    */
   public get royalty(): RoyaltyClient {
     if (this._royalty === null) {
-      this._royalty = new RoyaltyClient(this.rpcClient, this.wallet);
+      this._royalty = new RoyaltyClient(this.rpcClient, this.wallet, this.chainId);
     }
 
     return this._royalty;

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -85,6 +85,9 @@ export type {
   ClaimAllRevenueResponse,
   BatchClaimAllRevenueRequest,
   BatchClaimAllRevenueResponse,
+  NativeRoyaltyPolicy,
+  TransferToVaultRequest,
+  RoyaltyPolicyInput,
 } from "./types/resources/royalty";
 
 export type {

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -19,6 +19,7 @@ import {
   PayRoyaltyOnBehalfRequest,
   PayRoyaltyOnBehalfResponse,
   TransferClaimedTokensFromIpToWalletParams,
+  TransferToVaultRequest,
 } from "../types/resources/royalty";
 import {
   IpAccountImplClient,
@@ -28,6 +29,7 @@ import {
   IpRoyaltyVaultImplRevenueTokenClaimedEvent,
   Multicall3Client,
   RoyaltyModuleClient,
+  royaltyPolicyLrpAbi,
   RoyaltyWorkflowsClient,
   SimpleWalletClient,
   WrappedIpClient,
@@ -36,6 +38,10 @@ import { getAddress, validateAddress, validateAddresses } from "../utils/utils";
 import { WIP_TOKEN_ADDRESS } from "../constants/common";
 import { contractCallWithFees } from "../utils/feeUtils";
 import { Erc20Spender } from "../types/utils/wip";
+import { TransactionResponse } from "../types/options";
+import { ChainIds } from "../types/config";
+import { royaltyPolicyInputToAddress } from "../utils/royalty";
+import { handleTxOptions } from "../utils/txOptions";
 
 export class RoyaltyClient {
   public royaltyModuleClient: RoyaltyModuleClient;
@@ -48,8 +54,9 @@ export class RoyaltyClient {
   private readonly rpcClient: PublicClient;
   private readonly wallet: SimpleWalletClient;
   private readonly walletAddress: Address;
+  private readonly chainId: ChainIds;
 
-  constructor(rpcClient: PublicClient, wallet: SimpleWalletClient) {
+  constructor(rpcClient: PublicClient, wallet: SimpleWalletClient, chainId: ChainIds) {
     this.royaltyModuleClient = new RoyaltyModuleClient(rpcClient, wallet);
     this.ipAssetRegistryClient = new IpAssetRegistryClient(rpcClient, wallet);
     this.ipRoyaltyVaultImplReadOnlyClient = new IpRoyaltyVaultImplReadOnlyClient(rpcClient);
@@ -59,6 +66,7 @@ export class RoyaltyClient {
     this.wrappedIpClient = new WrappedIpClient(rpcClient, wallet);
     this.rpcClient = rpcClient;
     this.wallet = wallet;
+    this.chainId = chainId;
     this.walletAddress = wallet.account!.address;
   }
   /**
@@ -345,6 +353,37 @@ export class RoyaltyClient {
       throw new Error(`The royalty vault IP with id ${royaltyVaultIpId} is not registered.`);
     }
     return await this.royaltyModuleClient.ipRoyaltyVaults({ ipId: royaltyVaultIpId });
+  }
+
+  /**
+   * Transfers to vault an amount of revenue tokens claimable via a royalty policy.
+   */
+  public async transferToVault({
+    txOptions,
+    ipId,
+    royaltyPolicy,
+    ancestorIpId,
+    token,
+  }: TransferToVaultRequest): Promise<TransactionResponse> {
+    const royaltyPolicyAddress = royaltyPolicyInputToAddress(royaltyPolicy, this.chainId);
+    const protocolArgs = [
+      validateAddress(ipId),
+      validateAddress(ancestorIpId),
+      validateAddress(token),
+    ] as const;
+    const { request: call } = await this.rpcClient.simulateContract({
+      abi: royaltyPolicyLrpAbi, // same abi for all royalty policies
+      address: royaltyPolicyAddress,
+      functionName: "transferToVault",
+      account: this.wallet.account,
+      args: protocolArgs,
+    });
+    const txHash = await this.wallet.writeContract(call);
+    return handleTxOptions({
+      txHash,
+      rpcClient: this.rpcClient,
+      txOptions,
+    });
   }
 
   private async transferClaimedTokensFromIpToWallet({

--- a/packages/core-sdk/src/types/resources/royalty.ts
+++ b/packages/core-sdk/src/types/resources/royalty.ts
@@ -116,3 +116,24 @@ export type TransferClaimedTokensFromIpToWalletParams = {
   ipAccount: IpAccountImplClient;
   claimedTokens: IpRoyaltyVaultImplRevenueTokenClaimedEvent[];
 };
+
+/**
+ * Native royalty policy created by the Story team
+ */
+export enum NativeRoyaltyPolicy {
+  LAP = 0,
+  LRP,
+}
+
+/**
+ * Allow custom royalty policy address or use a native royalty policy enum
+ */
+export type RoyaltyPolicyInput = Address | NativeRoyaltyPolicy;
+
+export type TransferToVaultRequest = WithTxOptions & {
+  royaltyPolicy: RoyaltyPolicyInput;
+  ipId: Address;
+  ancestorIpId: Address;
+  /** the token address to transfer */
+  token: Address;
+};

--- a/packages/core-sdk/src/utils/royalty.ts
+++ b/packages/core-sdk/src/utils/royalty.ts
@@ -1,0 +1,22 @@
+import { Address } from "viem";
+
+import { NativeRoyaltyPolicy, RoyaltyPolicyInput } from "../types/resources/royalty";
+import { chain, validateAddress } from "./utils";
+import { royaltyPolicyLapAddress, royaltyPolicyLrpAddress } from "../abi/generated";
+import { ChainIds } from "../types/config";
+
+export const royaltyPolicyInputToAddress = (
+  input: RoyaltyPolicyInput,
+  chainId: ChainIds,
+): Address => {
+  // if input is string, validate and return address
+  if (typeof input === "string") {
+    return validateAddress(input);
+  }
+  switch (input) {
+    case NativeRoyaltyPolicy.LAP:
+      return royaltyPolicyLapAddress[chain[chainId]];
+    case NativeRoyaltyPolicy.LRP:
+      return royaltyPolicyLrpAddress[chain[chainId]];
+  }
+};

--- a/packages/core-sdk/src/utils/royalty.ts
+++ b/packages/core-sdk/src/utils/royalty.ts
@@ -9,14 +9,12 @@ export const royaltyPolicyInputToAddress = (
   input: RoyaltyPolicyInput,
   chainId: ChainIds,
 ): Address => {
-  // if input is string, validate and return address
-  if (typeof input === "string") {
-    return validateAddress(input);
-  }
   switch (input) {
     case NativeRoyaltyPolicy.LAP:
       return royaltyPolicyLapAddress[chain[chainId]];
     case NativeRoyaltyPolicy.LRP:
       return royaltyPolicyLrpAddress[chain[chainId]];
+    default:
+      return validateAddress(input);
   }
 };

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -11,6 +11,7 @@ import {
   wrappedIpAddress,
 } from "../../src/abi/generated";
 import { ValidatedLicenseTermsData } from "../../src/types/resources/ipAsset";
+import { NativeRoyaltyPolicy } from "../../src/types/resources/royalty";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
@@ -374,14 +375,13 @@ describe("Group Functions", () => {
 
       //5. Transfer to vault
       const transferToVault = async (childIpId: Address, groupIpId: Address, token: Address) => {
-        const { request: call } = await publicClient.simulateContract({
-          abi: royaltyPolicyLrpAbi,
-          address: royaltyPolicyLrpAddress[aeneid],
-          functionName: "transferToVault",
-          account: walletClient.account,
-          args: [childIpId, groupIpId, token],
+        await client.royalty.transferToVault({
+          royaltyPolicy: NativeRoyaltyPolicy.LRP,
+          ipId: childIpId,
+          ancestorIpId: groupIpId,
+          token,
+          txOptions: { waitForTransaction: true },
         });
-        await walletClient.writeContract(call);
       };
       await transferToVault(childIpId1, groupIpId, WIP_TOKEN_ADDRESS);
       await transferToVault(childIpId2, groupIpId, WIP_TOKEN_ADDRESS);

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -554,7 +554,7 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("collectAndDistributeGroupRoyalties", async () => {
+  describe("Test groupClient.collectAndDistributeGroupRoyalties", async () => {
     it("throws if group ipId is not registered", async () => {
       sinon.stub(groupClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 


### PR DESCRIPTION
## New Royalty Client Method: `transferToVault`

Transfers to vault an amount of revenue tokens claimable via a royalty policy.

### Usage Example

```tsx
const result = await storyClient.royalty.transferToVault({
  royaltyPolicy: NativeRoyaltyPolicy.LAP,
  ipId,
  ancestorIpId,
  token: WIP_TOKEN_ADDRESS,
  txOptions: { waitForTransaction: true },
});
```