### PR TITLE
Fix issue about registerDerivative method

### DIFF
--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -358,7 +358,7 @@ export class IPAssetClient {
           contractCall,
           txOptions: request.txOptions,
           encodedTxs: [encodedTxData],
-          spgSpenderAddress: this.royaltyTokenDistributionWorkflowsClient.address,
+          spgSpenderAddress: this.royaltyModuleEventClient.address,
           wipOptions: {
             ...request.wipOptions,
             useMulticallWhenPossible: false,

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -113,6 +113,7 @@ describe("IP Asset Functions", () => {
           txOptions: { waitForTransaction: true },
         })
       ).ipId!;
+
       await client.license.attachLicenseTerms({
         ipId: parentIpId,
         licenseTermsId: noCommercialLicenseTermsId,
@@ -120,7 +121,7 @@ describe("IP Asset Functions", () => {
       });
 
       const response = await client.ipAsset.registerDerivative({
-        childIpId: childIpId2,
+        childIpId: childIpId,
         parentIpIds: [parentIpId],
         licenseTermsIds: [noCommercialLicenseTermsId],
         maxMintingFee: "0",
@@ -158,7 +159,7 @@ describe("IP Asset Functions", () => {
       });
 
       const response = await client.ipAsset.registerDerivative({
-        childIpId: childIpId,
+        childIpId: childIpId2,
         parentIpIds: [commercialParentIpId],
         licenseTermsIds: [licenseResponse.licenseTermsId!],
         maxMintingFee: "100",

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -103,6 +103,15 @@ describe("IP Asset Functions", () => {
     });
 
     it("should register derivative", async () => {
+      // Register commercial remix PIL
+      const licenseResponse = await client.license.registerCommercialRemixPIL({
+        defaultMintingFee: 10n,
+        commercialRevShare: 10,
+        currency: WIP_TOKEN_ADDRESS,
+        txOptions: { waitForTransaction: true },
+      });
+
+      // Register parent IP
       const tokenId = await getTokenId();
       parentIpId = (
         await client.ipAsset.register({
@@ -112,19 +121,20 @@ describe("IP Asset Functions", () => {
         })
       ).ipId!;
 
+      // Attach license terms to parent IP
       await client.license.attachLicenseTerms({
         ipId: parentIpId,
-        licenseTermsId: noCommercialLicenseTermsId,
+        licenseTermsId: licenseResponse.licenseTermsId!,
         txOptions: { waitForTransaction: true },
       });
 
       const response = await client.ipAsset.registerDerivative({
         childIpId: childIpId,
         parentIpIds: [parentIpId],
-        licenseTermsIds: [noCommercialLicenseTermsId],
-        maxMintingFee: "0",
+        licenseTermsIds: [licenseResponse.licenseTermsId!],
+        maxMintingFee: "100",
         maxRts: 5 * 10 ** 6,
-        maxRevenueShare: "0",
+        maxRevenueShare: "100",
         txOptions: { waitForTransaction: true },
       });
       expect(response.txHash).to.be.a("string").and.not.empty;


### PR DESCRIPTION
## Description
Fix the wrong spender from `royaltyTokenDistributionWorkflows` to `royaltyModule` in the `registerDerivative` method.

