### PR TITLE
Add addIp method 

### DIFF
--- a/packages/core-sdk/src/abi/generated.ts
+++ b/packages/core-sdk/src/abi/generated.ts
@@ -18772,12 +18772,36 @@ export type GroupingModuleIpGroupRegisteredEvent = {
 };
 
 /**
+ * GroupingModuleAddIpRequest
+ *
+ * @param groupIpId address
+ * @param ipIds address[]
+ * @param maxAllowedRewardShare uint256
+ */
+export type GroupingModuleAddIpRequest = {
+  groupIpId: Address;
+  ipIds: readonly Address[];
+  maxAllowedRewardShare: bigint;
+};
+
+/**
  * GroupingModuleRegisterGroupRequest
  *
  * @param groupPool address
  */
 export type GroupingModuleRegisterGroupRequest = {
   groupPool: Address;
+};
+
+/**
+ * GroupingModuleRemoveIpRequest
+ *
+ * @param groupIpId address
+ * @param ipIds address[]
+ */
+export type GroupingModuleRemoveIpRequest = {
+  groupIpId: Address;
+  ipIds: readonly Address[];
 };
 
 /**
@@ -18887,6 +18911,40 @@ export class GroupingModuleClient extends GroupingModuleEventClient {
   }
 
   /**
+   * method addIp for contract GroupingModule
+   *
+   * @param request GroupingModuleAddIpRequest
+   * @return Promise<WriteContractReturnType>
+   */
+  public async addIp(request: GroupingModuleAddIpRequest): Promise<WriteContractReturnType> {
+    const { request: call } = await this.rpcClient.simulateContract({
+      abi: groupingModuleAbi,
+      address: this.address,
+      functionName: "addIp",
+      account: this.wallet.account,
+      args: [request.groupIpId, request.ipIds, request.maxAllowedRewardShare],
+    });
+    return await this.wallet.writeContract(call as WriteContractParameters);
+  }
+
+  /**
+   * method addIp for contract GroupingModule with only encode
+   *
+   * @param request GroupingModuleAddIpRequest
+   * @return EncodedTxData
+   */
+  public addIpEncode(request: GroupingModuleAddIpRequest): EncodedTxData {
+    return {
+      to: this.address,
+      data: encodeFunctionData({
+        abi: groupingModuleAbi,
+        functionName: "addIp",
+        args: [request.groupIpId, request.ipIds, request.maxAllowedRewardShare],
+      }),
+    };
+  }
+
+  /**
    * method registerGroup for contract GroupingModule
    *
    * @param request GroupingModuleRegisterGroupRequest
@@ -18918,6 +18976,40 @@ export class GroupingModuleClient extends GroupingModuleEventClient {
         abi: groupingModuleAbi,
         functionName: "registerGroup",
         args: [request.groupPool],
+      }),
+    };
+  }
+
+  /**
+   * method removeIp for contract GroupingModule
+   *
+   * @param request GroupingModuleRemoveIpRequest
+   * @return Promise<WriteContractReturnType>
+   */
+  public async removeIp(request: GroupingModuleRemoveIpRequest): Promise<WriteContractReturnType> {
+    const { request: call } = await this.rpcClient.simulateContract({
+      abi: groupingModuleAbi,
+      address: this.address,
+      functionName: "removeIp",
+      account: this.wallet.account,
+      args: [request.groupIpId, request.ipIds],
+    });
+    return await this.wallet.writeContract(call as WriteContractParameters);
+  }
+
+  /**
+   * method removeIp for contract GroupingModule with only encode
+   *
+   * @param request GroupingModuleRemoveIpRequest
+   * @return EncodedTxData
+   */
+  public removeIpEncode(request: GroupingModuleRemoveIpRequest): EncodedTxData {
+    return {
+      to: this.address,
+      data: encodeFunctionData({
+        abi: groupingModuleAbi,
+        functionName: "removeIp",
+        args: [request.groupIpId, request.ipIds],
       }),
     };
   }
@@ -24912,70 +25004,6 @@ export class RoyaltyModuleClient extends RoyaltyModuleReadOnlyClient {
 }
 
 // Contract RoyaltyPolicyLAP =============================================================
-
-/**
- * RoyaltyPolicyLapTransferToVaultRequest
- *
- * @param ipId address
- * @param ancestorIpId address
- * @param token address
- */
-export type RoyaltyPolicyLapTransferToVaultRequest = {
-  ipId: Address;
-  ancestorIpId: Address;
-  token: Address;
-};
-
-/**
- * contract RoyaltyPolicyLAP write method
- */
-export class RoyaltyPolicyLapClient {
-  protected readonly wallet: SimpleWalletClient;
-  protected readonly rpcClient: PublicClient;
-  public readonly address: Address;
-
-  constructor(rpcClient: PublicClient, wallet: SimpleWalletClient, address?: Address) {
-    this.address = address || getAddress(royaltyPolicyLapAddress, rpcClient.chain?.id);
-    this.rpcClient = rpcClient;
-    this.wallet = wallet;
-  }
-
-  /**
-   * method transferToVault for contract RoyaltyPolicyLAP
-   *
-   * @param request RoyaltyPolicyLapTransferToVaultRequest
-   * @return Promise<WriteContractReturnType>
-   */
-  public async transferToVault(
-    request: RoyaltyPolicyLapTransferToVaultRequest,
-  ): Promise<WriteContractReturnType> {
-    const { request: call } = await this.rpcClient.simulateContract({
-      abi: royaltyPolicyLapAbi,
-      address: this.address,
-      functionName: "transferToVault",
-      account: this.wallet.account,
-      args: [request.ipId, request.ancestorIpId, request.token],
-    });
-    return await this.wallet.writeContract(call as WriteContractParameters);
-  }
-
-  /**
-   * method transferToVault for contract RoyaltyPolicyLAP with only encode
-   *
-   * @param request RoyaltyPolicyLapTransferToVaultRequest
-   * @return EncodedTxData
-   */
-  public transferToVaultEncode(request: RoyaltyPolicyLapTransferToVaultRequest): EncodedTxData {
-    return {
-      to: this.address,
-      data: encodeFunctionData({
-        abi: royaltyPolicyLapAbi,
-        functionName: "transferToVault",
-        args: [request.ipId, request.ancestorIpId, request.token],
-      }),
-    };
-  }
-}
 
 // Contract RoyaltyPolicyLRP =============================================================
 

--- a/packages/core-sdk/src/abi/generated.ts
+++ b/packages/core-sdk/src/abi/generated.ts
@@ -18746,6 +18746,17 @@ export class EvenSplitGroupPoolClient extends EvenSplitGroupPoolReadOnlyClient {
 // Contract GroupingModule =============================================================
 
 /**
+ * GroupingModuleAddedIpToGroupEvent
+ *
+ * @param groupId address
+ * @param ipIds address[]
+ */
+export type GroupingModuleAddedIpToGroupEvent = {
+  groupId: Address;
+  ipIds: readonly Address[];
+};
+
+/**
  * GroupingModuleCollectedRoyaltiesToGroupPoolEvent
  *
  * @param groupId address
@@ -18814,6 +18825,47 @@ export class GroupingModuleEventClient {
   constructor(rpcClient: PublicClient, address?: Address) {
     this.address = address || getAddress(groupingModuleAddress, rpcClient.chain?.id);
     this.rpcClient = rpcClient;
+  }
+
+  /**
+   * event AddedIpToGroup for contract GroupingModule
+   */
+  public watchAddedIpToGroupEvent(
+    onLogs: (txHash: Hex, ev: Partial<GroupingModuleAddedIpToGroupEvent>) => void,
+  ): WatchContractEventReturnType {
+    return this.rpcClient.watchContractEvent({
+      abi: groupingModuleAbi,
+      address: this.address,
+      eventName: "AddedIpToGroup",
+      onLogs: (evs) => {
+        evs.forEach((it) => onLogs(it.transactionHash, it.args));
+      },
+    });
+  }
+
+  /**
+   * parse tx receipt event AddedIpToGroup for contract GroupingModule
+   */
+  public parseTxAddedIpToGroupEvent(
+    txReceipt: TransactionReceipt,
+  ): Array<GroupingModuleAddedIpToGroupEvent> {
+    const targetLogs: Array<GroupingModuleAddedIpToGroupEvent> = [];
+    for (const log of txReceipt.logs) {
+      try {
+        const event = decodeEventLog({
+          abi: groupingModuleAbi,
+          eventName: "AddedIpToGroup",
+          data: log.data,
+          topics: log.topics,
+        });
+        if (event.eventName === "AddedIpToGroup") {
+          targetLogs.push(event.args);
+        }
+      } catch (e) {
+        /* empty */
+      }
+    }
+    return targetLogs;
   }
 
   /**

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -474,7 +474,7 @@ export class GroupClient {
    * Adds IPs to group.
    * The function must be called by the Group IP owner or an authorized operator.
    */
-  public async addIp({
+  public async addIpsToGroup({
     groupIpId,
     ipIds,
     maxAllowedRewardShare,

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -477,7 +477,7 @@ export class GroupClient {
   public async addIpsToGroup({
     groupIpId,
     ipIds,
-    maxAllowedRewardShare,
+    maxAllowedRewardSharePercentage,
     txOptions,
   }: AddIpRequest): Promise<TransactionResponse> {
     try {
@@ -485,7 +485,10 @@ export class GroupClient {
         groupIpId: validateAddress(groupIpId),
         ipIds: validateAddresses(ipIds),
         maxAllowedRewardShare: BigInt(
-          getRevenueShare(maxAllowedRewardShare, RevShareType.MAX_ALLOWED_REWARD_SHARE),
+          getRevenueShare(
+            maxAllowedRewardSharePercentage || 100,
+            RevShareType.MAX_ALLOWED_REWARD_SHARE,
+          ),
         ),
       };
       const txHash = await this.groupingModuleClient.addIp(addIpParam);

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -148,7 +148,8 @@ export type AddIpRequest = {
   /**
    * The maximum reward share percentage that can be allocated to each member IP.
    * Must be between 0 and 100 (where 100% represents 100_000_000).
+   * @default 100
    */
-  maxAllowedRewardShare: number | string;
+  maxAllowedRewardSharePercentage?: number;
   txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
 };

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -137,3 +137,18 @@ export type CollectAndDistributeGroupRoyaltiesResponse = {
     amountAfterFee: bigint;
   }[];
 };
+
+export type AddIpRequest = {
+  groupIpId: Address;
+  /**
+   * The addresses of the IPs to add to the Group IP.
+   * IP IDs must be attached to the group IP license terms.
+   */
+  ipIds: Address[];
+  /**
+   * The maximum reward share percentage that can be allocated to each member IP.
+   * Must be between 0 and 100 (where 100% represents 100_000_000).
+   */
+  maxAllowedRewardShare: number | string;
+  txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
+};

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -19,6 +19,39 @@ describe("Group Functions", () => {
   let ipId: Address;
   let licenseTermsId: bigint;
   const groupPoolAddress = evenSplitGroupPoolAddress[aeneid];
+  const licenseTermsData: LicenseTermsData[] = [
+    {
+      terms: {
+        transferable: true,
+        royaltyPolicy: royaltyPolicyLrpAddress[aeneid],
+        defaultMintingFee: 0n,
+        expiration: BigInt(1000),
+        commercialUse: true,
+        commercialAttribution: false,
+        commercializerChecker: zeroAddress,
+        commercializerCheckerData: zeroAddress,
+        commercialRevShare: 0,
+        commercialRevCeiling: BigInt(0),
+        derivativesAllowed: true,
+        derivativesAttribution: true,
+        derivativesApproval: false,
+        derivativesReciprocal: true,
+        derivativeRevCeiling: BigInt(0),
+        currency: WIP_TOKEN_ADDRESS,
+        uri: "test case",
+      },
+      licensingConfig: {
+        isSet: true,
+        mintingFee: 0n,
+        licensingHook: zeroAddress,
+        hookData: zeroAddress,
+        commercialRevShare: 0,
+        disabled: false,
+        expectMinimumGroupRewardShare: 0,
+        expectGroupRewardPool: groupPoolAddress,
+      },
+    },
+  ];
 
   // Setup - create necessary contracts and initial IP
   before(async () => {
@@ -42,39 +75,7 @@ describe("Group Functions", () => {
     const result = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
       spgNftContract,
       allowDuplicates: false,
-      licenseTermsData: [
-        {
-          terms: {
-            transferable: true,
-            royaltyPolicy: royaltyPolicyLrpAddress[aeneid],
-            defaultMintingFee: 0n,
-            expiration: BigInt(1000),
-            commercialUse: true,
-            commercialAttribution: false,
-            commercializerChecker: zeroAddress,
-            commercializerCheckerData: zeroAddress,
-            commercialRevShare: 0,
-            commercialRevCeiling: BigInt(0),
-            derivativesAllowed: true,
-            derivativesAttribution: true,
-            derivativesApproval: false,
-            derivativesReciprocal: true,
-            derivativeRevCeiling: BigInt(0),
-            currency: WIP_TOKEN_ADDRESS,
-            uri: "test case",
-          },
-          licensingConfig: {
-            isSet: true,
-            mintingFee: 0n,
-            licensingHook: zeroAddress,
-            hookData: zeroAddress,
-            commercialRevShare: 0,
-            disabled: false,
-            expectMinimumGroupRewardShare: 0,
-            expectGroupRewardPool: groupPoolAddress,
-          },
-        },
-      ],
+      licenseTermsData,
       txOptions: { waitForTransaction: true },
     });
 
@@ -252,6 +253,35 @@ describe("Group Functions", () => {
           txOptions: { waitForTransaction: true },
         }),
       ).to.be.rejectedWith("Failed to register group and attach license and add ips");
+    });
+
+    it("should successfully add IP to group", async () => {
+      const registerResult = await client.ipAsset.batchMintAndRegisterIpAssetWithPilTerms({
+        args: [
+          {
+            spgNftContract,
+            licenseTermsData,
+          },
+          {
+            spgNftContract,
+            licenseTermsData,
+          },
+          {
+            spgNftContract,
+            licenseTermsData,
+          },
+        ],
+        txOptions: { waitForTransaction: true },
+      });
+      const ipIds = registerResult.results?.map((result) => result.ipId);
+
+      const result = await client.groupClient.addIp({
+        groupIpId: groupId,
+        ipIds: ipIds!,
+        maxAllowedRewardShare: 5,
+        txOptions: { waitForTransaction: true },
+      });
+      expect(result.txHash).to.be.a("string").and.not.empty;
     });
   });
 

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -255,7 +255,7 @@ describe("Group Functions", () => {
       ).to.be.rejectedWith("Failed to register group and attach license and add ips");
     });
 
-    it("should successfully add IP to group", async () => {
+    it("should successfully add multiple IPs to group", async () => {
       const registerResult = await client.ipAsset.batchMintAndRegisterIpAssetWithPilTerms({
         args: [
           {
@@ -275,7 +275,7 @@ describe("Group Functions", () => {
       });
       const ipIds = registerResult.results?.map((result) => result.ipId);
 
-      const result = await client.groupClient.addIp({
+      const result = await client.groupClient.addIpsToGroup({
         groupIpId: groupId,
         ipIds: ipIds!,
         maxAllowedRewardShare: 5,

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -278,7 +278,7 @@ describe("Group Functions", () => {
       const result = await client.groupClient.addIpsToGroup({
         groupIpId: groupId,
         ipIds: ipIds!,
-        maxAllowedRewardShare: 5,
+        maxAllowedRewardSharePercentage: 5,
         txOptions: { waitForTransaction: true },
       });
       expect(result.txHash).to.be.a("string").and.not.empty;

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -684,4 +684,28 @@ describe("Test IpAssetClient", () => {
       ]);
     });
   });
+
+  describe("Test groupClient.addIp", async () => {
+    it("should throw error when given ipId is wrong address", async () => {
+      const result = groupClient.addIp({
+        groupIpId: mockAddress,
+        ipIds: ["0x"],
+        maxAllowedRewardShare: 5,
+      });
+      await expect(result).to.be.rejectedWith("Failed to add IP to group: Invalid address: 0x.");
+    });
+
+    it("should return txHash when call addIp successfully", async () => {
+      sinon.stub(groupClient.groupingModuleClient, "addIp").resolves(txHash);
+      const result = await groupClient.addIp({
+        groupIpId: mockAddress,
+        ipIds: [mockAddress],
+        maxAllowedRewardShare: 5,
+        txOptions: {
+          waitForTransaction: true,
+        },
+      });
+      expect(result.txHash).equal(txHash);
+    });
+  });
 });

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -686,13 +686,13 @@ describe("Test IpAssetClient", () => {
   });
 
   describe("Test groupClient.addIp", async () => {
-    it("should throw error when given ipId is wrong address", async () => {
+    it("should throw error when call fail", async () => {
+      sinon.stub(groupClient.groupingModuleClient, "addIp").rejects(new Error("rpc error"));
       const result = groupClient.addIpsToGroup({
         groupIpId: mockAddress,
-        ipIds: ["0x"],
-        maxAllowedRewardShare: 5,
+        ipIds: [mockAddress],
       });
-      await expect(result).to.be.rejectedWith("Failed to add IP to group: Invalid address: 0x.");
+      await expect(result).to.be.rejectedWith("Failed to add IP to group: rpc error");
     });
 
     it("should return txHash when call addIp successfully", async () => {
@@ -700,7 +700,7 @@ describe("Test IpAssetClient", () => {
       const result = await groupClient.addIpsToGroup({
         groupIpId: mockAddress,
         ipIds: [mockAddress],
-        maxAllowedRewardShare: 5,
+        maxAllowedRewardSharePercentage: 5,
         txOptions: {
           waitForTransaction: true,
         },

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -687,7 +687,7 @@ describe("Test IpAssetClient", () => {
 
   describe("Test groupClient.addIp", async () => {
     it("should throw error when given ipId is wrong address", async () => {
-      const result = groupClient.addIp({
+      const result = groupClient.addIpsToGroup({
         groupIpId: mockAddress,
         ipIds: ["0x"],
         maxAllowedRewardShare: 5,
@@ -697,7 +697,7 @@ describe("Test IpAssetClient", () => {
 
     it("should return txHash when call addIp successfully", async () => {
       sinon.stub(groupClient.groupingModuleClient, "addIp").resolves(txHash);
-      const result = await groupClient.addIp({
+      const result = await groupClient.addIpsToGroup({
         groupIpId: mockAddress,
         ipIds: [mockAddress],
         maxAllowedRewardShare: 5,

--- a/packages/wagmi-generator/wagmi.config.ts
+++ b/packages/wagmi-generator/wagmi.config.ts
@@ -361,7 +361,6 @@ export default defineConfig(async () => {
             "registerGroup",
             "IPGroupRegistered",
             "addIp",
-            "removeIp",
           ],
         },
       }),

--- a/packages/wagmi-generator/wagmi.config.ts
+++ b/packages/wagmi-generator/wagmi.config.ts
@@ -360,6 +360,8 @@ export default defineConfig(async () => {
             "CollectedRoyaltiesToGroupPool",
             "registerGroup",
             "IPGroupRegistered",
+            "addIp",
+            "removeIp",
           ],
         },
       }),


### PR DESCRIPTION
## Description  
This PR implements the `addIpsToGroup` method in the group module, mirroring the functionality of the [Smart Contract `addIp` method](https://github.com/storyprotocol/protocol-core-v1/blob/main/contracts/modules/grouping/GroupingModule.sol#L149).

## Changes  
- Added `addIpsToGroup` method to the `group` module  
- Introduced corresponding `AddIpRequest` type in `group` types  

## Testing  
**Unit Tests Added:**  
- Validates error throwing for invalid IP addresses  
- Verifies successful transaction hash return  

**Integration Test Added:**  
- Ensures successful addition of multiple IPs to a group  

