### PR TITLE
fix: remove default license check for mint license tokens

### DIFF
--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -357,10 +357,8 @@ export class LicenseClient {
         throw new Error(`License terms id ${request.licenseTermsId} do not exist.`);
       }
       const ipAccount = new IpAccountImplClient(this.rpcClient, this.wallet, req.licensorIpId);
-      const { licenseTermsId: defaultLicenseTermsId } =
-        await this.licenseRegistryReadOnlyClient.getDefaultLicenseTerms();
       const ipOwner = await ipAccount.owner();
-      if (ipOwner !== this.walletAddress && defaultLicenseTermsId !== req.licenseTermsId) {
+      if (ipOwner !== this.walletAddress) {
         const isAttachedLicenseTerms =
           await this.licenseRegistryReadOnlyClient.hasIpAttachedLicenseTerms({
             ipId: req.licensorIpId,


### PR DESCRIPTION
## Description

Default license terms no longer are attached to ip assets by default.
Updating mint tokens logic to ensure we check that parent has the license terms even if its the default terms.