### PR TITLE
fix: wait for tx in dispute approve call

### DIFF
--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -296,9 +296,12 @@ export class DisputeClient {
         // Note: We must use client wallet directly because:
         // 1. The bond payment requires WrappedIP tokens
         // 2. Cannot use ipAccount.executeBatch since msg.sender would be the same as spender
-        await this.wrappedIpClient.approve({
+        const txHash = await this.wrappedIpClient.approve({
           spender: ipAccount.address,
           amount: maxUint256,
+        });
+        await this.rpcClient.waitForTransactionReceipt({
+          hash: txHash,
         });
       }
       const contractCall = () => {

--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -157,7 +157,7 @@ describe("Dispute Functions", () => {
       disputeId = response.disputeId;
     });
 
-    it.skip("should be able to counter existing dispute once", async () => {
+    it("should be able to counter existing dispute once", async () => {
       const assertionId = await clientB.dispute.disputeIdToAssertionId(disputeId!);
       const counterEvidenceCID = await generateCID();
       const ret = await clientB.dispute.disputeAssertion({


### PR DESCRIPTION
## Description

need to make sure approve call finishes before executing the rest of the functions.