### PR TITLE
NftClient  Integration Test - `setTokenURI`

### DIFF
--- a/packages/core-sdk/test/integration/nftClient.test.ts
+++ b/packages/core-sdk/test/integration/nftClient.test.ts
@@ -191,7 +191,6 @@ describe("nftClient Functions", () => {
     });
 
     it("updates URI for multiple tokens", async () => {
-      // Setup: Approve the contract for ERC20 transfers
       const erc20Client = new ERC20Client(publicClient, walletClient, erc20Address[aeneid]);
       const txHash = await erc20Client.approve(spgNftContract, maxUint256);
       await publicClient.waitForTransactionReceipt({ hash: txHash });
@@ -203,11 +202,9 @@ describe("nftClient Functions", () => {
       ];
   
       for (let i = 0; i < tokenURIs.length; i++) {
-        // Mint a new token with initial metadata
         const tokenId = await mintBySpg(spgNftContract, tokenURIs[i]);
         expect(tokenId).to.not.be.undefined;
 
-        // Update the token URI
         const updatedMetadata = "ipfs://QmUpdated/metadata.json";
         const result = await client.nftClient.setTokenURI({
           tokenId: tokenId!,
@@ -218,10 +215,8 @@ describe("nftClient Functions", () => {
           },
         });
 
-        // Verify the transaction
         expect(result.txHash).to.be.a("string").and.not.empty;
 
-        // Verification that the URI was updated
         const tokenURI = await client.nftClient.getTokenURI({
           tokenId: tokenId!,
           spgNftContract,


### PR DESCRIPTION
## Description
This PR expands coverage for the `nftClient` module, more specifically for the `setTokenURI` function.