### PR TITLE
fix: revert test changes to disputeAssertion

### DIFF
--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -168,7 +168,7 @@ describe("Dispute Functions", () => {
       expect(ret.txHash).to.be.a("string").and.not.empty;
 
       // should throw error if attempting to dispute assertion again
-      const secondDispute = clientB.dispute.disputeAssertion({
+      const secondDispute = await clientB.dispute.disputeAssertion({
         ipId: ipIdB,
         assertionId,
         counterEvidenceCID,
@@ -176,7 +176,7 @@ describe("Dispute Functions", () => {
           waitForTransaction: true,
         },
       });
-      await expect(secondDispute).to.be.rejectedWith("Execution reverted for an unknown reason");
+      expect(secondDispute.receipt?.status).to.equal("reverted");
     });
 
     it("should throw error when liveness is out of bounds", async () => {


### PR DESCRIPTION
## Description

Reverts https://github.com/storyprotocol/sdk/pull/480 since [this fix](https://github.com/storyprotocol/sdk/pull/482) should have resolved the initial issue.