### PR TITLE
Add blank line between statements

### DIFF
--- a/packages/core-sdk/src/client.ts
+++ b/packages/core-sdk/src/client.ts
@@ -65,9 +65,11 @@ export class StoryClient {
       throw new Error("must specify a wallet or account");
     }
   }
+
   private get chainId(): ChainIds {
     return this.config.chainId as ChainIds;
   }
+
   /**
    * Factory method for creating an SDK client with a signer.
    *

--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -195,6 +195,7 @@ export class DisputeClient {
       return handleError(error, "Failed to resolve dispute");
     }
   }
+
   /**
    * Tags a derivative if a parent has been tagged with an infringement tag
    * or a group ip if a group member has been tagged with an infringement tag.

--- a/packages/core-sdk/src/resources/dispute.ts
+++ b/packages/core-sdk/src/resources/dispute.ts
@@ -290,6 +290,7 @@ export class DisputeClient {
           hash: txHash,
         });
       }
+
       const contractCall = (): Promise<Hash> => {
         const calls = [];
         if (bond > 0) {

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -93,6 +93,7 @@ export class GroupClient {
     this.licenseRegistryReadOnlyClient = new LicenseRegistryReadOnlyClient(rpcClient);
     this.royaltyModuleEventClient = new RoyaltyModuleEventClient(rpcClient);
   }
+
   /** Registers a Group IPA.
    *
    * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | `IPGroupRegistered`} event.
@@ -123,6 +124,7 @@ export class GroupClient {
       return handleError(error, "Failed to register group");
     }
   }
+
   /** Mint an NFT from a SPGNFT collection, register it with metadata as an IP, attach license terms to the registered IP, and add it to a group IP.
    *
    * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/registries/IIPAssetRegistry.sol#L17 | `IPRegistered`} event.
@@ -314,6 +316,7 @@ export class GroupClient {
       return handleError(error, "Failed to register IP and attach license and add to group");
     }
   }
+
   /** Register a group IP with a group reward pool and attach license terms to the group IP.
    *
    * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | `IPGroupRegistered`} event.
@@ -346,6 +349,7 @@ export class GroupClient {
       return handleError(error, "Failed to register group and attach license");
     }
   }
+
   /** Register a group IP with a group reward pool, attach license terms to the group IP, and add individual IPs to the group IP.
    *
    * Emits an on-chain {@link https://github.com/storyprotocol/protocol-core-v1/blob/v1.3.1/contracts/interfaces/modules/grouping/IGroupingModule.sol#L14 | `IPGroupRegistered`} event.
@@ -405,6 +409,7 @@ export class GroupClient {
       return handleError(error, "Failed to register group and attach license and add ips");
     }
   }
+
   /**
    * Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault.
    *
@@ -513,6 +518,7 @@ export class GroupClient {
       return handleError(error, "Failed to add IP to group");
     }
   }
+
   /**
    * Returns the available reward for each IP in the group.
    */

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -372,6 +372,7 @@ export class GroupClient {
           throw new Error(`IP ${request.ipIds[i]} is not registered.`);
         }
       }
+
       for (let i = 0; i < request.ipIds.length; i++) {
         const isAttachedLicenseTerms =
           await this.licenseRegistryReadOnlyClient.hasIpAttachedLicenseTerms({
@@ -425,9 +426,11 @@ export class GroupClient {
       if (!currencyTokens.length) {
         throw new Error("At least one currency token is required.");
       }
+
       if (!memberIpIds.length) {
         throw new Error("At least one member IP ID is required.");
       }
+
       if (currencyTokens.some((token) => token === zeroAddress)) {
         throw new Error("Currency token cannot be the zero address.");
       }

--- a/packages/core-sdk/src/resources/ipAccount.ts
+++ b/packages/core-sdk/src/resources/ipAccount.ts
@@ -142,6 +142,7 @@ export class IPAccountClient {
       return handleError(error, "Failed to get the token");
     }
   }
+
   /**
    * Sets the metadataURI for an IP asset.
    */

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -219,6 +219,7 @@ export class IPAssetClient {
           signature,
         };
       }
+
       if (request.txOptions?.encodedTxDataOnly) {
         if (request.ipMetadata) {
           return { encodedTxData: this.registrationWorkflowsClient.registerIpEncode(object) };
@@ -242,6 +243,7 @@ export class IPAssetClient {
             chainid: BigInt(this.chainId),
           });
         }
+
         if (request.txOptions?.waitForTransaction) {
           const txReceipt = await this.rpcClient.waitForTransactionReceipt({
             ...request.txOptions,
@@ -280,6 +282,7 @@ export class IPAssetClient {
         } catch (error) {
           throw new Error((error as Error).message.replace("Failed to register IP:", "").trim());
         }
+
         if (arg.ipMetadata) {
           spgContracts.push(encodedTxData);
         } else {
@@ -295,6 +298,7 @@ export class IPAssetClient {
       if (spgContracts.length > 0) {
         spgTxHash = await this.registrationWorkflowsClient.multicall({ data: spgContracts });
       }
+
       if (contracts.length > 0) {
         txHash = await this.multicall3Client.aggregate3({ calls: contracts });
       }
@@ -311,9 +315,11 @@ export class IPAssetClient {
           const eventResults = this.getIpIdAndTokenIdsFromEvent(txReceipt, contractType);
           results.push(...eventResults);
         };
+
         if (txHash) {
           await processTransaction(txHash, "nftContract");
         }
+
         if (spgTxHash) {
           await processTransaction(spgTxHash, "spgNftContract");
         }
@@ -485,6 +491,7 @@ export class IPAssetClient {
       if (!isChildIpIdRegistered) {
         throw new Error(`The child IP with id ${request.childIpId} is not registered.`);
       }
+
       if (request.licenseTokenIds.length === 0) {
         throw new Error("The licenseTokenIds must be provided.");
       }
@@ -541,6 +548,7 @@ export class IPAssetClient {
       if (request.txOptions?.encodedTxDataOnly) {
         return { encodedTxData };
       }
+
       const contractCall = (): Promise<Hash> => {
         return this.licenseAttachmentWorkflowsClient.mintAndRegisterIpAndAttachPilTerms(
           transformRequest,
@@ -721,6 +729,7 @@ export class IPAssetClient {
       if (request.txOptions?.encodedTxDataOnly) {
         return { encodedTxData };
       }
+
       const contractCall = (): Promise<Hash> => {
         return this.derivativeWorkflowsClient.registerIpAndMakeDerivative(transformRequest);
       };
@@ -765,6 +774,7 @@ export class IPAssetClient {
       if (request.txOptions?.encodedTxDataOnly) {
         return { encodedTxData };
       }
+
       const contractCall = (): Promise<Hash> => {
         return this.derivativeWorkflowsClient.mintAndRegisterIpAndMakeDerivative(transformRequest);
       };
@@ -842,6 +852,7 @@ export class IPAssetClient {
       if (request.txOptions?.encodedTxDataOnly) {
         return { encodedTxData };
       }
+
       const contractCall = (): Promise<Hash> => {
         return this.registrationWorkflowsClient.mintAndRegisterIp(object);
       };
@@ -955,6 +966,7 @@ export class IPAssetClient {
       if (request.txOptions?.encodedTxDataOnly) {
         return { encodedTxData };
       }
+
       const contractCall = async (): Promise<Hash> => {
         return this.derivativeWorkflowsClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
           object,
@@ -1587,6 +1599,7 @@ export class IPAssetClient {
         });
       }
     }
+
     if (totalFees < 0) {
       throw new Error(
         `Total fees for registering derivative should never be negative: ${totalFees}`,

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -329,6 +329,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to batch register IP");
     }
   }
+
   /**
    * Registers a derivative directly with parent IP's license terms, without needing license tokens,
    * and attaches the license terms of the parent IPs to the derivative IP.
@@ -463,6 +464,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to batch register derivative");
     }
   }
+
   /**
    * Registers a derivative with license tokens. The derivative IP is registered with license tokens minted from the parent IP's license terms.
    * The license terms of the parent IPs issued with license tokens are attached to the derivative IP.
@@ -508,6 +510,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to register derivative with license tokens");
     }
   }
+
   /**
    * Mint an NFT from a collection and register it as an IP.
    *
@@ -620,6 +623,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to batch mint and register IP and attach PIL terms");
     }
   }
+
   /**
    * Register a given NFT as an IP and attach Programmable IP License Terms.
    *
@@ -683,6 +687,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to register IP and attach PIL terms");
     }
   }
+
   /**
    * Register the given NFT as a derivative IP with metadata without using license tokens.
    *
@@ -735,6 +740,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to register derivative IP");
     }
   }
+
   /**
    * Mint an NFT from a collection and register it as a derivative IP without license tokens.
    *
@@ -776,6 +782,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to mint and register IP and make derivative");
     }
   }
+
   /**
    * Batch mint an NFT from a collection and register it as a derivative IP without license tokens.
    *
@@ -817,6 +824,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to batch mint and register IP and make derivative");
     }
   }
+
   /**
    * Mint an NFT from a SPGNFT collection and register it with metadata as an IP.
    *
@@ -853,6 +861,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to mint and register IP");
     }
   }
+
   /**
    * Register Programmable IP License Terms (if unregistered) and attach it to IP.
    *
@@ -915,6 +924,7 @@ export class IPAssetClient {
       return handleError(error, "Failed to register PIL terms and attach");
     }
   }
+
   /**
    * Mint an NFT from a collection and register it as a derivative IP using license tokens.
    * Requires caller to have the minter role or the SPG NFT to allow public minting. Caller must own the license tokens and have approved DerivativeWorkflows to transfer them.
@@ -971,6 +981,7 @@ export class IPAssetClient {
       );
     }
   }
+
   /**
    * Register the given NFT as a derivative IP using license tokens.
    *
@@ -1117,6 +1128,7 @@ export class IPAssetClient {
       );
     }
   }
+
   /**
    * Register the given NFT as a derivative IP and attach license terms and distribute royalty tokens.  In order to successfully distribute royalty tokens, the license terms attached to the IP must be
    * a commercial license.
@@ -1265,6 +1277,7 @@ export class IPAssetClient {
       );
     }
   }
+
   /**
    * Mint an NFT and register the IP, make a derivative, and distribute royalty tokens.
    *
@@ -1337,6 +1350,7 @@ export class IPAssetClient {
   public async isRegistered(ipId: Hex): Promise<boolean> {
     return await this.ipAssetRegistryClient.isRegistered({ id: validateAddress(ipId) });
   }
+
   /**
    * Batch register multiple IP assets in optimized transactions, supporting various registration methods:
    * - {@link mintAndRegisterIpAndMakeDerivative}

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -84,6 +84,7 @@ export class LicenseClient {
     this.chainId = chainId;
     this.walletAddress = wallet.account!.address;
   }
+
   /**
    * Registers new license terms and return the ID of the newly registered license terms.
    *
@@ -119,6 +120,7 @@ export class LicenseClient {
       return handleError(error, "Failed to register non commercial social remixing PIL");
     }
   }
+
   /**
    * Convenient function to register a PIL commercial use license to the registry.
    *
@@ -142,6 +144,7 @@ export class LicenseClient {
       return handleError(error, "Failed to register commercial use PIL");
     }
   }
+
   /**
    * Convenient function to register a PIL commercial Remix license to the registry.
    *
@@ -166,6 +169,7 @@ export class LicenseClient {
       return handleError(error, "Failed to register commercial remix PIL");
     }
   }
+
   /**
    * Convenient function to register a PIL creative commons attribution license to the registry.
    * Creates a Creative Commons Attribution (CC-BY) license terms flavor.
@@ -191,6 +195,7 @@ export class LicenseClient {
       return handleError(error, "Failed to register creative commons attribution PIL");
     }
   }
+
   /**
    * Attaches license terms to an IP.
    */

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -450,6 +450,7 @@ export class LicenseClient {
       if (!isExisted) {
         throw new Error(`License terms id ${req.licenseTermsId} do not exist.`);
       }
+
       if (req.licensingConfig.licensingHook !== zeroAddress) {
         const isRegistered = await this.moduleRegistryReadOnlyClient.isRegistered({
           moduleAddress: req.licensingConfig.licensingHook,
@@ -458,6 +459,7 @@ export class LicenseClient {
           throw new Error("The licensing hook is not registered.");
         }
       }
+
       if (req.licenseTemplate === zeroAddress && req.licenseTermsId !== 0n) {
         throw new Error("The license template is zero address but license terms id is not zero.");
       }

--- a/packages/core-sdk/src/resources/nftClient.ts
+++ b/packages/core-sdk/src/resources/nftClient.ts
@@ -89,6 +89,7 @@ export class NftClient {
       return handleError(error, "Failed to create an SPG NFT collection");
     }
   }
+
   /**
    * Returns the current mint token of the collection.
    */
@@ -110,6 +111,7 @@ export class NftClient {
     );
     return spgNftClient.mintFee();
   }
+
   /**
    * Sets the token URI for a specific token id.
    *

--- a/packages/core-sdk/src/resources/permission.ts
+++ b/packages/core-sdk/src/resources/permission.ts
@@ -78,6 +78,7 @@ export class PermissionClient {
       return handleError(error, "Failed to set permissions");
     }
   }
+
   /**
    * Specific permission overrides wildcard permission with signature.
    *
@@ -147,6 +148,7 @@ export class PermissionClient {
       return handleError(error, "Failed to create set permission signature");
     }
   }
+
   /**
    * Sets permission to a signer for all functions across all modules.
    *
@@ -180,6 +182,7 @@ export class PermissionClient {
       return handleError(error, "Failed to set all permissions");
     }
   }
+
   /**
    * Sets a batch of permissions in a single transaction.
    *
@@ -220,6 +223,7 @@ export class PermissionClient {
       return handleError(error, "Failed to set batch permissions");
     }
   }
+
   /**
    * Sets a batch of permissions in a single transaction with signature.
    *

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -116,6 +116,7 @@ export class RoyaltyClient {
         });
         txHashes.push(...hashes);
       }
+
       if (autoUnwrapIp && ownsClaimer) {
         const hashes = await this.unwrapWipTokens(claimedTokens);
         if (hashes) {
@@ -232,6 +233,7 @@ export class RoyaltyClient {
           return acc;
         }, 0n);
       }
+
       if (wipClaimableAmounts > 0n && autoUnwrapIp) {
         const hash = await this.unwrapWipTokens([
           {
@@ -277,6 +279,7 @@ export class RoyaltyClient {
       if (!isReceiverRegistered) {
         throw new Error(`The receiver IP with id ${receiverIpId} is not registered.`);
       }
+
       if (validateAddress(payerIpId) && payerIpId !== zeroAddress) {
         const isPayerRegistered = await this.ipAssetRegistryClient.isRegistered({
           id: payerIpId,
@@ -296,6 +299,7 @@ export class RoyaltyClient {
       if (request.txOptions?.encodedTxDataOnly) {
         return { encodedTxData };
       }
+
       const contractCall = (): Promise<Hash> => {
         return this.royaltyModuleClient.payRoyaltyOnBehalf(req);
       };

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -71,6 +71,7 @@ export class RoyaltyClient {
     this.chainId = chainId;
     this.walletAddress = wallet.account!.address;
   }
+
   /**
    * Claims all revenue from the child IPs of an ancestor IP, then transfer
    * all claimed tokens to the wallet if the wallet owns the IP or is the claimer.
@@ -420,6 +421,7 @@ export class RoyaltyClient {
     }
     return { ownsClaimer, isClaimerIp, ipAccount };
   }
+
   /**
    * Unwraps WIP tokens back to their underlying IP tokens. Only accepts a single WIP token entry
    * in the claimed tokens array. Throws an error if multiple WIP tokens are found.

--- a/packages/core-sdk/src/utils/calculateMintFee.ts
+++ b/packages/core-sdk/src/utils/calculateMintFee.ts
@@ -95,6 +95,7 @@ export const calculateLicenseWipMintFee = async ({
   }
   return fee.tokenAmount;
 };
+
 export const calculateSPGWipMintFee = async (
   spgNftClient: SpgnftImplReadOnlyClient,
 ): Promise<bigint> => {

--- a/packages/core-sdk/src/utils/feeUtils.ts
+++ b/packages/core-sdk/src/utils/feeUtils.ts
@@ -221,6 +221,7 @@ export const contractCallWithFees = async <T extends Hash | Hash[] = Hash>({
       )}, balance: ${getTokenAmountDisplay(startingBalance)}.`,
     );
   }
+
   // error if there's enough IP to cover fees and we cannot wrap IP to WIP
   if (!autoWrapIp) {
     throw new Error(

--- a/packages/core-sdk/src/utils/licenseTermsHelper.ts
+++ b/packages/core-sdk/src/utils/licenseTermsHelper.ts
@@ -105,6 +105,7 @@ export const validateLicenseTerms = async (
       throw new Error("The royalty policy is not whitelisted.");
     }
   }
+
   if (validateAddress(currency) !== zeroAddress) {
     const isWhitelistedRoyaltyToken = await royaltyModuleReadOnlyClient.isWhitelistedRoyaltyToken({
       token: currency,
@@ -113,6 +114,7 @@ export const validateLicenseTerms = async (
       throw new Error("The currency token is not whitelisted.");
     }
   }
+
   if (royaltyPolicy !== zeroAddress && currency === zeroAddress) {
     throw new Error("Royalty policy requires currency token.");
   }
@@ -126,6 +128,7 @@ export const validateLicenseTerms = async (
   if (object.defaultMintingFee < 0) {
     throw new Error("DefaultMintingFee should be greater than or equal to 0.");
   }
+
   if (object.defaultMintingFee > 0 && object.royaltyPolicy === zeroAddress) {
     throw new Error("Royalty policy is required when defaultMintingFee is greater than 0.");
   }
@@ -144,20 +147,25 @@ const verifyCommercialUse = (terms: LicenseTerms): void => {
     if (terms.commercialAttribution) {
       throw new Error("Cannot add commercial attribution when commercial use is disabled.");
     }
+
     if (terms.commercializerChecker !== zeroAddress) {
       throw new Error("Cannot add commercializerChecker when commercial use is disabled.");
     }
+
     if (terms.commercialRevShare > 0) {
       throw new Error("Cannot add commercial revenue share when commercial use is disabled.");
     }
+
     if (terms.commercialRevCeiling > 0) {
       throw new Error("Cannot add commercial revenue ceiling when commercial use is disabled.");
     }
+
     if (terms.derivativeRevCeiling > 0) {
       throw new Error(
         "Cannot add derivative revenue ceiling share when commercial use is disabled.",
       );
     }
+
     if (terms.royaltyPolicy !== zeroAddress) {
       throw new Error("Cannot add commercial royalty policy when commercial use is disabled.");
     }
@@ -173,12 +181,15 @@ const verifyDerivatives = (terms: LicenseTerms): void => {
     if (terms.derivativesAttribution) {
       throw new Error("Cannot add derivative attribution when derivative use is disabled.");
     }
+
     if (terms.derivativesApproval) {
       throw new Error("Cannot add derivative approval when derivative use is disabled.");
     }
+
     if (terms.derivativesReciprocal) {
       throw new Error("Cannot add derivative reciprocal when derivative use is disabled.");
     }
+
     if (terms.derivativeRevCeiling > 0) {
       throw new Error("Cannot add derivative revenue ceiling when derivative use is disabled.");
     }
@@ -193,6 +204,7 @@ export const getRevenueShare = (
   if (isNaN(revShareNumber)) {
     throw new Error(`${type} must be a valid number.`);
   }
+
   if (revShareNumber < 0 || revShareNumber > 100) {
     throw new Error(`${type} must be between 0 and 100.`);
   }

--- a/packages/core-sdk/src/utils/oov3.ts
+++ b/packages/core-sdk/src/utils/oov3.ts
@@ -8,6 +8,7 @@ export const getOov3Contract = async (
 ): Promise<Address> => {
   return await arbitrationPolicyUmaClient.oov3();
 };
+
 export const getAssertionDetails = async (
   rpcClient: PublicClient,
   arbitrationPolicyUmaClient: ArbitrationPolicyUmaClient,

--- a/packages/core-sdk/src/utils/registrationUtils/registerValidation.ts
+++ b/packages/core-sdk/src/utils/registrationUtils/registerValidation.ts
@@ -32,6 +32,7 @@ export const getPublicMinting = async (
   const spgNftContractImpl = new SpgnftImplReadOnlyClient(rpcClient, spgNftContract);
   return await spgNftContractImpl.publicMinting();
 };
+
 export const validateLicenseTermsData = async (
   licenseTermsData: LicenseTermsDataInput[],
   rpcClient: PublicClient,
@@ -55,6 +56,7 @@ export const validateLicenseTermsData = async (
   }
   return { licenseTerms, licenseTermsData: processedLicenseTermsData };
 };
+
 export const getRoyaltyShares = (
   royaltyShares: RoyaltyShare[],
 ): { royaltyShares: RoyaltyShare[]; totalAmount: number } => {
@@ -64,6 +66,7 @@ export const getRoyaltyShares = (
     if (share.percentage <= 0) {
       throw new Error("The percentage of the royalty shares must be greater than 0.");
     }
+
     if (share.percentage > 100) {
       throw new Error("The percentage of the royalty shares must be less than or equal to 100.");
     }
@@ -102,12 +105,15 @@ export const validateDerivativeData = async ({
   if (derivativeData.parentIpIds.length === 0) {
     throw new Error("The parent IP IDs must be provided.");
   }
+
   if (derivativeData.licenseTermsIds.length === 0) {
     throw new Error("The license terms IDs must be provided.");
   }
+
   if (derivativeData.parentIpIds.length !== derivativeData.licenseTermsIds.length) {
     throw new Error("The number of parent IP IDs must match the number of license terms IDs.");
   }
+
   if (derivativeData.maxMintingFee < 0) {
     throw new Error(`The maxMintingFee must be greater than 0.`);
   }
@@ -148,10 +154,12 @@ export const validateMaxRts = (maxRts: number): void => {
   if (isNaN(maxRts)) {
     throw new Error(`The maxRts must be a number.`);
   }
+
   if (maxRts < 0 || maxRts > MAX_ROYALTY_TOKEN) {
     throw new Error(`The maxRts must be greater than 0 and less than ${MAX_ROYALTY_TOKEN}.`);
   }
 };
+
 export const getIpIdAddress = async ({
   nftContract,
   tokenId,

--- a/packages/core-sdk/src/utils/registrationUtils/transformRegistrationRequest.ts
+++ b/packages/core-sdk/src/utils/registrationUtils/transformRegistrationRequest.ts
@@ -201,6 +201,7 @@ const handleRegisterRequest = async <T extends TransformIpRegistrationWorkflowRe
 
   throw new Error("Invalid register request type");
 };
+
 /**
  * Transforms a request for the `registerDerivativeIp` contract method.
  */
@@ -320,6 +321,7 @@ const transferRegisterIpAndAttachPilTermsAndDeployRoyaltyVaultRequest = async <
     },
   };
 };
+
 /**
  * Transforms a request for the `registerIpAndAttachPilTerms` contract method.
  */
@@ -439,6 +441,7 @@ const transferRegisterIpAndMakeDerivativeAndDeployRoyaltyVaultRequest = async <
     },
   };
 };
+
 /**
  * Handles a request for the `mintAndRegister*` contract methods.
  *
@@ -507,6 +510,7 @@ const handleMintAndRegisterRequest = async <T extends TransformIpRegistrationWor
       isPublicMinting,
     });
   }
+
   if ("derivData" in request) {
     const derivData = await validateDerivativeData({
       derivativeDataInput: request.derivData,
@@ -547,6 +551,7 @@ const handleMintAndRegisterRequest = async <T extends TransformIpRegistrationWor
   }
   throw new Error("Invalid mint and register request type");
 };
+
 /**
  * Transforms a request for the `mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens` contract method.
  */
@@ -592,6 +597,7 @@ const transformMintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensReque
     workflowClient: royaltyTokenDistributionWorkflowsClient,
   };
 };
+
 /**
  * Transforms a request for the `mintAndRegisterIpAssetWithPilTerms` contract method.
  */
@@ -629,6 +635,7 @@ const transferMintAndRegisterIpAssetWithPilTermsRequest = <
     workflowClient: licenseAttachmentWorkflowsClient,
   };
 };
+
 /**
  * Transforms a request for the `mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens` contract method.
  */
@@ -731,6 +738,7 @@ const transferMintAndRegisterIpAndMakeDerivativeRequest = <
     workflowClient: derivativeWorkflowsClient,
   };
 };
+
 /**
  * Transforms a request for the `distributeRoyaltyTokens` contract method.
  */

--- a/packages/core-sdk/src/utils/sign.ts
+++ b/packages/core-sdk/src/utils/sign.ts
@@ -80,6 +80,7 @@ export const getSignature = async ({
   if (!(wallet as WalletClient).signTypedData) {
     throw new Error("The wallet client does not support signTypedData, please try again.");
   }
+
   if (!wallet.account) {
     throw new Error("The wallet client does not have an account, please try again.");
   }

--- a/packages/core-sdk/src/utils/token.ts
+++ b/packages/core-sdk/src/utils/token.ts
@@ -31,6 +31,7 @@ export class ERC20Client implements TokenClient {
   approveEncode(spender: Address, value: bigint): EncodedTxData {
     return this.ercClient.approveEncode({ spender, value });
   }
+
   // The method only will work in test environment
   async mint(to: Address, amount: bigint): Promise<Hash> {
     return await this.ercClient.mint({ to, amount });

--- a/packages/core-sdk/src/utils/utils.ts
+++ b/packages/core-sdk/src/utils/utils.ts
@@ -56,6 +56,7 @@ export const waitTxAndFilterLog = async <
       continue;
     }
   }
+
   if (targetLogs.length === 0) {
     throw new Error(`Not found event ${params.eventName} in target transaction`);
   }

--- a/packages/core-sdk/src/utils/validateLicenseConfig.ts
+++ b/packages/core-sdk/src/utils/validateLicenseConfig.ts
@@ -30,12 +30,14 @@ export const validateLicenseConfig = (licensingConfig?: LicensingConfigInput): L
   if (isNaN(licenseConfig.expectMinimumGroupRewardShare)) {
     throw new Error(`The expectMinimumGroupRewardShare must be a valid number.`);
   }
+
   if (
     licenseConfig.expectMinimumGroupRewardShare < 0 ||
     licenseConfig.expectMinimumGroupRewardShare > 100
   ) {
     throw new Error(`The expectMinimumGroupRewardShare must be greater than 0 and less than 100.`);
   }
+
   if (licenseConfig.mintingFee < 0) {
     throw new Error(`The mintingFee must be greater than 0.`);
   }

--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -36,6 +36,9 @@ export default [
       "no-console": "error",
       "func-style": ["error", "expression"],
       "no-duplicate-imports": "error",
+      "default-case": "error",
+      eqeqeq: "error",
+      "prefer-const": "error",
 
       // Typescript
       "no-shadow": "off",

--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -35,6 +35,7 @@ export default [
       "no-useless-computed-key": "error",
       "no-console": "error",
       "func-style": ["error", "expression"],
+      "no-duplicate-imports": "error",
 
       // Typescript
       "no-shadow": "off",

--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -5,6 +5,8 @@ import tsdocPlugin from "eslint-plugin-tsdoc";
 import eslintConfigPrettier from "eslint-config-prettier";
 import tsParser from "@typescript-eslint/parser";
 import importPlugin from "eslint-plugin-import";
+import tsEslintPlugin from "@typescript-eslint/eslint-plugin";
+import tsStylistic from "@stylistic/eslint-plugin-ts";
 
 export default [
   js.configs.recommended,
@@ -17,6 +19,8 @@ export default [
     plugins: {
       turbo,
       tsdocPlugin,
+      tsEslintPlugin,
+      "@stylistic/ts": tsStylistic,
     },
     settings: {
       "import/resolver": {
@@ -24,6 +28,13 @@ export default [
         // See also https://github.com/import-js/eslint-import-resolver-typescript#configuration
         typescript: true,
         node: true,
+      },
+    },
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
     rules: {
@@ -77,12 +88,15 @@ export default [
           },
         },
       ],
-    },
-    languageOptions: {
-      parserOptions: {
-        projectService: true,
-        tsconfigRootDir: import.meta.dirname,
-      },
+
+      // stylistic
+      "@stylistic/ts/lines-between-class-members": [
+        "error",
+        "always",
+        {
+          exceptAfterSingleLine: true,
+        },
+      ],
     },
   },
 ];

--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -90,12 +90,13 @@ export default [
       ],
 
       // stylistic
-      "@stylistic/ts/lines-between-class-members": [
+      "@stylistic/ts/padding-line-between-statements": [
         "error",
-        "always",
-        {
-          exceptAfterSingleLine: true,
-        },
+        { blankLine: "always", prev: "function", next: "function" },
+        { blankLine: "always", prev: "class", next: "class" },
+        { blankLine: "always", prev: "interface", next: "interface" },
+        { blankLine: "always", prev: "type", next: "type" },
+        { blankLine: "always", prev: "block-like", next: "block-like" },
       ],
     },
   },

--- a/packages/eslint-config-story/package.json
+++ b/packages/eslint-config-story/package.json
@@ -6,6 +6,9 @@
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@story-protocol/prettier-config": "workspace:*",
+    "@stylistic/eslint-plugin-ts": "^4.2.0",
+    "@typescript-eslint/eslint-plugin": "^8.32.1",
+    "@typescript-eslint/parser": "^8.32.1",
     "eslint": "^9.26.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-config-turbo": "^1.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,15 @@ importers:
       '@story-protocol/prettier-config':
         specifier: workspace:*
         version: link:../prettier-config
+      '@stylistic/eslint-plugin-ts':
+        specifier: ^4.2.0
+        version: 4.2.0(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.32.1
+        version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
+      '@typescript-eslint/parser':
+        specifier: ^8.32.1
+        version: 8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
       eslint:
         specifier: ^9.26.0
         version: 9.26.0(jiti@1.21.0)
@@ -137,7 +146,7 @@ importers:
         version: 4.3.4(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@1.21.0))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0))
+        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0))
       eslint-plugin-tsdoc:
         specifier: ^0.4.0
         version: 0.4.0
@@ -1842,6 +1851,12 @@ packages:
   '@stablelib/x25519@1.0.3':
     resolution: {integrity: sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==}
 
+  '@stylistic/eslint-plugin-ts@4.2.0':
+    resolution: {integrity: sha512-j2o2GvOx9v66x8hmp/HJ+0T+nOppiO5ycGsCkifh7JPGgjxEhpkGmIGx3RWsoxpWbad3VCX8e8/T8n3+7ze1Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=9.0.0'
+
   '@tanstack/query-core@5.29.0':
     resolution: {integrity: sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==}
 
@@ -1981,8 +1996,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/eslint-plugin@8.32.1':
+    resolution: {integrity: sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/parser@8.32.0':
     resolution: {integrity: sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/parser@8.32.1':
+    resolution: {integrity: sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -1992,8 +2022,19 @@ packages:
     resolution: {integrity: sha512-jc/4IxGNedXkmG4mx4nJTILb6TMjL66D41vyeaPWvDUmeYQzF3lKtN15WsAeTr65ce4mPxwopPSo1yUUAWw0hQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.32.1':
+    resolution: {integrity: sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/type-utils@8.32.0':
     resolution: {integrity: sha512-t2vouuYQKEKSLtJaa5bB4jHeha2HJczQ6E5IXPDPgIty9EqcJxpr1QHQ86YyIPwDwxvUmLfP2YADQ5ZY4qddZg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/type-utils@8.32.1':
+    resolution: {integrity: sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2003,8 +2044,18 @@ packages:
     resolution: {integrity: sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.32.1':
+    resolution: {integrity: sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.32.0':
     resolution: {integrity: sha512-pU9VD7anSCOIoBFnhTGfOzlVFQIA1XXiQpH/CezqOBaDppRwTglJzCC6fUQGpfwey4T183NKhF1/mfatYmjRqQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/typescript-estree@8.32.1':
+    resolution: {integrity: sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
@@ -2016,8 +2067,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
+  '@typescript-eslint/utils@8.32.1':
+    resolution: {integrity: sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/visitor-keys@8.32.0':
     resolution: {integrity: sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.32.1':
+    resolution: {integrity: sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unrs/resolver-binding-darwin-arm64@1.7.2':
@@ -3586,6 +3648,7 @@ packages:
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -3594,6 +3657,7 @@ packages:
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3757,6 +3821,10 @@ packages:
 
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.4:
+    resolution: {integrity: sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==}
     engines: {node: '>= 4'}
 
   image-size@1.1.1:
@@ -4241,6 +4309,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
@@ -6311,7 +6380,7 @@ snapshots:
       '@babel/core': 7.24.4
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -7786,8 +7855,8 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
-      semver: 7.6.0
+      debug: 4.4.0
+      semver: 7.7.1
       superstruct: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -7798,9 +7867,9 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.6
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.4.0
       pony-cause: 2.1.10
-      semver: 7.6.0
+      semver: 7.7.1
       superstruct: 1.0.4
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -8523,6 +8592,16 @@ snapshots:
       '@stablelib/random': 1.0.2
       '@stablelib/wipe': 1.0.1
 
+  '@stylistic/eslint-plugin-ts@4.2.0(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/utils': 8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
+      eslint: 9.26.0(jiti@1.21.0)
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@tanstack/query-core@5.29.0': {}
 
   '@tanstack/react-query@5.29.2(react@18.3.1)':
@@ -8662,6 +8741,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 8.32.1
+      '@typescript-eslint/type-utils': 8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 8.32.1
+      eslint: 9.26.0(jiti@1.21.0)
+      graphemer: 1.4.0
+      ignore: 7.0.4
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.32.0(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.32.0
@@ -8674,16 +8770,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.32.1
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.4.5)
+      '@typescript-eslint/visitor-keys': 8.32.1
+      debug: 4.4.0
+      eslint: 9.26.0(jiti@1.21.0)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.32.0':
     dependencies:
       '@typescript-eslint/types': 8.32.0
       '@typescript-eslint/visitor-keys': 8.32.0
 
+  '@typescript-eslint/scope-manager@8.32.1':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/visitor-keys': 8.32.1
+
   '@typescript-eslint/type-utils@8.32.0(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.32.0(typescript@5.4.5)
       '@typescript-eslint/utils': 8.32.0(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.4.0
+      eslint: 9.26.0(jiti@1.21.0)
+      ts-api-utils: 2.1.0(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
+      debug: 4.4.0
       eslint: 9.26.0(jiti@1.21.0)
       ts-api-utils: 2.1.0(typescript@5.4.5)
       typescript: 5.4.5
@@ -8692,15 +8816,31 @@ snapshots:
 
   '@typescript-eslint/types@8.32.0': {}
 
+  '@typescript-eslint/types@8.32.1': {}
+
   '@typescript-eslint/typescript-estree@8.32.0(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 8.32.0
       '@typescript-eslint/visitor-keys': 8.32.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.4.0
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.0
+      ts-api-utils: 2.1.0(typescript@5.4.5)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.32.1(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/visitor-keys': 8.32.1
+      debug: 4.4.0
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
       ts-api-utils: 2.1.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -8717,9 +8857,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.26.0(jiti@1.21.0))
+      '@typescript-eslint/scope-manager': 8.32.1
+      '@typescript-eslint/types': 8.32.1
+      '@typescript-eslint/typescript-estree': 8.32.1(typescript@5.4.5)
+      eslint: 9.26.0(jiti@1.21.0)
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.32.0':
     dependencies:
       '@typescript-eslint/types': 8.32.0
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.32.1':
+    dependencies:
+      '@typescript-eslint/types': 8.32.1
       eslint-visitor-keys: 4.2.0
 
   '@unrs/resolver-binding-darwin-arm64@1.7.2':
@@ -10229,21 +10385,22 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
       eslint: 9.26.0(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.3.4(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@1.21.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -10254,7 +10411,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.26.0(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.26.0(jiti@1.21.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10265,6 +10422,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.32.1(eslint@9.26.0(jiti@1.21.0))(typescript@5.4.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -10915,6 +11074,8 @@ snapshots:
 
   ignore@5.3.1: {}
 
+  ignore@7.0.4: {}
+
   image-size@1.1.1:
     dependencies:
       queue: 6.0.2
@@ -11129,7 +11290,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  isows@1.0.3(ws@8.13.0(bufferutil@4.0.8)):
+  isows@1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)):
     dependencies:
       ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
 
@@ -13339,7 +13500,7 @@ snapshots:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 0.9.8(typescript@5.4.5)(zod@3.23.8)
-      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8))
+      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))
       ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     optionalDependencies:
       typescript: 5.4.5
@@ -13356,7 +13517,7 @@ snapshots:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 1.0.0(typescript@5.4.5)(zod@3.24.4)
-      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8))
+      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))
       ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     optionalDependencies:
       typescript: 5.4.5
@@ -13373,7 +13534,7 @@ snapshots:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 1.0.0(typescript@5.4.5)(zod@3.23.8)
-      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8))
+      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))
       ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     optionalDependencies:
       typescript: 5.4.5


### PR DESCRIPTION
## Description
1. Install `stylistic` package( This `padding-line-between-statements` was deprecated in `ESLint` v8.53.0 and migrate into `stylistic`)

2. Add a blank line, follow the rule below: 
``` ts
"@stylistic/ts/padding-line-between-statements": [
        "error",
        { blankLine: "always", prev: "function", next: "function" },
        { blankLine: "always", prev: "class", next: "class" },
        { blankLine: "always", prev: "interface", next: "interface" },
        { blankLine: "always", prev: "type", next: "type" },
        { blankLine: "always", prev: "block-like", next: "block-like" },
      ],
```
3. Fix lint error about space.
## Notes
To reduce conflict, I rebased the `Add extract eslint rules` pr into the pr, so the code has some duplication.