### PR TITLE
Enhance mintLicenseTokens method

### DIFF
--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -1668,13 +1668,17 @@ export class IPAssetClient {
       let totalDerivativeMintingFee = 0n;
       for (let i = 0; i < derivData.parentIpIds.length; i++) {
         const derivativeMintingFee = await calculateLicenseWipMintFee({
-          multicall3Client: this.multicall3Client,
-          licenseTemplateClient: this.licenseTemplateClient,
-          licensingModuleClient: this.licensingModuleClient,
-          parentIpId: derivData.parentIpIds[i],
-          licenseTermsId: derivData.licenseTermsIds[i],
-          receiver: sender,
-          amount: 1n,
+          predictMintingFeeRequest: {
+            licensorIpId: derivData.parentIpIds[i],
+            licenseTemplate: derivData.licenseTemplate,
+            licenseTermsId: derivData.licenseTermsIds[i],
+            receiver: sender,
+            amount: 1n,
+            royaltyContext: zeroAddress,
+          },
+          rpcClient: this.rpcClient,
+          chainId: this.chainId,
+          walletAddress: this.walletAddress,
         });
         totalDerivativeMintingFee += derivativeMintingFee;
       }

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -395,7 +395,6 @@ export class LicenseClient {
           amount: licenseMintingFee,
         });
       }
-      console.log("licenseMintingFee", licenseMintingFee);
       const { txHash, receipt } = await contractCallWithFees({
         totalFees: licenseMintingFee,
         options: { wipOptions: request.wipOptions },

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -50,6 +50,7 @@ import { calculateLicenseWipMintFee, contractCallWithFees } from "../utils/feeUt
 import { Erc20Spender } from "../types/utils/wip";
 import { validateLicenseConfig } from "../utils/validateLicenseConfig";
 import { RevShareType } from "../types/common";
+import { predictMintingLicenseFee } from "../utils/predictMintingLicenseFee";
 
 export class LicenseClient {
   public licenseRegistryClient: LicenseRegistryEventClient;
@@ -381,13 +382,10 @@ export class LicenseClient {
 
       // get license token minting fee
       const licenseMintingFee = await calculateLicenseWipMintFee({
-        multicall3Client: this.multicall3Client,
-        licenseTemplateClient: this.licenseTemplateClient,
-        licensingModuleClient: this.licensingModuleClient,
-        parentIpId: req.licensorIpId,
-        licenseTermsId: req.licenseTermsId,
-        receiver,
-        amount: req.amount,
+        predictMintingFeeRequest: req,
+        rpcClient: this.rpcClient,
+        chainId: this.chainId,
+        walletAddress: this.walletAddress,
       });
 
       const wipSpenders: Erc20Spender[] = [];
@@ -471,7 +469,12 @@ export class LicenseClient {
         ),
         licenseTermsId,
       };
-      return await this.licensingModuleClient.predictMintingLicenseFee(object);
+      return await predictMintingLicenseFee({
+        predictMintingFeeRequest: object,
+        rpcClient: this.rpcClient,
+        chainId: this.chainId,
+        walletAddress: this.walletAddress,
+      });
     } catch (error) {
       handleError(error, "Failed to predict minting license fee");
     }

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -360,7 +360,7 @@ export class LicenseClient {
       const { licenseTermsId: defaultLicenseTermsId } =
         await this.licenseRegistryReadOnlyClient.getDefaultLicenseTerms();
       const ipOwner = await ipAccount.owner();
-      if (ipOwner !== this.walletAddress || defaultLicenseTermsId !== req.licenseTermsId) {
+      if (ipOwner !== this.walletAddress && defaultLicenseTermsId !== req.licenseTermsId) {
         const isAttachedLicenseTerms =
           await this.licenseRegistryReadOnlyClient.hasIpAttachedLicenseTerms({
             ipId: req.licensorIpId,
@@ -395,6 +395,7 @@ export class LicenseClient {
           amount: licenseMintingFee,
         });
       }
+      console.log("licenseMintingFee", licenseMintingFee);
       const { txHash, receipt } = await contractCallWithFees({
         totalFees: licenseMintingFee,
         options: { wipOptions: request.wipOptions },

--- a/packages/core-sdk/src/types/utils/wip.ts
+++ b/packages/core-sdk/src/types/utils/wip.ts
@@ -73,13 +73,3 @@ export type MulticallWithWrapIp = WithWipOptions & {
   rpcClient: PublicClient;
   wallet: SimpleWalletClient;
 };
-
-export type CalculateDerivativeMintFeeParams = {
-  multicall3Client: Multicall3Client;
-  licenseTemplateClient: PiLicenseTemplateClient;
-  licensingModuleClient: LicensingModuleClient;
-  parentIpId: Address;
-  licenseTermsId: bigint;
-  receiver: Address;
-  amount: bigint;
-};

--- a/packages/core-sdk/src/utils/feeUtils.ts
+++ b/packages/core-sdk/src/utils/feeUtils.ts
@@ -1,4 +1,4 @@
-import { maxUint256, zeroAddress } from "viem";
+import { maxUint256 } from "viem";
 
 import { multicall3Abi, SpgnftImplReadOnlyClient, wrappedIpAbi } from "../abi/generated";
 import { WIP_TOKEN_ADDRESS } from "../constants/common";
@@ -6,7 +6,6 @@ import { getTokenAmountDisplay } from "./utils";
 import {
   ApprovalCall,
   Multicall3ValueCall,
-  CalculateDerivativeMintFeeParams,
   MulticallWithWrapIp,
   ContractCallWithFees,
 } from "../types/utils/wip";
@@ -14,6 +13,10 @@ import { simulateAndWriteContract } from "./contract";
 import { handleTxOptions } from "./txOptions";
 import { TransactionResponse } from "../types/options";
 import { ERC20Client, WipTokenClient } from "./token";
+import {
+  predictMintingLicenseFee,
+  PredictMintingLicenseFeeParams,
+} from "./predictMintingLicenseFee";
 
 /**
  * check the allowance of all spenders and call approval if any spender
@@ -73,14 +76,17 @@ const approvalAllSpenders = async ({
   return [];
 };
 
-export const calculateLicenseWipMintFee = async (params: CalculateDerivativeMintFeeParams) => {
-  const fee = await params.licensingModuleClient.predictMintingLicenseFee({
-    licensorIpId: params.parentIpId,
-    licenseTemplate: params.licenseTemplateClient.address,
-    licenseTermsId: params.licenseTermsId,
-    amount: params.amount,
-    receiver: params.receiver,
-    royaltyContext: zeroAddress,
+export const calculateLicenseWipMintFee = async ({
+  predictMintingFeeRequest,
+  rpcClient,
+  chainId,
+  walletAddress,
+}: PredictMintingLicenseFeeParams) => {
+  const fee = await predictMintingLicenseFee({
+    predictMintingFeeRequest,
+    rpcClient,
+    chainId,
+    walletAddress,
   });
   if (fee.currencyToken !== WIP_TOKEN_ADDRESS) {
     return 0n;

--- a/packages/core-sdk/src/utils/predictMintingLicenseFee.ts
+++ b/packages/core-sdk/src/utils/predictMintingLicenseFee.ts
@@ -1,0 +1,48 @@
+import { Address, PublicClient } from "viem";
+
+import {
+  licensingModuleAbi,
+  licensingModuleAddress,
+  LicensingModulePredictMintingLicenseFeeRequest,
+  LicensingModulePredictMintingLicenseFeeResponse,
+} from "../abi/generated";
+import { ChainIds } from "../types/config";
+
+export type PredictMintingLicenseFeeParams = {
+  predictMintingFeeRequest: LicensingModulePredictMintingLicenseFeeRequest;
+  rpcClient: PublicClient;
+  chainId: ChainIds;
+  walletAddress: Address;
+};
+/**
+ * Predict the minting license fee.
+ *
+ * @remarks
+ * The method passes `walletAddress` to the `readContract` function so the smart contract can verify
+ * if the wallet is the owner of the IP ID. The wallet address is required when using the default license terms ID.
+ */
+export const predictMintingLicenseFee = async ({
+  predictMintingFeeRequest,
+  rpcClient,
+  chainId,
+  walletAddress,
+}: PredictMintingLicenseFeeParams): Promise<LicensingModulePredictMintingLicenseFeeResponse> => {
+  const result = await rpcClient.readContract({
+    abi: licensingModuleAbi,
+    address: licensingModuleAddress[chainId],
+    functionName: "predictMintingLicenseFee",
+    args: [
+      predictMintingFeeRequest.licensorIpId,
+      predictMintingFeeRequest.licenseTemplate,
+      predictMintingFeeRequest.licenseTermsId,
+      predictMintingFeeRequest.amount,
+      predictMintingFeeRequest.receiver,
+      predictMintingFeeRequest.royaltyContext,
+    ],
+    account: walletAddress,
+  });
+  return {
+    currencyToken: result[0],
+    tokenAmount: result[1],
+  };
+};

--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./utils/util";
 import { getDerivedStoryClient } from "./utils/BIP32";
 import chaiAsPromised from "chai-as-promised";
-import { Address, zeroAddress, Hex } from "viem";
+import { Address, zeroAddress, Hex, parseEther } from "viem";
 import {
   disputeModuleAddress,
   evenSplitGroupPoolAddress,

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./utils/util";
 import {
   erc20Address,
+  LicenseRegistryReadOnlyClient,
   licensingModuleAddress,
   piLicenseTemplateAddress,
 } from "../../src/abi/generated";
@@ -190,6 +191,23 @@ describe("License Functions", () => {
       expect(result.licenseTokenIds).to.be.a("array").and.not.empty;
     });
 
+    it.only("should mint license token with default license terms", async () => {
+      // get default license terms id
+      const licenseRegistryReadOnlyClient = new LicenseRegistryReadOnlyClient(publicClient);
+      const { licenseTermsId: defaultLicenseTermsId } =
+        await licenseRegistryReadOnlyClient.getDefaultLicenseTerms();
+
+      const result = await client.license.mintLicenseTokens({
+        licenseTermsId: defaultLicenseTermsId,
+        licensorIpId: ipId,
+        maxMintingFee: 0n,
+        maxRevenueShare: 1,
+        txOptions: { waitForTransaction: true },
+      });
+      
+      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.licenseTokenIds).to.be.a("array").and.not.empty;
+    });
     it("should mint license tokens with fee and pay with IP", async () => {
       const balanceBefore = await client.getWalletBalance();
       const result = await client.license.mintLicenseTokens({

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -191,7 +191,7 @@ describe("License Functions", () => {
       expect(result.licenseTokenIds).to.be.a("array").and.not.empty;
     });
 
-    it.only("should mint license token with default license terms", async () => {
+    it("should mint license token with default license terms", async () => {
       // get default license terms id
       const licenseRegistryReadOnlyClient = new LicenseRegistryReadOnlyClient(publicClient);
       const { licenseTermsId: defaultLicenseTermsId } =
@@ -204,10 +204,11 @@ describe("License Functions", () => {
         maxRevenueShare: 1,
         txOptions: { waitForTransaction: true },
       });
-      
+
       expect(result.txHash).to.be.a("string").and.not.empty;
       expect(result.licenseTokenIds).to.be.a("array").and.not.empty;
     });
+
     it("should mint license tokens with fee and pay with IP", async () => {
       const balanceBefore = await client.getWalletBalance();
       const result = await client.license.mintLicenseTokens({

--- a/packages/core-sdk/test/integration/utils/BIP32.ts
+++ b/packages/core-sdk/test/integration/utils/BIP32.ts
@@ -1,6 +1,9 @@
 import { HDKey } from "@scure/bip32";
-import { Hex } from "viem";
+import { createWalletClient, Hex, http, parseEther } from "viem";
 import * as crypto from "crypto";
+import { privateKeyToAccount } from "viem/accounts";
+import { getStoryClient, publicClient, RPC } from "./util";
+import { chainStringToViemChain } from "../../../src/utils/utils";
 
 /**
  * Extract a standard private key directly from an extended private key without derivation.
@@ -8,7 +11,7 @@ import * as crypto from "crypto";
  * @param xprv Extended private key
  * @returns Extracted standard private key as a hex string
  */
-export function getPrivateKeyFromXprv(xprv: string): Hex {
+function getPrivateKeyFromXprv(xprv: string): Hex {
   // Create HDKey instance from xprv
   const hdKey = HDKey.fromExtendedKey(xprv);
   // Extract the private key buffer
@@ -28,7 +31,7 @@ export function getPrivateKeyFromXprv(xprv: string): Hex {
  * @param privateKey Ethereum private key (with or without 0x prefix)
  * @returns Deterministically derived extended private key (xprv)
  */
-export function getXprvFromPrivateKey(privateKey: string | Hex): string {
+function getXprvFromPrivateKey(privateKey: string | Hex): string {
   // Remove 0x prefix if present
   const pkHex = privateKey.toString().replace(/^0x/, "");
 
@@ -51,3 +54,36 @@ export function getXprvFromPrivateKey(privateKey: string | Hex): string {
   // Return the extended private key (xprv)
   return hdKey.privateExtendedKey;
 }
+
+/**
+ * Get a StoryClient instance for a new wallet that is deterministically derived from an extended private key (xprv).
+ * The wallet is ensured to have a minimum balance of 5 tokens before being returned.
+ * @returns StoryClient instance for the new wallet
+ */
+export const getDerivedStoryClient = async () => {
+  const xprv = getXprvFromPrivateKey(process.env.WALLET_PRIVATE_KEY as string);
+  const privateKey = getPrivateKeyFromXprv(xprv);
+  const clientB = getStoryClient(privateKey);
+  const walletB = privateKeyToAccount(privateKey);
+
+  // ClientA transfer some funds to walletB
+  const clientAWalletClient = createWalletClient({
+    chain: chainStringToViemChain("aeneid"),
+    transport: http(RPC),
+    account: privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as Hex),
+  });
+  const clientBBalance = await publicClient.getBalance({
+    address: walletB.address,
+  });
+
+  if (clientBBalance < parseEther("5")) {
+    // Less than 5 tokens (assuming 1 token = 0.01 ETH)
+    const txHash = await clientAWalletClient.sendTransaction({
+      to: walletB.address,
+      value: parseEther("5"),
+    });
+    await publicClient.waitForTransactionReceipt({ hash: txHash });
+  }
+
+  return clientB;
+};

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -75,6 +75,8 @@ describe("Test IpAssetClient", () => {
     walletMock = createMock<WalletClient>();
     const accountMock = createMock<LocalAccount>();
     walletMock.account = accountMock;
+    // Mock predictMintingLicenseFee
+    rpcMock.readContract = sinon.stub().resolves([zeroAddress, 0n]);
     ipAssetClient = new IPAssetClient(rpcMock, walletMock, "1315");
     sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getDefaultLicenseTerms").resolves({
       licenseTemplate: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -1841,7 +1841,7 @@ describe("Test IpAssetClient", () => {
         isSet: false,
         mintingFee: 0n,
         licensingHook: zeroAddress,
-        hookData: zeroAddress,
+        hookData: zeroHash,
         commercialRevShare: 0,
         disabled: false,
         expectMinimumGroupRewardShare: 0,

--- a/packages/core-sdk/test/unit/utils/validateLicenseConfig.test.ts
+++ b/packages/core-sdk/test/unit/utils/validateLicenseConfig.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { zeroAddress } from "viem";
+import { zeroAddress, zeroHash } from "viem";
 import { validateLicenseConfig } from "../../../src/utils/validateLicenseConfig";
 
 describe("validateLicenseConfig", () => {
@@ -84,7 +84,7 @@ describe("validateLicenseConfig", () => {
       isSet: false,
       mintingFee: 0n,
       licensingHook: zeroAddress,
-      hookData: zeroAddress,
+      hookData: zeroHash,
       commercialRevShare: 0,
       disabled: false,
       expectMinimumGroupRewardShare: 0,


### PR DESCRIPTION
## Description
1. Refactor the attached license terms check from `mintLicenseTokens` . The license terms must be attached to the IP ID,  with two exceptions:
    1. Default license terms can be minted without explicit attachment since they are automatically
    2. IP owners have special privileges and can mint license tokens for their own IPs using any license terms, even if those terms are not explicitly attached.

2. Create the `getDerivedStoryClient` method to generate a derived story client in the integration test.
3. Fix bug when calling `predictMintingLicenseFee` method with default license id.
