### PR TITLE
Add extra eslint rules

### DIFF
--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -36,6 +36,9 @@ export default [
       "no-console": "error",
       "func-style": ["error", "expression"],
       "no-duplicate-imports": "error",
+      "default-case": "error",
+      eqeqeq: "error",
+      "prefer-const": "error",
 
       // Typescript
       "no-shadow": "off",

--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -35,6 +35,7 @@ export default [
       "no-useless-computed-key": "error",
       "no-console": "error",
       "func-style": ["error", "expression"],
+      "no-duplicate-imports": "error",
 
       // Typescript
       "no-shadow": "off",


### PR DESCRIPTION
## Description
1. Using a single import statement per module will make the code clearer because you can see everything being imported from that module on one line.

Example of incorrect code for this rule:
```
import { merge } from 'module';
import something from 'another-module';
import { find } from 'module'; //error

```
2. Require default cases in switch statements

Example of incorrect code for this rule:
```
/*eslint default-case: "error"*/

switch (a) {
    case 1:
        /* code */
        break;
}
```
3. Require the use of === and !==

Example of incorrect code for this rule:

```
if (x == 42) { }
```
4. Require const declarations for variables that are never reassigned after declared

Example of incorrect code for this rule:
```
// it's initialized and never reassigned.
let a = 3;
console.log(a);
```