### PR TITLE
Add creative commons attribution method

### DIFF
--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -55,6 +55,7 @@ import { validateLicenseConfig } from "../utils/validateLicenseConfig";
 import { LicensingConfig, RevShareType } from "../types/common";
 import { predictMintingLicenseFee } from "../utils/calculateMintFee";
 import { waitForTxReceipt } from "../utils/txOptions";
+import { TxOptions } from "../types/options";
 
 export class LicenseClient {
   public licensingModuleClient: LicensingModuleClient;
@@ -96,34 +97,16 @@ export class LicenseClient {
       if (licenseTermsId !== 0n) {
         return { licenseTermsId: licenseTermsId };
       }
-      if (request?.txOptions?.encodedTxDataOnly) {
-        return {
-          encodedTxData: this.licenseTemplateClient.registerLicenseTermsEncode({
-            terms: object,
-          }),
-        };
-      } else {
-        const txHash = await this.licenseTemplateClient.registerLicenseTerms({
-          terms: object,
-        });
-        if (request?.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({
-            ...request.txOptions,
-            hash: txHash,
-          });
-          const targetLogs =
-            this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(txReceipt);
-          return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
-        } else {
-          return { txHash: txHash };
-        }
-      }
+      return await this.registerPILTermsHelper(object, request.txOptions);
     } catch (error) {
       handleError(error, "Failed to register license terms");
     }
   }
+
   /**
    * Convenient function to register a PIL non commercial social remix license to the registry
+   *
+   * For more details, see {@link https://docs.story.foundation/concepts/programmable-ip-license/pil-flavors#flavor-%231%3A-non-commercial-social-remixing | Non Commercial Social Remixing}.
    *
    * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | `LicenseTermsRegistered`} event.
    */
@@ -132,38 +115,15 @@ export class LicenseClient {
   ): Promise<RegisterPILResponse> {
     try {
       const licenseTerms = getLicenseTermByType(PIL_TYPE.NON_COMMERCIAL_REMIX);
-      const licenseTermsId = await this.getLicenseTermsId(licenseTerms);
-      if (licenseTermsId !== 0n) {
-        return { licenseTermsId: licenseTermsId };
-      }
-      if (request?.txOptions?.encodedTxDataOnly) {
-        return {
-          encodedTxData: this.licenseTemplateClient.registerLicenseTermsEncode({
-            terms: licenseTerms,
-          }),
-        };
-      } else {
-        const txHash = await this.licenseTemplateClient.registerLicenseTerms({
-          terms: licenseTerms,
-        });
-        if (request?.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({
-            ...request.txOptions,
-            hash: txHash,
-          });
-          const targetLogs =
-            this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(txReceipt);
-          return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
-        } else {
-          return { txHash: txHash };
-        }
-      }
+      return await this.registerPILTermsHelper(licenseTerms, request?.txOptions);
     } catch (error) {
       handleError(error, "Failed to register non commercial social remixing PIL");
     }
   }
   /**
    * Convenient function to register a PIL commercial use license to the registry.
+   *
+   * For more details, see {@link https://docs.story.foundation/concepts/programmable-ip-license/pil-flavors#flavor-%232%3A-commercial-use | Commercial Use}.
    *
    * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | `LicenseTermsRegistered`} event.
    */
@@ -178,38 +138,15 @@ export class LicenseClient {
           request.royaltyPolicyAddress || royaltyPolicyLapAddress[chain[this.chainId]],
         ),
       });
-      const licenseTermsId = await this.getLicenseTermsId(licenseTerms);
-      if (licenseTermsId !== 0n) {
-        return { licenseTermsId: licenseTermsId };
-      }
-      if (request.txOptions?.encodedTxDataOnly) {
-        return {
-          encodedTxData: this.licenseTemplateClient.registerLicenseTermsEncode({
-            terms: licenseTerms,
-          }),
-        };
-      } else {
-        const txHash = await this.licenseTemplateClient.registerLicenseTerms({
-          terms: licenseTerms,
-        });
-        if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({
-            ...request.txOptions,
-            hash: txHash,
-          });
-          const targetLogs =
-            this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(txReceipt);
-          return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
-        } else {
-          return { txHash: txHash };
-        }
-      }
+      return await this.registerPILTermsHelper(licenseTerms, request.txOptions);
     } catch (error) {
       handleError(error, "Failed to register commercial use PIL");
     }
   }
   /**
    * Convenient function to register a PIL commercial Remix license to the registry.
+   *
+   * For more details, see {@link https://docs.story.foundation/concepts/programmable-ip-license/pil-flavors#flavor-%233%3A-commercial-remix | Commercial Remix }.
    *
    * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | `LicenseTermsRegistered`} event.
    */
@@ -225,32 +162,7 @@ export class LicenseClient {
         ),
         commercialRevShare: request.commercialRevShare,
       });
-      const licenseTermsId = await this.getLicenseTermsId(licenseTerms);
-      if (licenseTermsId !== 0n) {
-        return { licenseTermsId: licenseTermsId };
-      }
-      if (request.txOptions?.encodedTxDataOnly) {
-        return {
-          encodedTxData: this.licenseTemplateClient.registerLicenseTermsEncode({
-            terms: licenseTerms,
-          }),
-        };
-      } else {
-        const txHash = await this.licenseTemplateClient.registerLicenseTerms({
-          terms: licenseTerms,
-        });
-        if (request.txOptions?.waitForTransaction) {
-          const txReceipt = await this.rpcClient.waitForTransactionReceipt({
-            ...request.txOptions,
-            hash: txHash,
-          });
-          const targetLogs =
-            this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(txReceipt);
-          return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
-        } else {
-          return { txHash: txHash };
-        }
-      }
+      return await this.registerPILTermsHelper(licenseTerms, request.txOptions);
     } catch (error) {
       handleError(error, "Failed to register commercial remix PIL");
     }
@@ -259,7 +171,7 @@ export class LicenseClient {
    * Convenient function to register a PIL creative commons attribution license to the registry.
    * Creates a Creative Commons Attribution (CC-BY) license terms flavor.
    *
-   * For more details, see {@link https://docs.story.foundation/concepts/programmable-ip-license/pil-flavors#flavor-%234%3A-creative-commons-attribution | Creative Commons Attribution PIL}.
+   * For more details, see {@link https://docs.story.foundation/concepts/programmable-ip-license/pil-flavors#flavor-%234%3A-creative-commons-attribution | Creative Commons Attribution}.
    *
    * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/licensing/ILicenseTemplate.sol#L19 | `LicenseTermsRegistered`} event.
    */
@@ -269,28 +181,14 @@ export class LicenseClient {
     txOptions,
   }: RegisterCreativeCommonsAttributionPILRequest): Promise<RegisterPILResponse> {
     try {
-      const licenseTerms = getLicenseTermByType(PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION, {
-        currency,
-        royaltyPolicyAddress: royaltyPolicyAddress || royaltyPolicyLapAddress[chain[this.chainId]],
-      });
-      const licenseTermsId = await this.getLicenseTermsId(licenseTerms);
-      if (licenseTermsId !== 0n) {
-        return { licenseTermsId: licenseTermsId };
-      }
-      const txHash = await this.licenseTemplateClient.registerLicenseTerms({
-        terms: licenseTerms,
-      });
-
-      const { receipt } = await waitForTxReceipt({
-        ...txOptions,
-        rpcClient: this.rpcClient,
-        txHash,
-      });
-      if (!receipt) {
-        return { txHash };
-      }
-      const targetLogs = this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(receipt);
-      return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
+      return await this.registerPILTermsHelper(
+        getLicenseTermByType(PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION, {
+          currency,
+          royaltyPolicyAddress:
+            royaltyPolicyAddress || royaltyPolicyLapAddress[chain[this.chainId]],
+        }),
+        txOptions,
+      );
     } catch (error) {
       handleError(error, "Failed to register creative commons attribution PIL");
     }
@@ -597,5 +495,37 @@ export class LicenseClient {
   private async getLicenseTermsId(request: LicenseTerms): Promise<LicenseTermsIdResponse> {
     const licenseRes = await this.licenseTemplateClient.getLicenseTermsId({ terms: request });
     return licenseRes.selectedLicenseTermsId;
+  }
+
+  private async registerPILTermsHelper(
+    licenseTerms: LicenseTerms,
+    txOptions?: TxOptions,
+  ): Promise<RegisterPILResponse> {
+    if (txOptions?.encodedTxDataOnly) {
+      return {
+        encodedTxData: this.licenseTemplateClient.registerLicenseTermsEncode({
+          terms: licenseTerms,
+        }),
+      };
+    } else {
+      const licenseTermsId = await this.getLicenseTermsId(licenseTerms);
+      if (licenseTermsId !== 0n) {
+        return { licenseTermsId: licenseTermsId };
+      }
+      const txHash = await this.licenseTemplateClient.registerLicenseTerms({
+        terms: licenseTerms,
+      });
+
+      const { receipt } = await waitForTxReceipt({
+        txOptions,
+        rpcClient: this.rpcClient,
+        txHash,
+      });
+      if (!receipt) {
+        return { txHash };
+      }
+      const targetLogs = this.licenseTemplateClient.parseTxLicenseTermsRegisteredEvent(receipt);
+      return { txHash: txHash, licenseTermsId: targetLogs[0].licenseTermsId };
+    }
   }
 }

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -116,6 +116,17 @@ export type RegisterCommercialRemixPILRequest = {
   txOptions?: TxOptions;
 };
 
+export type RegisterCreativeCommonsAttributionPILRequest = {
+  /** The ERC20 or WIP token to be used to pay the minting fee. */
+  currency: Address;
+  /**
+   * The address of the royalty policy contract.
+   * Defaults to {@link https://docs.story.foundation/docs/liquid-absolute-percentage | LAP} policy address if not provided.
+   */
+  royaltyPolicyAddress?: Address;
+  txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
+};
+
 export type AttachLicenseTermsRequest = {
   /** The address of the IP ID to which the license terms are being attached. */
   ipId: Address;
@@ -167,6 +178,7 @@ export enum PIL_TYPE {
   NON_COMMERCIAL_REMIX,
   COMMERCIAL_USE,
   COMMERCIAL_REMIX,
+  CREATIVE_COMMONS_ATTRIBUTION,
 }
 
 export type LicenseTermsId = string | number | bigint;

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -116,7 +116,7 @@ export type RegisterCommercialRemixPILRequest = {
   txOptions?: TxOptions;
 };
 
-export type RegisterCreativeCommonsAttributionPILRequest = {
+export type RegisterCreativeCommonsAttributionPILRequest = WithTxOptions & {
   /** The ERC20 or WIP token to be used to pay the minting fee. */
   currency: Address;
   /**
@@ -124,7 +124,6 @@ export type RegisterCreativeCommonsAttributionPILRequest = {
    * Defaults to {@link https://docs.story.foundation/docs/liquid-absolute-percentage | LAP} policy address if not provided.
    */
   royaltyPolicyAddress?: Address;
-  txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
 };
 
 export type AttachLicenseTermsRequest = {

--- a/packages/core-sdk/src/utils/licenseTermsHelper.ts
+++ b/packages/core-sdk/src/utils/licenseTermsHelper.ts
@@ -90,6 +90,7 @@ export function getLicenseTermByType(
     licenseTerms.currency = validateAddress(term.currency);
     return licenseTerms;
   }
+  return licenseTerms;
 }
 
 export async function validateLicenseTerms(

--- a/packages/core-sdk/src/utils/licenseTermsHelper.ts
+++ b/packages/core-sdk/src/utils/licenseTermsHelper.ts
@@ -68,7 +68,7 @@ export function getLicenseTermByType(
       "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/CC-BY.json";
 
     return licenseTerms;
-  } else if (type === PIL_TYPE.COMMERCIAL_REMIX) {
+  } else {
     if (
       !term ||
       term.defaultMintingFee === undefined ||
@@ -90,7 +90,6 @@ export function getLicenseTermByType(
     licenseTerms.currency = validateAddress(term.currency);
     return licenseTerms;
   }
-  return licenseTerms;
 }
 
 export async function validateLicenseTerms(

--- a/packages/core-sdk/src/utils/licenseTermsHelper.ts
+++ b/packages/core-sdk/src/utils/licenseTermsHelper.ts
@@ -54,7 +54,21 @@ export function getLicenseTermByType(
     licenseTerms.derivativesAllowed = false;
     licenseTerms.derivativesAttribution = false;
     return licenseTerms;
-  } else {
+  } else if (type === PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION) {
+    if (!term || !term.royaltyPolicyAddress || !term.currency) {
+      throw new Error(
+        "royaltyPolicyAddress and currency are required for creative commons attribution PIL.",
+      );
+    }
+    licenseTerms.royaltyPolicy = validateAddress(term.royaltyPolicyAddress);
+    licenseTerms.currency = validateAddress(term.currency);
+    licenseTerms.commercialUse = true;
+    licenseTerms.commercialAttribution = true;
+    licenseTerms.uri =
+      "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/CC-BY.json";
+
+    return licenseTerms;
+  } else if (type === PIL_TYPE.COMMERCIAL_REMIX) {
     if (
       !term ||
       term.defaultMintingFee === undefined ||

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -14,6 +14,7 @@ import {
   erc20Address,
   LicenseRegistryReadOnlyClient,
   licensingModuleAddress,
+  royaltyPolicyLapAddress,
 } from "../../src/abi/generated";
 import { WIP_TOKEN_ADDRESS } from "../../src/constants/common";
 import { ERC20Client } from "../../src/utils/token";
@@ -81,6 +82,17 @@ describe("License Functions", () => {
         defaultMintingFee: "1",
         commercialRevShare: 100,
         currency: WIP_TOKEN_ADDRESS,
+        txOptions: {
+          waitForTransaction: true,
+        },
+      });
+      expect(result.licenseTermsId).to.be.a("bigint");
+    });
+
+    it("should register license with creative commons attribution PIL", async () => {
+      const result = await client.license.registerCreativeCommonsAttributionPIL({
+        currency: WIP_TOKEN_ADDRESS,
+        royaltyPolicyAddress: royaltyPolicyLapAddress[aeneid],
         txOptions: {
           waitForTransaction: true,
         },

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -1366,6 +1366,9 @@ describe("Test LicenseClient", () => {
       sinon
         .stub(licenseClient.licenseTemplateClient, "registerLicenseTerms")
         .rejects(new Error("rpc error"));
+      sinon.stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 0n,
+      });
       const result = licenseClient.registerCreativeCommonsAttributionPIL({
         currency: zeroAddress,
         royaltyPolicyAddress: zeroAddress,
@@ -1387,6 +1390,9 @@ describe("Test LicenseClient", () => {
     });
 
     it("should return txHash when call given args is correct", async () => {
+      sinon.stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 0n,
+      });
       sinon.stub(licenseClient.licenseTemplateClient, "registerLicenseTerms").resolves(txHash);
       const result = await licenseClient.registerCreativeCommonsAttributionPIL({
         currency: zeroAddress,
@@ -1398,6 +1404,18 @@ describe("Test LicenseClient", () => {
 
     it("should return txHash and success when call given args is correct and waitForTransaction of true", async () => {
       sinon.stub(licenseClient.licenseTemplateClient, "registerLicenseTerms").resolves(txHash);
+      sinon.stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 0n,
+      });
+      sinon
+        .stub(licenseClient.licenseTemplateClient, "parseTxLicenseTermsRegisteredEvent")
+        .returns([
+          {
+            licenseTermsId: 1n,
+            licenseTemplate: zeroAddress,
+            licenseTerms: zeroAddress,
+          },
+        ]);
       const result = await licenseClient.registerCreativeCommonsAttributionPIL({
         currency: zeroAddress,
         royaltyPolicyAddress: zeroAddress,
@@ -1406,7 +1424,7 @@ describe("Test LicenseClient", () => {
         },
       });
       expect(result.txHash).to.equal(txHash);
-      expect(result.licenseTermsId).to.undefined;
+      expect(result.licenseTermsId).to.equal(1n);
     });
   });
 });

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -1360,4 +1360,53 @@ describe("Test LicenseClient", () => {
       expect(result).to.deep.equal(mockLicensingConfig);
     });
   });
+
+  describe("Test licenseClient.registerCreativeCommonsAttributionPIL", () => {
+    it("should throw error given rpc error", async () => {
+      sinon
+        .stub(licenseClient.licenseTemplateClient, "registerLicenseTerms")
+        .rejects(new Error("rpc error"));
+      const result = licenseClient.registerCreativeCommonsAttributionPIL({
+        currency: zeroAddress,
+        royaltyPolicyAddress: zeroAddress,
+      });
+      await expect(result).to.rejectedWith(
+        "Failed to register creative commons attribution PIL: rpc error",
+      );
+    });
+    it("should return licenseTermsId when call given args is registered", async () => {
+      sinon.stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 1n,
+      });
+      const result = await licenseClient.registerCreativeCommonsAttributionPIL({
+        currency: zeroAddress,
+        royaltyPolicyAddress: zeroAddress,
+      });
+      expect(result.licenseTermsId).to.equal(1n);
+      expect(result.txHash).to.undefined;
+    });
+
+    it("should return txHash when call given args is correct", async () => {
+      sinon.stub(licenseClient.licenseTemplateClient, "registerLicenseTerms").resolves(txHash);
+      const result = await licenseClient.registerCreativeCommonsAttributionPIL({
+        currency: zeroAddress,
+        royaltyPolicyAddress: zeroAddress,
+      });
+      expect(result.txHash).to.equal(txHash);
+      expect(result.licenseTermsId).to.undefined;
+    });
+
+    it("should return txHash and success when call given args is correct and waitForTransaction of true", async () => {
+      sinon.stub(licenseClient.licenseTemplateClient, "registerLicenseTerms").resolves(txHash);
+      const result = await licenseClient.registerCreativeCommonsAttributionPIL({
+        currency: zeroAddress,
+        royaltyPolicyAddress: zeroAddress,
+        txOptions: {
+          waitForTransaction: true,
+        },
+      });
+      expect(result.txHash).to.equal(txHash);
+      expect(result.licenseTermsId).to.undefined;
+    });
+  });
 });

--- a/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
+++ b/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
@@ -10,6 +10,7 @@ import sinon from "sinon";
 import { createMock } from "../testUtils";
 import chaiAsPromised from "chai-as-promised";
 import { RoyaltyModuleReadOnlyClient } from "../../../src/abi/generated";
+import { mockAddress } from "../mockData";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -208,6 +209,50 @@ describe("License Terms Helper", () => {
         });
         expect(result).to.contains({
           commercialRevShare: 10000000,
+        });
+      });
+    });
+
+    describe("Get Creative Commons Attribution License Terms", () => {
+      it("should throw error when call getLicenseTermByType given CREATIVE_COMMONS_ATTRIBUTION without currency", async () => {
+        expect(() =>
+          getLicenseTermByType(PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION, {
+            royaltyPolicyAddress: mockAddress,
+          }),
+        ).to.throw(
+          "royaltyPolicyAddress and currency are required for creative commons attribution PIL.",
+        );
+      });
+
+      it("should throw error when call getLicenseTermByType without args", async () => {
+        expect(() => getLicenseTermByType(PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION)).to.throw(
+          "royaltyPolicyAddress and currency are required for creative commons attribution PIL.",
+        );
+      });
+
+      it("should return creative commons attribution license terms when given correct args", async () => {
+        const result = getLicenseTermByType(PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION, {
+          royaltyPolicyAddress: mockAddress,
+          currency: mockAddress,
+        });
+        expect(result).to.deep.include({
+          transferable: true,
+          royaltyPolicy: mockAddress,
+          defaultMintingFee: 0n,
+          expiration: 0n,
+          commercialUse: true,
+          commercialAttribution: true,
+          commercializerChecker: zeroAddress,
+          commercializerCheckerData: zeroAddress,
+          commercialRevShare: 0,
+          commercialRevCeiling: 0n,
+          derivativesAllowed: true,
+          derivativesAttribution: true,
+          derivativesApproval: false,
+          derivativesReciprocal: true,
+          derivativeRevCeiling: 0n,
+          currency: mockAddress,
+          uri: "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/CC-BY.json",
         });
       });
     });


### PR DESCRIPTION
## Description
1. Add `registerCreativeCommonsAttributionPIL` method 
2. Refactor register licenses with different types and extract a common method, which is the `registerPILTermsHelper`.

## Notes
The pr belongs to `SDK v1.3.2.`