### PR TITLE
Fix tagIfRelatedIpInfringed method when useMulticallWhenPossible is false

### DIFF
--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -223,9 +223,10 @@ export class DisputeClient {
         const txHash = await this.multicall3Client.aggregate3({ calls });
         txHashes.push(txHash);
       } else {
-        txHashes = await Promise.all(
-          objects.map((object) => this.disputeModuleClient.tagIfRelatedIpInfringed(object)),
-        );
+        for (const object of objects) {
+          const txHash = await this.disputeModuleClient.tagIfRelatedIpInfringed(object);
+          txHashes.push(txHash);
+        }
       }
       return await Promise.all(
         txHashes.map((txHash) =>

--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -544,11 +544,11 @@ describe("Dispute Functions", () => {
       const responses = await clientA.dispute.tagIfRelatedIpInfringed({
         infringementTags: [
           {
-            ipId: derivativeResponse4.ipId!,
+            ipId: derivativeResponse3.ipId!,
             disputeId: disputeId,
           },
           {
-            ipId: derivativeResponse3.ipId!,
+            ipId: derivativeResponse4.ipId!,
             disputeId: disputeId,
           },
         ],

--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -200,7 +200,7 @@ describe("Dispute Functions", () => {
         cid: await generateCID(),
         targetTag: "IMPROPER_REGISTRATION",
         liveness: 2592000,
-        bond: 2000000000000000000,
+        bond: parseEther("360"),
         txOptions: {
           waitForTransaction: true,
         },
@@ -541,8 +541,12 @@ describe("Dispute Functions", () => {
       });
       expect(disputeState[6]).to.equal(disputeState[5]);
 
-      const response1 = await clientA.dispute.tagIfRelatedIpInfringed({
+      const responses = await clientA.dispute.tagIfRelatedIpInfringed({
         infringementTags: [
+          {
+            ipId: derivativeResponse4.ipId!,
+            disputeId: disputeId,
+          },
           {
             ipId: derivativeResponse3.ipId!,
             disputeId: disputeId,
@@ -554,20 +558,6 @@ describe("Dispute Functions", () => {
         txOptions: { waitForTransaction: true },
       });
 
-      const response2 = await clientA.dispute.tagIfRelatedIpInfringed({
-        infringementTags: [
-          {
-            ipId: derivativeResponse4.ipId!,
-            disputeId: disputeId,
-          },
-        ],
-        options: {
-          useMulticallWhenPossible: false,
-        },
-        txOptions: { waitForTransaction: true },
-      });
-
-      const responses = [...response1, ...response2];
       expect(responses).to.have.lengthOf(2);
       expect(responses[0].txHash).to.be.a("string").and.not.empty;
       expect(responses[1].txHash).to.be.a("string").and.not.empty;


### PR DESCRIPTION
## Description
1. When `useMulticallWhenPossible` is false and multiple data entries are passed, the function concurrently executes `tagIfRelatedIpInfringed`, resulting in the same nonce being used. The SDK only tests with a single data entry when `useMulticallWhenPossible` is set to `false`.

2. Modify the integration test about the max bond , because the configuration has changed.

