### PR TITLE
Fix lint waring

### DIFF
--- a/packages/core-sdk/eslint.config.mjs
+++ b/packages/core-sdk/eslint.config.mjs
@@ -1,6 +1,6 @@
 import config from "@story-protocol/eslint-config";
 
-/** @type {import("eslint").Linter.Config} */
+/** @type {import("eslint").Linter.Config[]} */
 export default [
   ...config,
   //TODO: need to fix `e` which is not being used in generated files

--- a/packages/core-sdk/tsconfig.json
+++ b/packages/core-sdk/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "ESNext",
     "outDir": "dist",
     "types": ["mocha"],
-    "lib": ["dom", "es2015"]
+    "lib": ["dom", "es2015"],
+    "allowJs": true
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["eslint.config.mjs", "src/**/*", "test/**/*"]
 }

--- a/packages/eslint-config-story/index.js
+++ b/packages/eslint-config-story/index.js
@@ -7,7 +7,11 @@ import tsParser from "@typescript-eslint/parser";
 import importPlugin from "eslint-plugin-import";
 import tsEslintPlugin from "@typescript-eslint/eslint-plugin";
 import tsStylistic from "@stylistic/eslint-plugin-ts";
-
+/**
+ * A shared ESLint configuration for the repository.
+ *
+ * @type {import("eslint").Linter.Config[]}
+ * */
 export default [
   js.configs.recommended,
   eslintConfigPrettier,


### PR DESCRIPTION
## Description
In `packages/core-sdk`, there is the  `xx was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject` warning.
The pr fixes the warning.

