### PR TITLE
Fix txHash type

### DIFF
--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -225,7 +225,7 @@ export class LicenseClient {
           licenseTermsId: request.licenseTermsId,
         });
       if (isAttachedLicenseTerms) {
-        return { txHash: "", success: false };
+        return { success: false };
       }
       const req = {
         ipId: request.ipId,

--- a/packages/core-sdk/src/types/resources/dispute.ts
+++ b/packages/core-sdk/src/types/resources/dispute.ts
@@ -1,4 +1,4 @@
-import { Address, Hex } from "viem";
+import { Address, Hash, Hex } from "viem";
 
 import { EncodedTxData } from "../../abi/generated";
 import { TxOptions, WipOptions, WithTxOptions } from "../options";
@@ -35,7 +35,7 @@ export type RaiseDisputeRequest = WithTxOptions & {
 };
 
 export type RaiseDisputeResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   disputeId?: bigint;
 };
@@ -52,7 +52,7 @@ export type CancelDisputeRequest = {
 };
 
 export type CancelDisputeResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
 };
 
@@ -68,7 +68,7 @@ export type ResolveDisputeRequest = {
 };
 
 export type ResolveDisputeResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
 };
 

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -46,7 +46,7 @@ export type MintAndRegisterIpAndAttachLicenseAndAddToGroupRequest = {
 } & IpMetadataAndTxOptions;
 
 export type MintAndRegisterIpAndAttachLicenseAndAddToGroupResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   ipId?: Address;
   tokenId?: bigint;
@@ -58,7 +58,7 @@ export type RegisterGroupRequest = {
 };
 
 export type RegisterGroupResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   groupId?: Address;
 };
@@ -79,7 +79,7 @@ export type RegisterIpAndAttachLicenseAndAddToGroupRequest = {
 } & IpMetadataAndTxOptions;
 
 export type RegisterIpAndAttachLicenseAndAddToGroupResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   ipId?: Address;
   tokenId?: bigint;
@@ -93,7 +93,7 @@ export type RegisterGroupAndAttachLicenseRequest = {
 };
 
 export type RegisterGroupAndAttachLicenseResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   groupId?: Address;
 };
@@ -110,7 +110,7 @@ export type RegisterGroupAndAttachLicenseAndAddIpsRequest = {
 };
 
 export type RegisterGroupAndAttachLicenseAndAddIpsResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   groupId?: Address;
 };

--- a/packages/core-sdk/src/types/resources/ipAccount.ts
+++ b/packages/core-sdk/src/types/resources/ipAccount.ts
@@ -1,4 +1,4 @@
-import { Address, Hex } from "viem";
+import { Address, Hash, Hex } from "viem";
 
 import { EncodedTxData } from "../../abi/generated";
 import { TokenAmountInput } from "../common";
@@ -17,7 +17,7 @@ export type IPAccountExecuteRequest = {
 };
 
 export type IPAccountExecuteResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
 };
 
@@ -40,7 +40,7 @@ export type IPAccountExecuteWithSigRequest = {
 };
 
 export type IPAccountExecuteWithSigResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
 };
 

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -82,7 +82,7 @@ export type RegisterDerivativeWithLicenseTokensRequest = {
 };
 
 export type RegisterDerivativeWithLicenseTokensResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
 };
 
@@ -93,7 +93,7 @@ export type RegisterDerivativeRequest = WithWipOptions &
   };
 
 export type RegisterDerivativeResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
 };
 export type LicenseTermsDataInput<T = LicenseTermsInput, C = LicensingConfigInput> = {
@@ -123,7 +123,7 @@ export type MintAndRegisterIpAssetWithPilTermsRequest = {
   WithWipOptions;
 
 export type MintAndRegisterIpAssetWithPilTermsResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   ipId?: Address;
   tokenId?: bigint;
@@ -145,7 +145,7 @@ export type RegisterIpAndMakeDerivativeRequest = {
   WithWipOptions;
 
 export type RegisterIpAndMakeDerivativeResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   ipId?: Address;
   tokenId?: bigint;
@@ -165,7 +165,7 @@ export type RegisterIpAndAttachPilTermsRequest = {
 } & IpMetadataAndTxOptions;
 
 export type RegisterIpAndAttachPilTermsResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   ipId?: Address;
   licenseTermsIds?: bigint[];
@@ -221,7 +221,7 @@ export type RegisterPilTermsAndAttachRequest = {
 };
 
 export type RegisterPilTermsAndAttachResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   licenseTermsIds?: bigint[];
 };
@@ -268,7 +268,7 @@ export type BatchMintAndRegisterIpAssetWithPilTermsResult = {
   spgNftContract: Address;
 };
 export type BatchMintAndRegisterIpAssetWithPilTermsResponse = {
-  txHash: Hex;
+  txHash: Hash;
   results?: BatchMintAndRegisterIpAssetWithPilTermsResult[];
 };
 
@@ -282,14 +282,14 @@ export type BatchRegisterDerivativeRequest = {
 };
 
 export type BatchRegisterDerivativeResponse = {
-  txHash: Hex;
+  txHash: Hash;
 };
 export type BatchMintAndRegisterIpAndMakeDerivativeRequest = {
   args: Omit<MintAndRegisterIpAndMakeDerivativeRequest, "txOptions">[];
   txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
 };
 export type BatchMintAndRegisterIpAndMakeDerivativeResponse = {
-  txHash: string;
+  txHash: Hash;
   results?: IpIdAndTokenId<"spgNftContract">[];
 };
 
@@ -299,8 +299,8 @@ export type BatchRegisterRequest = {
 };
 
 export type BatchRegisterResponse = {
-  txHash?: Hex;
-  spgTxHash?: Hex;
+  txHash?: Hash;
+  spgTxHash?: Hash;
   results?: IpIdAndTokenId<"nftContract">[];
 };
 export type RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest = {
@@ -318,8 +318,8 @@ export type RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest = {
   txOptions?: Omit<TxOptions, "encodedTxDataOnly">;
 } & WithIpMetadata;
 export type RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensResponse = {
-  registerIpAndAttachPilTermsAndDeployRoyaltyVaultTxHash: Hex;
-  distributeRoyaltyTokensTxHash: Hex;
+  registerIpAndAttachPilTermsAndDeployRoyaltyVaultTxHash: Hash;
+  distributeRoyaltyTokensTxHash: Hash;
   ipId: Address;
   licenseTermsIds: bigint[];
   ipRoyaltyVault: Address;
@@ -362,8 +362,8 @@ export type RegisterDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokensReq
   WithIpMetadata;
 
 export type RegisterDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokensResponse = {
-  registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokensTxHash: Address;
-  distributeRoyaltyTokensTxHash: Address;
+  registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokensTxHash: Hash;
+  distributeRoyaltyTokensTxHash: Hash;
   ipId: Address;
   tokenId: bigint;
   ipRoyaltyVault: Address;
@@ -387,7 +387,7 @@ export type MintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokensRequest 
   WithWipOptions;
 
 export type MintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokensResponse = {
-  txHash: Hex;
+  txHash: Hash;
   ipId?: Address;
   licenseTermsIds?: bigint[];
   ipRoyaltyVault?: Address;
@@ -412,7 +412,7 @@ export type MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensRequest 
   WithWipOptions;
 
 export type MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensResponse = {
-  txHash: Hex;
+  txHash: Hash;
   ipId?: Address;
   tokenId?: bigint;
 };
@@ -429,14 +429,14 @@ export type CommonRegistrationParams = WithWipOptions & {
 };
 
 export type RegistrationResponse = {
-  txHash?: Hex;
+  txHash?: Hash;
   receipt?: TransactionReceipt;
   ipId?: Address;
   tokenId?: bigint;
 };
 
 export type CommonRegistrationTxResponse = RegistrationResponse & {
-  txHash: Hex;
+  txHash: Hash;
 };
 
 export type TransformIpRegistrationWorkflowRequest =

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -1,4 +1,4 @@
-import { Address, TransactionReceipt } from "viem";
+import { Address, Hash, TransactionReceipt } from "viem";
 
 import { EncodedTxData } from "../../abi/generated";
 import { LicensingConfigInput } from "../common";
@@ -81,7 +81,7 @@ export type LicenseTermsIdResponse = bigint;
 
 export type RegisterPILResponse = {
   licenseTermsId?: bigint;
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
 };
 
@@ -139,7 +139,7 @@ export type AttachLicenseTermsRequest = {
 };
 
 export type AttachLicenseTermsResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   success?: boolean;
 };
@@ -169,7 +169,7 @@ export type MintLicenseTokensRequest = {
 export type MintLicenseTokensResponse = {
   licenseTokenIds?: bigint[];
   receipt?: TransactionReceipt;
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
 };
 
@@ -203,7 +203,7 @@ export type SetLicensingConfigRequest = GetLicensingConfigRequest & {
 };
 
 export type SetLicensingConfigResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   success?: boolean;
 };

--- a/packages/core-sdk/src/types/resources/nftClient.ts
+++ b/packages/core-sdk/src/types/resources/nftClient.ts
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import { Address, Hash } from "viem";
 
 import { EncodedTxData } from "../../abi/generated";
 import { TxOptions } from "../options";
@@ -27,7 +27,7 @@ export type CreateNFTCollectionRequest = {
 };
 
 export type CreateNFTCollectionResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   spgNftContract?: Address;
 };

--- a/packages/core-sdk/src/types/resources/permission.ts
+++ b/packages/core-sdk/src/types/resources/permission.ts
@@ -1,4 +1,4 @@
-import { Address, Hex } from "viem";
+import { Address, Hash, Hex } from "viem";
 
 import { EncodedTxData, SimpleWalletClient } from "../../abi/generated";
 import { ChainIds } from "../config";
@@ -27,7 +27,7 @@ export type SetPermissionsRequest = {
 };
 
 export type SetPermissionsResponse = {
-  txHash?: string;
+  txHash?: Hash;
   encodedTxData?: EncodedTxData;
   success?: boolean;
 };

--- a/packages/core-sdk/src/types/resources/royalty.ts
+++ b/packages/core-sdk/src/types/resources/royalty.ts
@@ -34,7 +34,7 @@ export type PayRoyaltyOnBehalfRequest = WithTxOptions &
   };
 
 export type PayRoyaltyOnBehalfResponse = {
-  txHash?: string;
+  txHash?: Hash;
   receipt?: TransactionReceipt;
   encodedTxData?: EncodedTxData;
 };

--- a/packages/core-sdk/src/types/resources/tagging.ts
+++ b/packages/core-sdk/src/types/resources/tagging.ts
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import { Address, Hash } from "viem";
 
 import { TxOptions } from "../options";
 
@@ -15,7 +15,7 @@ export type SetTagRequest = {
 };
 
 export type SetTagResponse = {
-  txHash: string;
+  txHash: Hash;
 };
 
 export type RemoveTagRequest = {
@@ -25,5 +25,6 @@ export type RemoveTagRequest = {
 };
 
 export type RemoveTagResponse = {
-  txHash: string;
+  txHash: Hash;
 };
+

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -503,7 +503,7 @@ describe("Test LicenseClient", () => {
       }
     });
 
-    it("should return txHash of empty and success of false when call attachLicenseTerms given licenseTermsId is already attached", async () => {
+    it("should success of false when call attachLicenseTerms given licenseTermsId is already attached", async () => {
       sinon.stub(licenseClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       sinon.stub(licenseClient.piLicenseTemplateReadOnlyClient, "exists").resolves(true);
       sinon
@@ -514,7 +514,6 @@ describe("Test LicenseClient", () => {
         licenseTermsId: "1",
       });
       expect(result).to.deep.equal({
-        txHash: "",
         success: false,
       });
     });


### PR DESCRIPTION
## Description
Fix `txHash` type from `string` and `Hex` into `txHash`.

## Notes
Removing `txHash` when attachLicenseTerms given licenseTermsId is already attached. @bpolania, there is a breaking change, and we need to highlight it in the release notes.