### PR TITLE
Add the settleAssertion method

### DIFF
--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "pnpm run fix && preconstruct build",
     "test": "pnpm run test:unit",
-    "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts'",
+    "test:unit": "TS_NODE_PROJECT='./tsconfig.test.json' c8 --all --src ./src mocha -r ts-node/register './test/unit/**/*.test.ts' --require ./test/unit/hooks.ts",
     "test:integration": "TS_NODE_PROJECT='./tsconfig.test.json' mocha -r ts-node/register './test/integration/**/*.test.ts' --timeout 300000",
     "fix": "pnpm run format:fix && pnpm run lint:fix",
     "format": "prettier --check .",

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -38,3 +38,5 @@ export { royaltyPolicyLapAddress, royaltyPolicyLrpAddress } from "./abi/generate
 export { getPermissionSignature, getSignature } from "./utils/sign";
 
 export { convertCIDtoHashIPFS, convertHashIPFStoCID } from "./utils/ipfs";
+
+export { settleAssertion } from "./utils/oov3";

--- a/packages/core-sdk/src/utils/oov3.ts
+++ b/packages/core-sdk/src/utils/oov3.ts
@@ -1,5 +1,9 @@
-import { Address, Hex, PublicClient } from "viem";
+import { Address, createPublicClient, createWalletClient, Hex, http, PublicClient } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
 
+import { aeneid } from "./chain";
+import { handleError } from "./errors";
+import { chainStringToViemChain } from "./utils";
 import { ArbitrationPolicyUmaClient } from "../abi/generated";
 import { ASSERTION_ABI } from "../abi/oov3Abi";
 
@@ -36,4 +40,59 @@ export const getMinimumBond = async (
     functionName: "getMinimumBond",
     args: [currency],
   });
+};
+
+/**
+ * Settles an assertion associated with a dispute in the UMA arbitration protocol.
+ *
+ * This function takes a dispute ID, resolves it to an assertion ID, and then calls
+ * the `settleAssertion` function on the Optimistic Oracle V3 contract to finalize
+ * the arbitration outcome.
+ *
+ * The function is specifically designed for testing on the `aeneid` testnet and will
+ * not work on other chains. It handles the entire settlement process including:
+ * - Creating the appropriate clients with the provided private key
+ * - Retrieving the assertion ID from the dispute ID
+ * - Executing the settlement transaction
+ * - Waiting for transaction confirmation
+ *
+ * @see https://docs.story.foundation/docs/uma-arbitration-policy#/
+ * @see https://docs.uma.xyz/developers/optimistic-oracle-v3
+ *
+ * @param privateKey - The private key of the wallet that will sign the settlement transaction.
+ * @param disputeId - The ID of the dispute to be settled.
+ * @param transport - Optional custom RPC URL; defaults to the aeneid testnet RPC URL.
+ * @returns A promise that resolves to the transaction hash of the settlement transaction.
+ */
+export const settleAssertion = async (
+  privateKey: Hex,
+  disputeId: bigint,
+  transport?: string,
+): Promise<Hex> => {
+  try {
+    const baseConfig = {
+      chain: chainStringToViemChain("aeneid"),
+      transport: http(transport ?? aeneid.rpcUrls.default.http[0]),
+    };
+    const rpcClient = createPublicClient(baseConfig);
+    const walletClient = createWalletClient({
+      ...baseConfig,
+      account: privateKeyToAccount(privateKey),
+    });
+    const arbitrationPolicyUmaClient = new ArbitrationPolicyUmaClient(rpcClient, walletClient);
+    const oov3Contract = await getOov3Contract(arbitrationPolicyUmaClient);
+    const assertionId = await arbitrationPolicyUmaClient.disputeIdToAssertionId({
+      disputeId: BigInt(disputeId),
+    });
+    const txHash = await walletClient.writeContract({
+      address: oov3Contract,
+      abi: ASSERTION_ABI,
+      functionName: "settleAssertion",
+      args: [assertionId],
+    });
+    await rpcClient.waitForTransactionReceipt({ hash: txHash });
+    return txHash;
+  } catch (error) {
+    return handleError(error, "Failed to settle assertion");
+  }
 };

--- a/packages/core-sdk/test/integration/utils/util.ts
+++ b/packages/core-sdk/test/integration/utils/util.ts
@@ -14,6 +14,7 @@ export const mockERC721 = "0xa1119092ea911202E0a65B743a13AE28C5CF2f21";
 export const licenseToken = licenseTokenAddress[aeneid];
 export const spgNftBeacon = spgnftBeaconAddress[aeneid];
 export const TEST_WALLET_ADDRESS = process.env.TEST_WALLET_ADDRESS! as Address;
+export const TEST_PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY! as Hex;
 
 const baseConfig = {
   chain: chainStringToViemChain("aeneid"),
@@ -22,7 +23,7 @@ const baseConfig = {
 export const publicClient = createPublicClient(baseConfig);
 export const walletClient = createWalletClient({
   ...baseConfig,
-  account: privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as Hex),
+  account: privateKeyToAccount(TEST_PRIVATE_KEY),
 });
 
 export const getTokenId = async (): Promise<number | undefined> => {

--- a/packages/core-sdk/test/unit/hooks.js
+++ b/packages/core-sdk/test/unit/hooks.js
@@ -1,0 +1,8 @@
+// Restores the default sandbox after every test
+const sinon = require("sinon");
+
+exports.mochaHooks = {
+  afterEach() {
+    sinon.restore();
+  },
+};

--- a/packages/core-sdk/test/unit/hooks.ts
+++ b/packages/core-sdk/test/unit/hooks.ts
@@ -1,6 +1,5 @@
 // Restores the default sandbox after every test
-const sinon = require("sinon");
-
+import * as sinon from "sinon";
 exports.mochaHooks = {
   afterEach() {
     sinon.restore();


### PR DESCRIPTION
## Description
-  Add the `settleAssertion` method
- Create `packages/core-sdk/test/unit/hooks.js` file, which will automatically run `restore`. Don't need to add test cases.
```
  afterEach() {
    sinon.restore();
  },
```