### PR TITLE
Refactor wipOptions and erc20Options

### DIFF
--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -376,7 +376,7 @@ export class IPAssetClient {
           encodedTxs: [encodedTxData],
           spgSpenderAddress: this.royaltyModuleEventClient.address,
           wipOptions: {
-            ...request.wipOptions,
+            ...request.options?.wipOptions,
             useMulticallWhenPossible: false,
           },
         });
@@ -555,7 +555,7 @@ export class IPAssetClient {
         );
       };
       const rsp = await this.handleRegistrationWithFees({
-        wipOptions: request.wipOptions,
+        wipOptions: request.options?.wipOptions,
         sender: this.walletAddress,
         spgNftContract: transformRequest.spgNftContract,
         spgSpenderAddress: this.royaltyTokenDistributionWorkflowsClient.address,
@@ -735,7 +735,7 @@ export class IPAssetClient {
       };
       return this.handleRegistrationWithFees({
         wipOptions: {
-          ...request.wipOptions,
+          ...request.options?.wipOptions,
           useMulticallWhenPossible: false,
         },
         sender: this.walletAddress,
@@ -779,7 +779,7 @@ export class IPAssetClient {
         return this.derivativeWorkflowsClient.mintAndRegisterIpAndMakeDerivative(transformRequest);
       };
       return this.handleRegistrationWithFees({
-        wipOptions: request.wipOptions,
+        wipOptions: request.options?.wipOptions,
         sender: this.walletAddress,
         spgSpenderAddress: this.derivativeWorkflowsClient.address,
         spgNftContract,
@@ -864,7 +864,7 @@ export class IPAssetClient {
         spgNftContract: object.spgNftContract,
         txOptions: request.txOptions,
         wipOptions: {
-          ...request.wipOptions,
+          ...request.options?.wipOptions,
           useMulticallWhenPossible: false,
         },
       });
@@ -974,7 +974,7 @@ export class IPAssetClient {
       };
       return this.handleRegistrationWithFees({
         wipOptions: {
-          ...request.wipOptions,
+          ...request.options?.wipOptions,
           // need to disable multicall to avoid needing to transfer the license
           // token to the multicall contract.
           useMulticallWhenPossible: false,
@@ -1183,7 +1183,7 @@ export class IPAssetClient {
       };
       const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationWithFees({
         wipOptions: {
-          ...request.wipOptions,
+          ...request.options?.wipOptions,
           useMulticallWhenPossible: false,
         },
         sender: this.walletAddress,
@@ -1261,7 +1261,7 @@ export class IPAssetClient {
         );
       };
       const { txHash, ipId, tokenId, receipt } = await this.handleRegistrationWithFees({
-        wipOptions: request.wipOptions,
+        wipOptions: request.options?.wipOptions,
         sender: this.walletAddress,
         spgNftContract: transformRequest.spgNftContract,
         spgSpenderAddress: this.royaltyTokenDistributionWorkflowsClient.address,
@@ -1320,7 +1320,7 @@ export class IPAssetClient {
       };
       return await this.handleRegistrationWithFees({
         spgNftContract: transformRequest.spgNftContract,
-        wipOptions: request.wipOptions,
+        wipOptions: request.options?.wipOptions,
         sender: this.walletAddress,
         spgSpenderAddress: this.royaltyTokenDistributionWorkflowsClient.address,
         derivData: transformRequest.derivData,
@@ -1439,7 +1439,7 @@ export class IPAssetClient {
         rpcClient: this.rpcClient,
         wallet: this.wallet,
         walletAddress: this.walletAddress,
-        wipOptions: request.wipOptions,
+        wipOptions: request.options?.wipOptions,
         chainId: this.chainId,
       });
 
@@ -1483,7 +1483,7 @@ export class IPAssetClient {
           rpcClient: this.rpcClient,
           wallet: this.wallet,
           walletAddress: this.walletAddress,
-          wipOptions: request.wipOptions,
+          wipOptions: request.options?.wipOptions,
           chainId: this.chainId,
         });
         distributeRoyaltyTokensTxHashes = txResponse.map((tx) => tx.txHash);

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -335,7 +335,7 @@ export class LicenseClient {
       }
       const { txHash, receipt } = await contractCallWithFees({
         totalFees: licenseMintingFee,
-        options: { wipOptions: request.wipOptions },
+        options: { wipOptions: request.options?.wipOptions },
         multicall3Address: this.multicall3Client.address,
         rpcClient: this.rpcClient,
         tokenSpenders: wipSpenders,

--- a/packages/core-sdk/src/resources/royalty.ts
+++ b/packages/core-sdk/src/resources/royalty.ts
@@ -266,8 +266,14 @@ export class RoyaltyClient {
     request: PayRoyaltyOnBehalfRequest,
   ): Promise<PayRoyaltyOnBehalfResponse> {
     try {
-      const { receiverIpId, payerIpId, token, amount, erc20Options, wipOptions, txOptions } =
-        request;
+      const {
+        receiverIpId,
+        payerIpId,
+        token,
+        amount,
+        options: { erc20Options, wipOptions } = {},
+        txOptions,
+      } = request;
       const sender = this.wallet.account!.address;
       const payAmount = BigInt(amount);
       if (payAmount <= 0n) {

--- a/packages/core-sdk/src/types/options.ts
+++ b/packages/core-sdk/src/types/options.ts
@@ -31,7 +31,9 @@ export type ERC20Options = {
  * Options to override the default behavior of the auto approve logic
  */
 export type WithERC20Options = {
-  erc20Options?: ERC20Options;
+  options?: {
+    erc20Options?: ERC20Options;
+  };
 };
 
 export type WipOptions = {

--- a/packages/core-sdk/src/types/options.ts
+++ b/packages/core-sdk/src/types/options.ts
@@ -65,8 +65,19 @@ export type WipOptions = {
  * and auto approve logic.
  */
 export type WithWipOptions = {
-  /** options to configure WIP behavior */
-  wipOptions?: WipOptions;
+  options?: {
+    /** options to configure WIP behavior */
+    wipOptions?: WipOptions;
+  };
+};
+
+export type WithErc20AndWipOptions = {
+  options?: {
+    /** options to configure ERC20 behavior */
+    erc20Options?: ERC20Options;
+    /** options to configure WIP behavior */
+    wipOptions?: WipOptions;
+  };
 };
 
 export type WaitForTransactionReceiptRequest = {

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -426,7 +426,7 @@ export type CommonRegistrationParams = {
   derivData?: DerivativeData;
   sender: Address;
   txOptions?: TxOptions;
-  wipOptions?: WipOptions;  
+  wipOptions?: WipOptions;
 };
 
 export type RegistrationResponse = {

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -17,7 +17,7 @@ import {
   RoyaltyTokenDistributionWorkflowsRegisterIpAndMakeDerivativeAndDeployRoyaltyVaultRequest,
 } from "../../abi/generated";
 import { IpMetadataAndTxOptions, LicensingConfig, LicensingConfigInput } from "../common";
-import { TxOptions, WithWipOptions } from "../options";
+import { TxOptions, WipOptions, WithWipOptions } from "../options";
 import { LicenseTerms, LicenseTermsInput } from "./license";
 import { Erc20Spender } from "../utils/wip";
 
@@ -417,7 +417,7 @@ export type MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensResponse
   tokenId?: bigint;
 };
 
-export type CommonRegistrationParams = WithWipOptions & {
+export type CommonRegistrationParams = {
   contractCall: () => Promise<Hash>;
   encodedTxs: EncodedTxData[];
   spgNftContract?: Address;
@@ -426,6 +426,7 @@ export type CommonRegistrationParams = WithWipOptions & {
   derivData?: DerivativeData;
   sender: Address;
   txOptions?: TxOptions;
+  wipOptions?: WipOptions;  
 };
 
 export type RegistrationResponse = {

--- a/packages/core-sdk/src/types/resources/royalty.ts
+++ b/packages/core-sdk/src/types/resources/royalty.ts
@@ -6,7 +6,7 @@ import {
   IpRoyaltyVaultImplRevenueTokenClaimedEvent,
 } from "../../abi/generated";
 import { TokenAmountInput } from "../common";
-import {  WithErc20AndWipOptions, WithTxOptions } from "../options";
+import { WithErc20AndWipOptions, WithTxOptions } from "../options";
 
 export type ClaimableRevenueRequest = {
   /** The IP ID of the royalty vault. */

--- a/packages/core-sdk/src/types/resources/royalty.ts
+++ b/packages/core-sdk/src/types/resources/royalty.ts
@@ -6,7 +6,7 @@ import {
   IpRoyaltyVaultImplRevenueTokenClaimedEvent,
 } from "../../abi/generated";
 import { TokenAmountInput } from "../common";
-import { WithERC20Options, WithTxOptions, WithWipOptions } from "../options";
+import {  WithErc20AndWipOptions, WithTxOptions } from "../options";
 
 export type ClaimableRevenueRequest = {
   /** The IP ID of the royalty vault. */
@@ -21,8 +21,7 @@ export type ClaimableRevenueRequest = {
 export type ClaimableRevenueResponse = bigint;
 
 export type PayRoyaltyOnBehalfRequest = WithTxOptions &
-  WithERC20Options &
-  WithWipOptions & {
+  WithErc20AndWipOptions & {
     /** The IP ID that receives the royalties. */
     receiverIpId: Address;
     /** The IP ID that pays the royalties. */

--- a/packages/core-sdk/src/types/resources/tagging.ts
+++ b/packages/core-sdk/src/types/resources/tagging.ts
@@ -27,4 +27,3 @@ export type RemoveTagRequest = {
 export type RemoveTagResponse = {
   txHash: Hash;
 };
-

--- a/packages/core-sdk/src/types/utils/wip.ts
+++ b/packages/core-sdk/src/types/utils/wip.ts
@@ -7,13 +7,7 @@ import {
   SimpleWalletClient,
 } from "../../abi/generated";
 import { TokenClient, WipTokenClient } from "../../utils/token";
-import {
-  ERC20Options,
-  TransactionResponse,
-  TxOptions,
-  WipOptions,
-  WithWipOptions,
-} from "../options";
+import { ERC20Options, TransactionResponse, TxOptions, WipOptions } from "../options";
 
 export type Multicall3ValueCall = Multicall3Aggregate3Request["calls"][0] & { value: bigint };
 

--- a/packages/core-sdk/src/types/utils/wip.ts
+++ b/packages/core-sdk/src/types/utils/wip.ts
@@ -66,7 +66,7 @@ export type ContractCallWithFees<T extends Hash | Hash[] = Hash> = {
   txOptions?: TxOptions;
 };
 
-export type MulticallWithWrapIp = WithWipOptions & {
+export type MulticallWithWrapIp = {
   calls: Multicall3ValueCall[];
   ipAmountToWrap: bigint;
   contractCall: () => Promise<Hash | Hash[]>;
@@ -75,6 +75,7 @@ export type MulticallWithWrapIp = WithWipOptions & {
   wipClient: WipTokenClient;
   rpcClient: PublicClient;
   wallet: SimpleWalletClient;
+  wipOptions?: WipOptions;
 };
 
 export type ContractCallWithFeesResponse<T extends Hash | Hash[]> = Promise<

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -1189,8 +1189,10 @@ describe("IP Asset Functions", () => {
               percentage: 100,
             },
           ],
-          wipOptions: {
-            enableAutoWrapIp: false,
+          options: {
+            wipOptions: {
+              enableAutoWrapIp: false,
+            },
           },
           txOptions: { waitForTransaction: true },
         });
@@ -3078,8 +3080,10 @@ describe("IP Asset Functions", () => {
       const totalFees = 15 + 0 + 10 + 5 + 5;
       const result = await client.ipAsset.batchRegisterIpAssetsWithOptimizedWorkflows({
         requests: requests,
-        wipOptions: {
-          useMulticallWhenPossible: false,
+        options: {
+          wipOptions: {
+            useMulticallWhenPossible: false,
+          },
         },
       });
       const userBalanceAfter = await client.getBalance(walletAddress);

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -4627,8 +4627,10 @@ describe("Test IpAssetClient", () => {
             },
           },
         ],
-        wipOptions: {
-          useMulticallWhenPossible: false,
+        options: {
+          wipOptions: {
+            useMulticallWhenPossible: false,
+          },
         },
       });
       expect(mintAndRegisterIpAndMakeDerivativeStub.callCount).to.equal(1);

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -929,7 +929,9 @@ describe("Test LicenseClient", () => {
           maxMintingFee: 1,
           maxRevenueShare: 1,
           txOptions: { waitForTransaction: false },
-          wipOptions: { useMulticallWhenPossible: false },
+          options: {
+            wipOptions: { useMulticallWhenPossible: false },
+          },
         });
         expect(result.txHash).to.equal(txHash);
         expect(result.receipt).to.be.undefined;


### PR DESCRIPTION
## Description
Remove all options (wipOptions, etc) into a single optional options property. Every public client method that accepts options should do this.
Put `wipOptions` and `erc20Options` under the `options` property.

## Note
This is a breaking change to require the SDK user to move `wipOptions` and `erc20Options` into `options`.
Before
```
await client.ipAsset.batchRegisterIpAssetsWithOptimizedWorkflows({
        requests: requests,
        wipOptions: {
          useMulticallWhenPossible: false,
        },
      });
```

Now
```
 await client.ipAsset.batchRegisterIpAssetsWithOptimizedWorkflows({
        requests: requests,
        options: {
          wipOptions: {
            useMulticallWhenPossible: false,
          },
        },
      });
```