### PR TITLE
Clean chain id usage

### DIFF
--- a/packages/core-sdk/src/client.ts
+++ b/packages/core-sdk/src/client.ts
@@ -37,7 +37,7 @@ export class StoryClient {
   private constructor(config: StoryConfig) {
     this.config = {
       ...config,
-      chainId: chain[config.chainId || "1315"],
+      chainId: chain[config.chainId || 1315],
     };
     if (!this.config.transport) {
       throw new Error(

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -29,7 +29,7 @@ import {
 import { AccessPermission } from "../types/resources/permission";
 import { handleError } from "../utils/errors";
 import { getPermissionSignature, getDeadline } from "../utils/sign";
-import { chain, validateAddress, validateAddresses } from "../utils/utils";
+import { validateAddress, validateAddresses } from "../utils/utils";
 import { ChainIds } from "../types/config";
 import {
   LicenseDataInput,
@@ -147,7 +147,7 @@ export class GroupClient {
         deadline: calculatedDeadline,
         state,
         wallet: this.wallet as WalletClient,
-        chainId: chain[this.chainId],
+        chainId: this.chainId,
         permissions: [
           {
             ipId: groupId,
@@ -208,7 +208,7 @@ export class GroupClient {
   ): Promise<RegisterIpAndAttachLicenseAndAddToGroupResponse> {
     try {
       const ipIdAddress = await this.ipAssetRegistryClient.ipId({
-        chainId: BigInt(chain[this.chainId]),
+        chainId: BigInt(this.chainId),
         tokenContract: validateAddress(request.nftContract),
         tokenId: BigInt(request.tokenId),
       });
@@ -228,7 +228,7 @@ export class GroupClient {
         deadline: calculatedDeadline,
         state,
         wallet: this.wallet as WalletClient,
-        chainId: chain[this.chainId],
+        chainId: this.chainId,
         permissions: [
           {
             ipId: request.groupId,
@@ -244,7 +244,7 @@ export class GroupClient {
         deadline: calculatedDeadline,
         state: toHex(0, { size: 32 }),
         wallet: this.wallet as WalletClient,
-        chainId: chain[this.chainId],
+        chainId: this.chainId,
         permissions: [
           {
             ipId: ipIdAddress,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -9,7 +9,7 @@ import {
   Hash,
 } from "viem";
 
-import { chain, validateAddress } from "../utils/utils";
+import { validateAddress } from "../utils/utils";
 import { handleError } from "../utils/errors";
 import {
   BatchMintAndRegisterIpAndMakeDerivativeRequest,
@@ -229,7 +229,7 @@ export class IPAssetClient {
             encodedTxData: this.ipAssetRegistryClient.registerEncode({
               tokenContract: object.nftContract,
               tokenId: object.tokenId,
-              chainid: BigInt(chain[this.chainId]),
+              chainid: BigInt(this.chainId),
             }),
           };
         }

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -173,7 +173,7 @@ export class LicenseClient {
         defaultMintingFee: request.defaultMintingFee,
         currency: request.currency,
         royaltyPolicyAddress: validateAddress(
-          request.royaltyPolicyAddress || royaltyPolicyLapAddress[chain[this.chainId]],
+          request.royaltyPolicyAddress || royaltyPolicyLapAddress[this.chainId],
         ),
       });
       const licenseTermsId = await this.getLicenseTermsId(licenseTerms);
@@ -219,7 +219,7 @@ export class LicenseClient {
         defaultMintingFee: request.defaultMintingFee,
         currency: request.currency,
         royaltyPolicyAddress: validateAddress(
-          request.royaltyPolicyAddress || royaltyPolicyLapAddress[chain[this.chainId]],
+          request.royaltyPolicyAddress || royaltyPolicyLapAddress[this.chainId],
         ),
         commercialRevShare: request.commercialRevShare,
       });
@@ -387,7 +387,7 @@ export class LicenseClient {
       const wipSpenders: Erc20Spender[] = [];
       if (licenseMintingFee > 0n) {
         wipSpenders.push({
-          address: royaltyModuleAddress[chain[this.chainId]],
+          address: royaltyModuleAddress[this.chainId],
           amount: licenseMintingFee,
         });
       }

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -45,7 +45,7 @@ import {
   getRevenueShare,
   validateLicenseTerms,
 } from "../utils/licenseTermsHelper";
-import { chain, validateAddress } from "../utils/utils";
+import { validateAddress } from "../utils/utils";
 import { ChainIds } from "../types/config";
 import { contractCallWithFees } from "../utils/feeUtils";
 import { calculateLicenseWipMintFee } from "../utils/calculateMintFee";

--- a/packages/core-sdk/src/resources/permission.ts
+++ b/packages/core-sdk/src/resources/permission.ts
@@ -17,7 +17,7 @@ import {
   IpAssetRegistryClient,
   SimpleWalletClient,
 } from "../abi/generated";
-import { chain, validateAddress } from "../utils/utils";
+import { validateAddress } from "../utils/utils";
 import { defaultFunctionSelector } from "../constants/common";
 import { getDeadline, getPermissionSignature } from "../utils/sign";
 import { ChainIds } from "../types/config";

--- a/packages/core-sdk/src/resources/permission.ts
+++ b/packages/core-sdk/src/resources/permission.ts
@@ -118,7 +118,7 @@ export class PermissionClient {
             func,
           },
         ],
-        chainId: chain[this.chainId],
+        chainId: this.chainId,
         wallet: this.wallet as WalletClient,
       });
       const req = {
@@ -255,7 +255,7 @@ export class PermissionClient {
         deadline: calculatedDeadline,
         state,
         permissions,
-        chainId: chain[this.chainId],
+        chainId: this.chainId,
         wallet: this.wallet as WalletClient,
       });
       const req = {

--- a/packages/core-sdk/src/types/config.ts
+++ b/packages/core-sdk/src/types/config.ts
@@ -50,4 +50,4 @@ export type StoryConfig = {
 
 export type ContractAddress = { [key in SupportedChainIds]: Record<string, string> };
 
-export type ChainIds = "1315" | "1514";
+export type ChainIds = 1315 | 1514;

--- a/packages/core-sdk/src/types/resources/permission.ts
+++ b/packages/core-sdk/src/types/resources/permission.ts
@@ -1,5 +1,6 @@
 import { Address, Hex } from "viem";
 
+import { ChainIds } from "../config";
 import { TxOptions } from "../options";
 import { EncodedTxData, SimpleWalletClient } from "../../abi/generated";
 
@@ -84,7 +85,7 @@ export type PermissionSignatureRequest = {
   /** The deadline for the signature in seconds. */
   deadline: string | number | bigint;
   wallet: SimpleWalletClient;
-  chainId: string | number | bigint;
+  chainId: ChainIds;
   permissions: Omit<SetPermissionsRequest, "txOptions">[];
 };
 
@@ -96,7 +97,7 @@ export type SignatureRequest = {
   verifyingContract: Address;
   /** The deadline for the signature in seconds. */
   deadline: bigint | number | string;
-  chainId: number | bigint | string;
+  chainId: ChainIds;
 };
 
 export type SignatureResponse = { signature: Hex; nonce: Hex };

--- a/packages/core-sdk/src/utils/sign.ts
+++ b/packages/core-sdk/src/utils/sign.ts
@@ -22,8 +22,7 @@ export const getPermissionSignature = async (
   param: PermissionSignatureRequest,
 ): Promise<SignatureResponse> => {
   const { ipId, deadline, state, wallet, chainId, permissions } = param;
-  const accessAddress =
-    accessControllerAddress[Number(chainId) as keyof typeof accessControllerAddress];
+  const accessAddress = accessControllerAddress[chainId];
   const isBatchPermissionFunction = permissions.length >= 2;
   const data = encodeFunctionData({
     abi: accessControllerAbi,
@@ -105,7 +104,7 @@ export const getSignature = async ({
     domain: {
       name: "Story Protocol IP Account",
       version: "1",
-      chainId: Number(chainId),
+      chainId,
       verifyingContract,
     },
     types: {

--- a/packages/core-sdk/src/utils/utils.ts
+++ b/packages/core-sdk/src/utils/utils.ts
@@ -90,11 +90,11 @@ export function chainStringToViemChain(chainId: SupportedChainIds): Chain {
   }
 }
 
-export const chain: { [key in SupportedChainIds]: "1315" | "1514" } = {
-  aeneid: "1315",
-  1315: "1315",
-  1514: "1514",
-  mainnet: "1514",
+export const chain: Record<SupportedChainIds, 1315 | 1514> = {
+  aeneid: 1315,
+  1315: 1315,
+  mainnet: 1514,
+  1514: 1514,
 };
 
 export function validateAddress(address: string): Address {

--- a/packages/core-sdk/src/utils/utils.ts
+++ b/packages/core-sdk/src/utils/utils.ts
@@ -12,7 +12,7 @@ import {
   formatEther,
 } from "viem";
 
-import { SupportedChainIds } from "../types/config";
+import { ChainIds, SupportedChainIds } from "../types/config";
 import { aeneid, mainnet } from "./chain";
 
 export async function waitTxAndFilterLog<
@@ -78,19 +78,19 @@ export async function waitTx(
 }
 
 export function chainStringToViemChain(chainId: SupportedChainIds): Chain {
-  switch (chainId.toString()) {
-    case "1315":
+  switch (chainId) {
+    case 1315:
     case "aeneid":
       return aeneid;
-    case "1514":
+    case 1514:
     case "mainnet":
       return mainnet;
     default:
-      throw new Error(`ChainId ${chainId as string} not supported`);
+      throw new Error(`ChainId ${String(chainId)} not supported`);
   }
 }
 
-export const chain: Record<SupportedChainIds, 1315 | 1514> = {
+export const chain: Record<SupportedChainIds, ChainIds> = {
   aeneid: 1315,
   1315: 1315,
   mainnet: 1514,

--- a/packages/core-sdk/test/integration/utils/util.ts
+++ b/packages/core-sdk/test/integration/utils/util.ts
@@ -1,7 +1,7 @@
 import { privateKeyToAccount } from "viem/accounts";
 import { chainStringToViemChain, waitTx } from "../../../src/utils/utils";
 import { http, createPublicClient, createWalletClient, Hex, Address, zeroHash } from "viem";
-import { StoryClient, StoryConfig } from "../../../src";
+import { ChainIds, StoryClient, StoryConfig } from "../../../src";
 import {
   licenseTokenAbi,
   licenseTokenAddress,
@@ -9,7 +9,7 @@ import {
   SpgnftImplEventClient,
 } from "../../../src/abi/generated";
 export const RPC = "https://aeneid.storyrpc.io";
-export const aeneid = 1315;
+export const aeneid: ChainIds = 1315;
 export const mockERC721 = "0xa1119092ea911202E0a65B743a13AE28C5CF2f21";
 export const licenseToken = licenseTokenAddress[aeneid];
 export const spgNftBeacon = spgnftBeaconAddress[aeneid];

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -1,6 +1,6 @@
 export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e86ee629cfb";
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
-export const aeneid = "1315";
+export const aeneid = 1315;
 export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const walletAddress = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const mockAddress = "0x73fcb515cee99e4991465ef586cfe2b072ebb513";

--- a/packages/core-sdk/test/unit/resources/dispute.test.ts
+++ b/packages/core-sdk/test/unit/resources/dispute.test.ts
@@ -23,7 +23,7 @@ describe("Test DisputeClient", () => {
     const accountMock = createMock<Account>();
     accountMock.address = mockAddress;
     walletMock.account = accountMock;
-    disputeClient = new DisputeClient(rpcMock, walletMock, "1315");
+    disputeClient = new DisputeClient(rpcMock, walletMock, 1315);
   });
 
   afterEach(() => {
@@ -416,7 +416,7 @@ describe("Test DisputeClient", () => {
   describe("disputeAssertion", () => {
     beforeEach(() => {
       rpcMock.readContract = sinon.stub().resolves({ bond: 0n });
-      disputeClient = new DisputeClient(rpcMock, walletMock, "1315");
+      disputeClient = new DisputeClient(rpcMock, walletMock, 1315);
       (disputeClient.arbitrationPolicyUmaClient as any).address = mockAddress;
     });
 

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -37,7 +37,7 @@ describe("Test IpAssetClient", () => {
     walletMock.signTypedData = sinon
       .stub()
       .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-    groupClient = new GroupClient(rpcMock, walletMock, "1315");
+    groupClient = new GroupClient(rpcMock, walletMock, 1315);
     (groupClient.groupingWorkflowsClient as any).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
     (groupClient.groupingModuleClient as any).address =

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -94,7 +94,7 @@ describe("Test IpAssetClient", () => {
     walletMock.account = accountMock;
     // Mock predictMintingLicenseFee
     rpcMock.readContract = sinon.stub().resolves([zeroAddress, 0n]);
-    ipAssetClient = new IPAssetClient(rpcMock, walletMock, "1315");
+    ipAssetClient = new IPAssetClient(rpcMock, walletMock, 1315);
     sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getDefaultLicenseTerms").resolves({
       licenseTemplate: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       licenseTermsId: 5n,
@@ -277,7 +277,7 @@ describe("Test IpAssetClient", () => {
     it("should throw account error when register given wallet have no signTypedData ", async () => {
       const walletMock = createMock<WalletClient>();
       walletMock.account = createMock<Account>();
-      ipAssetClient = new IPAssetClient(rpcMock, walletMock, "1315");
+      ipAssetClient = new IPAssetClient(rpcMock, walletMock, 1315);
       (ipAssetClient.registrationWorkflowsClient as any).address =
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
       (ipAssetClient.coreMetadataModuleClient as any).address =

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -29,7 +29,7 @@ describe("Test LicenseClient", () => {
     const accountMock = createMock<Account>();
     accountMock.address = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
     walletMock.account = accountMock;
-    licenseClient = new LicenseClient(rpcMock, walletMock, "1315");
+    licenseClient = new LicenseClient(rpcMock, walletMock, 1315);
     (licenseClient.licenseTemplateClient as any).address = generateRandomAddress();
     (licenseClient.licensingModuleClient as any).address = generateRandomAddress();
   });

--- a/packages/core-sdk/test/unit/resources/permission.test.ts
+++ b/packages/core-sdk/test/unit/resources/permission.test.ts
@@ -20,7 +20,7 @@ describe("Test Permission", () => {
     walletMock.signTypedData = sinon
       .stub()
       .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-    permissionClient = new PermissionClient(rpcMock, walletMock, "1315");
+    permissionClient = new PermissionClient(rpcMock, walletMock, 1315);
     sinon
       .stub(IpAccountImplClient.prototype, "state")
       .resolves({ result: "0x2e778894d11b5308e4153f094e190496c1e0609652c19f8b87e5176484b9a5e" });
@@ -225,7 +225,7 @@ describe("Test Permission", () => {
 
     it("should wallet error when call createSetPermissionSignature given wallet has no signTypedData method", async () => {
       walletMock = createMock<WalletClient>();
-      permissionClient = new PermissionClient(rpcMock, walletMock, "1315");
+      permissionClient = new PermissionClient(rpcMock, walletMock, 1315);
       sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       (permissionClient.accessControllerClient as any).address =
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";

--- a/packages/core-sdk/test/unit/resources/royalty.test.ts
+++ b/packages/core-sdk/test/unit/resources/royalty.test.ts
@@ -29,7 +29,7 @@ describe("Test RoyaltyClient", () => {
     const accountMock = createMock<Account>();
     accountMock.address = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
     walletMock.account = accountMock;
-    royaltyClient = new RoyaltyClient(rpcMock, walletMock, "1315");
+    royaltyClient = new RoyaltyClient(rpcMock, walletMock, 1315);
   });
 
   afterEach(() => {

--- a/packages/core-sdk/test/unit/utils/sign.test.ts
+++ b/packages/core-sdk/test/unit/utils/sign.test.ts
@@ -15,7 +15,7 @@ describe("Sign", () => {
           deadline: 1000n,
           permissions: [{ ipId: zeroAddress, signer: zeroAddress, to: zeroAddress, permission: 0 }],
           wallet: {} as WalletClient,
-          chainId: BigInt(aeneid),
+          chainId: aeneid,
         });
       } catch (e) {
         expect((e as Error).message).to.equal(
@@ -32,7 +32,7 @@ describe("Sign", () => {
           deadline: 1000n,
           permissions: [{ ipId: zeroAddress, signer: zeroAddress, to: zeroAddress, permission: 0 }],
           wallet: { signTypedData: () => Promise.resolve("") } as unknown as WalletClient,
-          chainId: BigInt(aeneid),
+          chainId: aeneid,
         });
       } catch (e) {
         expect((e as Error).message).to.equal(
@@ -61,7 +61,7 @@ describe("Sign", () => {
           },
         ],
         wallet: walletClient,
-        chainId: BigInt(aeneid),
+        chainId: aeneid,
       });
       expect(result.signature).is.a("string").and.not.empty;
       expect(result.nonce).is.a("string").and.not.empty;
@@ -88,7 +88,7 @@ describe("Sign", () => {
           },
         ],
         wallet: walletClient,
-        chainId: BigInt(aeneid),
+        chainId: aeneid,
       });
       expect(result.signature).is.a("string").and.not.empty;
       expect(result.nonce).is.a("string").and.not.empty;

--- a/packages/core-sdk/test/unit/utils/utils.test.ts
+++ b/packages/core-sdk/test/unit/utils/utils.test.ts
@@ -155,7 +155,7 @@ describe("Test chainStringToViemChain", () => {
   });
 
   it("should return aeneid testnet if id is 1315", () => {
-    const chain = chainStringToViemChain("1315");
+    const chain = chainStringToViemChain(1315);
     expect(chain).to.equal(aeneid);
   });
   it("should return aeneid testnet if id is iliad", () => {
@@ -164,7 +164,7 @@ describe("Test chainStringToViemChain", () => {
   });
 
   it("should return mainnet if id is 1514", () => {
-    const chain = chainStringToViemChain("1514");
+    const chain = chainStringToViemChain(1514);
     expect(chain).to.equal(mainnet);
   });
 


### PR DESCRIPTION
## Description
### Scope
- Make `chainId` a type of `number` instead of `string`.
- Remove `chain[this.chainId]` in many places
- Change `getPermissionSignature` and `getSignature` requests of the `chainId` of `ChainIds`

### Break Change
- Update `chainId` from `string | number | bigint` to `ChainIds` in `getPermissionSignature`  and  `getSignature` methods
- Update  `ChainIds` from `"1315" | "1514"` to `1315 | 1514` when initiating story client.
