### PR TITLE
Enforce naming conventions for variables, functions, and types

### DIFF
--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -1505,8 +1505,8 @@ export class IPAssetClient {
     txReceipt: TransactionReceipt,
     key?: K,
   ): IpIdAndTokenId<K>[] {
-    const IPRegisteredLog = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(txReceipt);
-    return IPRegisteredLog.map((log) => {
+    const ipRegisteredLog = this.ipAssetRegistryClient.parseTxIpRegisteredEvent(txReceipt);
+    return ipRegisteredLog.map((log) => {
       const baseResult = { ipId: log.ipId, tokenId: log.tokenId };
       if (key) {
         return {

--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -35,6 +35,7 @@ export default [
       "no-useless-computed-key": "error",
       "no-console": "error",
       "func-style": ["error", "expression"],
+      camelcase: "error",
 
       // Typescript
       "no-shadow": "off",
@@ -42,7 +43,21 @@ export default [
       "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/no-unsafe-argument": "off", // causing a lot of IDE false positives.
       "@typescript-eslint/explicit-function-return-type": "error",
-
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          selector: ["variable", "function", "parameter"],
+          format: ["camelCase", "UPPER_CASE"],
+        },
+        {
+          selector: ["enumMember", "enum"],
+          format: ["UPPER_CASE", "PascalCase"],
+        },
+        {
+          selector: ["typeLike"],
+          format: ["PascalCase"],
+        },
+      ],
       // import rules
       "import/newline-after-import": "error",
       "import/no-cycle": "error",

--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -35,7 +35,6 @@ export default [
       "no-useless-computed-key": "error",
       "no-console": "error",
       "func-style": ["error", "expression"],
-      camelcase: "error",
 
       // Typescript
       "no-shadow": "off",


### PR DESCRIPTION
## Description
Enforcing a naming convention keeps the code base consistent and reduces overhead when naming variables. 

- Use `camelCase` and `UPPER_CASE`  for `variable`, `parameter`, and `function` names.
- Use `PascalCase` and `UPPER_CASE` for `enumMember` names and `enum` names.
- Use `PascalCase` for `typeLike`, such as the  `class`, `enum`, `interface`, `typeAlias`, `typeParameter`

```
"@typescript-eslint/naming-convention": [
        "error",
        {
          selector: ["variable", "function", "parameter"],
          format: ["camelCase", "UPPER_CASE"],
        },
        {
          selector: ["enumMember", "enum"],
          format: ["UPPER_CASE", "PascalCase"],
        },
        {
          selector: ["typeLike"],
          format: ["PascalCase"],
        },
      ],
```