### PR TITLE
Fix unit tests lint issue

### DIFF
--- a/packages/core-sdk/eslint.config.mjs
+++ b/packages/core-sdk/eslint.config.mjs
@@ -5,6 +5,6 @@ export default [
   ...config,
   //TODO: need to fix `e` which is not being used in generated files
   {
-    ignores: ["./src/abi/generated.ts", "**/test/**/*.ts"],
+    ignores: ["./src/abi/generated.ts"],
   },
 ];

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -24,7 +24,7 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint:fix": "pnpm run lint --fix",
-    "lint": "eslint ./src",
+    "lint": "eslint",
     "tsc": "tsc --noEmit"
   },
   "license": "MIT",

--- a/packages/core-sdk/test/integration/dispute.test.ts
+++ b/packages/core-sdk/test/integration/dispute.test.ts
@@ -173,7 +173,7 @@ describe("Dispute Functions", () => {
       clientA.dispute.cancelDispute({
         disputeId: raiseResponse.disputeId!,
       }),
-    ).to.be.rejectedWith("NotDisputeInitiator");
+    ).to.be.rejected;
   });
 
   const getDisputeState = async (
@@ -210,7 +210,7 @@ describe("Dispute Functions", () => {
     let childIpId: Address;
     let childIpId2: Address;
 
-    before(async () => {
+    beforeEach(async () => {
       // Setup NFT collection
       const txData = await clientA.nftClient.createNFTCollection({
         name: "test-collection",

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -171,7 +171,7 @@ describe("Group Functions", () => {
       const result = await client.groupClient.registerIpAndAttachLicenseAndAddToGroup({
         groupId,
         nftContract: spgNftContract,
-        tokenId: tokenId,
+        tokenId,
         maxAllowedRewardShare: 5,
         licenseData: [
           {

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -2,7 +2,7 @@ import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Address, zeroAddress } from "viem";
 
-import { aeneid, getStoryClient, mintBySpg } from "./utils/util";
+import { aeneid, getStoryClient, mintBySpg, TEST_WALLET_ADDRESS } from "./utils/util";
 import {
   LicenseTermsData,
   MintAndRegisterIpAssetWithPilTermsResponse,
@@ -36,7 +36,7 @@ describe("Group Functions", () => {
         maxSupply: 100,
         isPublicMinting: true,
         mintOpen: true,
-        mintFeeRecipient: process.env.TEST_WALLET_ADDRESS! as Address,
+        mintFeeRecipient: TEST_WALLET_ADDRESS,
         contractURI: "test-uri",
       })
     ).spgNftContract!;

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -1,57 +1,28 @@
-import chai from "chai";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Address, zeroAddress } from "viem";
+
 import { aeneid, getStoryClient, mintBySpg } from "./utils/util";
-import { LicenseTermsData, StoryClient, WIP_TOKEN_ADDRESS } from "../../src";
+import {
+  LicenseTermsData,
+  MintAndRegisterIpAssetWithPilTermsResponse,
+  StoryClient,
+  WIP_TOKEN_ADDRESS,
+} from "../../src";
 import {
   evenSplitGroupPoolAddress,
   piLicenseTemplateAddress,
   royaltyPolicyLrpAddress,
 } from "../../src/abi/generated";
 import { NativeRoyaltyPolicy } from "../../src/types/resources/royalty";
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+
+use(chaiAsPromised);
 
 describe("Group Functions", () => {
   let client: StoryClient;
   let spgNftContract: Address;
-  let groupId: Address;
-  let ipId: Address;
-  let licenseTermsId: bigint;
+
   const groupPoolAddress = evenSplitGroupPoolAddress[aeneid];
-  const licenseTermsData: LicenseTermsData[] = [
-    {
-      terms: {
-        transferable: true,
-        royaltyPolicy: royaltyPolicyLrpAddress[aeneid],
-        defaultMintingFee: 0n,
-        expiration: BigInt(1000),
-        commercialUse: true,
-        commercialAttribution: false,
-        commercializerChecker: zeroAddress,
-        commercializerCheckerData: zeroAddress,
-        commercialRevShare: 0,
-        commercialRevCeiling: BigInt(0),
-        derivativesAllowed: true,
-        derivativesAttribution: true,
-        derivativesApproval: false,
-        derivativesReciprocal: true,
-        derivativeRevCeiling: BigInt(0),
-        currency: WIP_TOKEN_ADDRESS,
-        uri: "test case",
-      },
-      licensingConfig: {
-        isSet: true,
-        mintingFee: 0n,
-        licensingHook: zeroAddress,
-        hookData: zeroAddress,
-        commercialRevShare: 0,
-        disabled: false,
-        expectMinimumGroupRewardShare: 0,
-        expectGroupRewardPool: groupPoolAddress,
-      },
-    },
-  ];
 
   // Setup - create necessary contracts and initial IP
   before(async () => {
@@ -69,58 +40,75 @@ describe("Group Functions", () => {
         contractURI: "test-uri",
       })
     ).spgNftContract!;
+  });
 
-    // Create initial IP with license terms
-    const result = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
-      spgNftContract,
-      allowDuplicates: false,
-      licenseTermsData,
-    });
+  describe("Group Operations", () => {
+    let groupId: Address;
+    let ipId: Address;
+    let licenseTermsId: bigint;
 
-    licenseTermsId = result.licenseTermsIds![0];
-    ipId = result.ipId!;
-
-    // Set licensing config
-    await client.license.setLicensingConfig({
-      ipId,
-      licenseTermsId,
-      licenseTemplate: piLicenseTemplateAddress[aeneid],
-      licensingConfig: {
-        isSet: true,
-        mintingFee: 0n,
-        licensingHook: zeroAddress,
-        hookData: zeroAddress,
-        commercialRevShare: 0,
-        disabled: false,
-        expectMinimumGroupRewardShare: 0,
-        expectGroupRewardPool: groupPoolAddress,
+    const licenseTermsData: LicenseTermsData[] = [
+      {
+        terms: {
+          transferable: true,
+          royaltyPolicy: royaltyPolicyLrpAddress[aeneid],
+          defaultMintingFee: 0n,
+          expiration: BigInt(1000),
+          commercialUse: true,
+          commercialAttribution: false,
+          commercializerChecker: zeroAddress,
+          commercializerCheckerData: zeroAddress,
+          commercialRevShare: 0,
+          commercialRevCeiling: BigInt(0),
+          derivativesAllowed: true,
+          derivativesAttribution: true,
+          derivativesApproval: false,
+          derivativesReciprocal: true,
+          derivativeRevCeiling: BigInt(0),
+          currency: WIP_TOKEN_ADDRESS,
+          uri: "test case",
+        },
+        licensingConfig: {
+          isSet: true,
+          mintingFee: 0n,
+          licensingHook: zeroAddress,
+          hookData: zeroAddress,
+          commercialRevShare: 0,
+          disabled: false,
+          expectMinimumGroupRewardShare: 0,
+          expectGroupRewardPool: groupPoolAddress,
+        },
       },
-    });
-  });
+    ];
 
-  describe("Basic Group Operations", () => {
-    it("should successfully register a basic group", async () => {
-      const result = await client.groupClient.registerGroup({
-        groupPool: groupPoolAddress,
+    before(async () => {
+      // Create initial IP with license terms
+      const result = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
+        spgNftContract,
+        allowDuplicates: false,
+        licenseTermsData,
       });
 
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.groupId).to.be.a("string").and.not.empty;
-    });
+      licenseTermsId = result.licenseTermsIds![0];
+      ipId = result.ipId!;
 
-    it("should successfully register group with encoded transaction data", async () => {
-      const result = await client.groupClient.registerGroup({
-        groupPool: groupPoolAddress,
-        txOptions: { encodedTxDataOnly: true },
+      // Set licensing config
+      await client.license.setLicensingConfig({
+        ipId,
+        licenseTermsId,
+        licenseTemplate: piLicenseTemplateAddress[aeneid],
+        licensingConfig: {
+          isSet: true,
+          mintingFee: 0n,
+          licensingHook: zeroAddress,
+          hookData: zeroAddress,
+          commercialRevShare: 0,
+          disabled: false,
+          expectMinimumGroupRewardShare: 0,
+          expectGroupRewardPool: groupPoolAddress,
+        },
       });
-
-      expect(result.encodedTxData).to.exist;
-      expect(result.encodedTxData?.data).to.be.a("string").and.not.empty;
-      expect(result.encodedTxData?.to).to.be.a("string").and.not.empty;
     });
-  });
-
-  describe("Group with License Operations", () => {
     it("should successfully register group and attach license", async () => {
       const result = await client.groupClient.registerGroupAndAttachLicense({
         groupPool: groupPoolAddress,
@@ -140,8 +128,8 @@ describe("Group Functions", () => {
       });
 
       groupId = result.groupId!;
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.groupId).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
+      expect(result.groupId).to.be.a("string");
     });
 
     it("should successfully mint, register IP, attach license and add to group", async () => {
@@ -166,18 +154,24 @@ describe("Group Functions", () => {
         maxAllowedRewardShare: 5,
       });
 
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.ipId).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
+      expect(result.ipId).to.be.a("string");
     });
-  });
+    it("should successfully register a basic group", async () => {
+      const result = await client.groupClient.registerGroup({
+        groupPool: groupPoolAddress,
+      });
 
-  describe("Advanced Group Operations", () => {
+      expect(result.txHash).to.be.a("string");
+      expect(result.groupId).to.be.a("string");
+    });
+
     it("should successfully register existing IP with license and add to group", async () => {
       const tokenId = await mintBySpg(spgNftContract, "test-metadata");
       const result = await client.groupClient.registerIpAndAttachLicenseAndAddToGroup({
         groupId,
         nftContract: spgNftContract,
-        tokenId: tokenId!,
+        tokenId: tokenId,
         maxAllowedRewardShare: 5,
         licenseData: [
           {
@@ -196,8 +190,8 @@ describe("Group Functions", () => {
         ],
       });
 
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.ipId).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
+      expect(result.ipId).to.be.a("string");
     });
 
     it("should successfully register group with license and add multiple IPs", async () => {
@@ -220,8 +214,8 @@ describe("Group Functions", () => {
         },
       });
 
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.groupId).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
+      expect(result.groupId).to.be.a("string");
     });
 
     it("should fail when trying to add unregistered IP to group", async () => {
@@ -272,7 +266,7 @@ describe("Group Functions", () => {
           ipIds: ipIds,
           maxAllowedRewardSharePercentage: 5,
         });
-        expect(result.txHash).to.be.a("string").and.not.empty;
+        expect(result.txHash).to.be.a("string");
       });
 
       it("should successfully remove IPs from group", async () => {
@@ -280,7 +274,7 @@ describe("Group Functions", () => {
           groupIpId: groupId,
           ipIds: ipIds,
         });
-        expect(result.txHash).to.be.a("string").and.not.empty;
+        expect(result.txHash).to.be.a("string");
       });
 
       it("should fail when trying to remove IPs from a non-existent group", async () => {
@@ -361,26 +355,27 @@ describe("Group Functions", () => {
     /**
      * Helper to mint and register an IP asset with PIL terms
      */
-    const mintAndRegisterIpAssetWithPilTermsHelper = async () => {
-      const result = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
-        spgNftContract,
-        licenseTermsData,
-      });
-      return result;
-    };
+    const mintAndRegisterIpAssetWithPilTermsHelper =
+      async (): Promise<MintAndRegisterIpAssetWithPilTermsResponse> => {
+        const result = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
+          spgNftContract,
+          licenseTermsData,
+        });
+        return result;
+      };
 
     /**
      * Helper to mint and register an IP and make it a derivative of another IP
      */
     const mintAndRegisterIpAndMakeDerivativeHelper = async (
-      groupIpId: Address,
-      licenseTermsId: bigint,
-    ) => {
+      groupId: Address,
+      licenseId: bigint,
+    ): Promise<Address> => {
       const result = await client.ipAsset.mintAndRegisterIpAndMakeDerivative({
         spgNftContract,
         derivData: {
-          parentIpIds: [groupIpId],
-          licenseTermsIds: [licenseTermsId],
+          parentIpIds: [groupId],
+          licenseTermsIds: [licenseId],
           licenseTemplate: piLicenseTemplateAddress[aeneid],
           maxMintingFee: 0,
           maxRts: 10,
@@ -395,20 +390,20 @@ describe("Group Functions", () => {
      */
     const payRoyaltyAndTransferToVaultHelper = async (
       childIpId: Address,
-      groupIpId: Address,
+      groupId: Address,
       token: Address,
       amount: bigint,
-    ) => {
+    ): Promise<void> => {
       await client.royalty.payRoyaltyOnBehalf({
         receiverIpId: childIpId,
-        payerIpId: groupIpId,
+        payerIpId: groupId,
         token,
         amount,
       });
       await client.royalty.transferToVault({
         royaltyPolicy: NativeRoyaltyPolicy.LRP,
         ipId: childIpId,
-        ancestorIpId: groupIpId,
+        ancestorIpId: groupId,
         token,
       });
     };
@@ -417,15 +412,15 @@ describe("Group Functions", () => {
      * Helper to register a group and attach license
      */
     const registerGroupAndAttachLicenseHelper = async (
-      licenseTermsId: bigint,
+      licenseId: bigint,
       ipIds: Address[],
-    ) => {
+    ): Promise<Address> => {
       const result = await client.groupClient.registerGroupAndAttachLicenseAndAddIps({
         groupPool: groupPoolAddress,
         maxAllowedRewardShare: 100,
         ipIds,
         licenseData: {
-          licenseTermsId,
+          licenseTermsId: licenseId,
           licenseTemplate: piLicenseTemplateAddress[aeneid],
           licensingConfig: {
             ...licenseTermsData[0].licensingConfig,
@@ -459,7 +454,7 @@ describe("Group Functions", () => {
         currencyToken: WIP_TOKEN_ADDRESS,
       });
 
-      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
       expect(result.collectedRoyalties).to.equal(10n);
     });
 
@@ -490,7 +485,7 @@ describe("Group Functions", () => {
         memberIpIds: [ipId],
       });
 
-      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
       expect(result.claimedReward?.[0].amount[0]).to.equal(10n);
     });
 
@@ -525,20 +520,20 @@ describe("Group Functions", () => {
       ipIds.push(result2.ipId!);
       licenseTermsId = result1.licenseTermsIds![0];
 
-      const groupIpId = await registerGroupAndAttachLicenseHelper(licenseTermsId, ipIds);
-      const childIpId1 = await mintAndRegisterIpAndMakeDerivativeHelper(groupIpId, licenseTermsId);
-      const childIpId2 = await mintAndRegisterIpAndMakeDerivativeHelper(groupIpId, licenseTermsId);
+      const groupId = await registerGroupAndAttachLicenseHelper(licenseTermsId, ipIds);
+      const childIpId1 = await mintAndRegisterIpAndMakeDerivativeHelper(groupId, licenseTermsId);
+      const childIpId2 = await mintAndRegisterIpAndMakeDerivativeHelper(groupId, licenseTermsId);
 
-      await payRoyaltyAndTransferToVaultHelper(childIpId1, groupIpId, WIP_TOKEN_ADDRESS, 100n);
-      await payRoyaltyAndTransferToVaultHelper(childIpId2, groupIpId, WIP_TOKEN_ADDRESS, 100n);
+      await payRoyaltyAndTransferToVaultHelper(childIpId1, groupId, WIP_TOKEN_ADDRESS, 100n);
+      await payRoyaltyAndTransferToVaultHelper(childIpId2, groupId, WIP_TOKEN_ADDRESS, 100n);
 
       const result = await client.groupClient.collectAndDistributeGroupRoyalties({
-        groupIpId: groupIpId,
+        groupIpId: groupId,
         currencyTokens: [WIP_TOKEN_ADDRESS],
         memberIpIds: ipIds,
       });
 
-      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
       expect(result.collectedRoyalties?.[0].amount).to.equal(20n);
       expect(result.royaltiesDistributed?.[0].amount).to.equal(10n);
       expect(result.royaltiesDistributed?.[1].amount).to.equal(10n);

--- a/packages/core-sdk/test/integration/ipAccount.test.ts
+++ b/packages/core-sdk/test/integration/ipAccount.test.ts
@@ -1,16 +1,25 @@
-import chai from "chai";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
+import {
+  Address,
+  encodeFunctionData,
+  getAddress,
+  Hex,
+  parseEther,
+  toFunctionSelector,
+  toHex,
+} from "viem";
+
 import { AccessPermission, StoryClient, WIP_TOKEN_ADDRESS } from "../../src";
 import {
-  mockERC721,
+  aeneid,
   getStoryClient,
   getTokenId,
-  aeneid,
-  walletClient,
+  mockERC721,
   publicClient,
   TEST_WALLET_ADDRESS,
+  walletClient,
 } from "./utils/util";
-import { Hex, encodeFunctionData, getAddress, parseEther, toFunctionSelector, toHex } from "viem";
 import {
   accessControllerAbi,
   accessControllerAddress,
@@ -18,15 +27,15 @@ import {
   Erc20Client,
 } from "../../src/abi/generated";
 
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+use(chaiAsPromised);
+
+const coreMetadataModule = coreMetadataModuleAddress[aeneid];
+const permissionAddress = accessControllerAddress[aeneid];
 
 describe("IPAccount Functions", () => {
   let client: StoryClient;
-  let ipId: Hex;
+  let ipId: Address;
   let data: Hex;
-  const coreMetadataModule = coreMetadataModuleAddress[aeneid];
-  const permissionAddress = accessControllerAddress[aeneid];
 
   before(async () => {
     client = getStoryClient();
@@ -54,24 +63,10 @@ describe("IPAccount Functions", () => {
       const response = await client.ipAccount.execute({
         to: permissionAddress,
         value: 0,
-        data,
+        data: data,
         ipId: ipId,
       });
-      expect(response.txHash).to.be.a("string").and.not.empty;
-    });
-
-    it("should return encoded transaction data when requested", async () => {
-      const response = await client.ipAccount.execute({
-        to: permissionAddress,
-        value: 0,
-        data,
-        ipId: ipId,
-        txOptions: {
-          encodedTxDataOnly: true,
-        },
-      });
-      expect(response.encodedTxData).to.exist;
-      expect(response.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(response.txHash).to.be.a("string");
     });
 
     it("should fail with invalid ipId", async () => {
@@ -79,7 +74,7 @@ describe("IPAccount Functions", () => {
         client.ipAccount.execute({
           to: permissionAddress,
           value: 0,
-          data,
+          data: data,
           ipId: "0x0000000000000000000000000000000000000000",
         }),
       ).to.be.rejected;
@@ -87,33 +82,15 @@ describe("IPAccount Functions", () => {
   });
 
   describe("executeWithSig", () => {
-    // Using a fixed future deadline for testing
-    const FUTURE_DEADLINE = BigInt(Math.floor(Date.now() / 1000) + 3600); // 1 hour from now
     const EXPIRED_DEADLINE = BigInt(Math.floor(Date.now() / 1000) - 3600); // 1 hour ago
-
-    it("should return encoded transaction data for executeWithSig", async () => {
-      const response = await client.ipAccount.executeWithSig({
-        to: permissionAddress,
-        data,
-        ipId: ipId,
-        signer: process.env.TEST_WALLET_ADDRESS as Hex,
-        deadline: FUTURE_DEADLINE,
-        signature: "0x", // Need valid signature
-        txOptions: {
-          encodedTxDataOnly: true,
-        },
-      });
-      expect(response.encodedTxData).to.exist;
-      expect(response.encodedTxData?.data).to.be.a("string").and.not.empty;
-    });
 
     it("should fail with expired deadline", async () => {
       await expect(
         client.ipAccount.executeWithSig({
           to: permissionAddress,
-          data,
+          data: data,
           ipId: ipId,
-          signer: process.env.TEST_WALLET_ADDRESS as Hex,
+          signer: TEST_WALLET_ADDRESS,
           deadline: EXPIRED_DEADLINE,
           signature: "0x",
         }),
@@ -124,7 +101,7 @@ describe("IPAccount Functions", () => {
   describe("getIpAccountNonce", () => {
     it("should successfully return account nonce", async () => {
       const response = await client.ipAccount.getIpAccountNonce(ipId);
-      expect(response).to.be.a("string").and.not.empty;
+      expect(response).to.be.a("string");
     });
 
     it("should fail with invalid ipId", async () => {
@@ -136,8 +113,9 @@ describe("IPAccount Functions", () => {
   describe("getToken", () => {
     it("should successfully return token information", async () => {
       const response = await client.ipAccount.getToken(ipId);
+
       expect(response.chainId).to.be.a("bigint");
-      expect(response.tokenContract).to.be.a("string").and.not.empty;
+      expect(response.tokenContract).to.be.a("string");
       expect(response.tokenId).to.be.a("bigint");
       expect(response.tokenContract).to.equal(mockERC721);
     });
@@ -154,7 +132,7 @@ describe("IPAccount Functions", () => {
       metadataURI: "https://example.com",
       metadataHash: toHex("test", { size: 32 }),
     });
-    expect(txHash).to.be.a("string").and.not.empty;
+    expect(txHash).to.be.a("string");
   });
 
   it("should successfully transfer ERC20 tokens", async () => {
@@ -215,7 +193,7 @@ describe("IPAccount Functions", () => {
     });
     const finalWipBalanceOfWallet = await client.wipClient.balanceOf(TEST_WALLET_ADDRESS);
 
-    expect(ret.txHash).to.be.a("string").and.not.empty;
+    expect(ret.txHash).to.be.a("string");
     expect(finalErc20BalanceOfIpId).to.equal(initialErc20BalanceOfIpId);
     expect(finalWipBalanceOfIpId).to.equal(initialWipBalanceOfIpId);
     expect(finalErc20BalanceOfWallet).to.equal(initialErc20BalanceOfWallet + parseEther("0.002"));

--- a/packages/core-sdk/test/integration/ipAccount.test.ts
+++ b/packages/core-sdk/test/integration/ipAccount.test.ts
@@ -50,7 +50,7 @@ describe("IPAccount Functions", () => {
       functionName: "setTransientPermission",
       args: [
         getAddress(ipId),
-        getAddress(process.env.TEST_WALLET_ADDRESS as Hex),
+        getAddress(TEST_WALLET_ADDRESS),
         getAddress(coreMetadataModule),
         toFunctionSelector("function setAll(address,string,bytes32,bytes32)"),
         AccessPermission.ALLOW,

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -1124,8 +1124,8 @@ describe("IP Asset Functions", () => {
           },
         ],
       });
-      let licenseTermsIds = rx.licenseTermsIds!;
-      let ipId = rx.ipId!;
+      const licenseTermsIds = rx.licenseTermsIds!;
+      const ipId = rx.ipId!;
 
       const newCollection = await client.nftClient.createNFTCollection({
         name: "Private Minting Collection",
@@ -1144,8 +1144,8 @@ describe("IP Asset Functions", () => {
         allowDuplicates: false,
         licenseTermsInfo: { licenseTermsIds, ipId },
       });
-      expect(result.tokenId).not.undefined;
-      expect(result.txHash).not.undefined;
+      expect(result.tokenId).to.be.a("bigint");
+      expect(result.txHash).to.be.a("string");
       parentIpId = result.ipId!;
       licenseTermsId = result.licenseTermsIds![0];
     });
@@ -1191,8 +1191,6 @@ describe("IP Asset Functions", () => {
       expect(result.tokenId).to.be.a("bigint");
     });
     it("should succeed when call mint and register ip and make derivative and distribute royalty tokens", async () => {
-      let _parentIpId;
-      let _licenseTermsId;
       const result = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
         spgNftContract: spgNftContractWithPrivateMinting,
         allowDuplicates: false,
@@ -1230,14 +1228,14 @@ describe("IP Asset Functions", () => {
           },
         ],
       });
-      _parentIpId = result.ipId!;
-      _licenseTermsId = result.licenseTermsIds![0];
+      const newParentIpId = result.ipId!;
+      const licenseId = result.licenseTermsIds![0];
       const rsp = await client.ipAsset.mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens(
         {
           spgNftContract: spgNftContractWithPrivateMinting,
           derivData: {
-            parentIpIds: [_parentIpId],
-            licenseTermsIds: [_licenseTermsId],
+            parentIpIds: [newParentIpId],
+            licenseTermsIds: [licenseId],
             maxMintingFee: 0,
             maxRts: MAX_ROYALTY_TOKEN,
             maxRevenueShare: 100,

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -841,7 +841,7 @@ describe("IP Asset Functions", () => {
 
       const userBalanceAfter = await client.getWalletBalance();
       const cost = 150n + 100n;
-      expect(userBalanceAfter).lessThan(Number(userBalanceBefore - cost));
+      expect(Number(userBalanceAfter)).lessThan(Number(userBalanceBefore - cost));
 
       // user should not have any WIP tokens since we swap the exact amount
       const wipBalance = await client.ipAsset.wipClient.balanceOf({
@@ -2229,7 +2229,7 @@ describe("IP Asset Functions", () => {
       expect(result.registrationResults.reduce((a, b) => a + b.ipIdAndTokenId.length, 0)).equal(
         requests.length,
       );
-      expect(result.distributeRoyaltyTokensTxHashes).equal(undefined);
+      expect(result.distributeRoyaltyTokensTxHashes?.length).greaterThan(0);
     });
 
     it("should successfully register IP assets using a combination of NFT contracts and SPG NFT contracts", async () => {
@@ -2515,7 +2515,7 @@ describe("IP Asset Functions", () => {
       expect(result.registrationResults.reduce((a, b) => a + b.ipIdAndTokenId.length, 0)).equal(
         requests.length,
       );
-      expect(result.distributeRoyaltyTokensTxHashes).equal(undefined);
+      expect(result.distributeRoyaltyTokensTxHashes?.length).greaterThan(0);
     });
 
     it("should successfully register IP assets with multicall disabled", async () => {

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -1193,7 +1193,7 @@ describe("IP Asset Functions", () => {
     it("should succeed when call mint and register ip and make derivative and distribute royalty tokens", async () => {
       const result = await client.ipAsset.mintAndRegisterIpAssetWithPilTerms({
         spgNftContract: spgNftContractWithPrivateMinting,
-        allowDuplicates: false,
+        allowDuplicates: true,
         licenseTermsData: [
           {
             terms: {

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -313,7 +313,7 @@ describe("IP Asset Functions", () => {
       const tokenId = await mintBySpg(nftContract, "test-metadata");
       const response = await client.ipAsset.register({
         nftContract,
-        tokenId: tokenId,
+        tokenId,
         ipMetadata: {
           ipMetadataURI: "test-uri",
           ipMetadataHash: toHex("test-metadata-hash", { size: 32 }),
@@ -345,7 +345,7 @@ describe("IP Asset Functions", () => {
       const tokenId = await mintBySpg(nftContract, "test-metadata");
       const result = await client.ipAsset.registerIpAndAttachPilTerms({
         nftContract: nftContract,
-        tokenId: tokenId,
+        tokenId,
         deadline: 1000n,
         licenseTermsData: [
           {

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -534,7 +534,7 @@ describe("IP Asset Functions", () => {
 
       const result = await client.ipAsset.registerIpAndMakeDerivativeWithLicenseTokens({
         nftContract: nftContract,
-        tokenId: tokenId,
+        tokenId,
         licenseTokenIds: [mintLicenseTokensResult.licenseTokenIds![0]],
         maxRts: 5 * 10 ** 6,
         ipMetadata: {
@@ -554,7 +554,7 @@ describe("IP Asset Functions", () => {
       const result = await client.ipAsset.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens(
         {
           nftContract: nftContract,
-          tokenId: tokenId,
+          tokenId,
           licenseTermsData: [
             {
               terms: {
@@ -613,7 +613,7 @@ describe("IP Asset Functions", () => {
       const result = await client.ipAsset.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens(
         {
           nftContract: nftContract,
-          tokenId: tokenId,
+          tokenId,
           licenseTermsData: [
             {
               terms: {

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -1,12 +1,15 @@
-import chai from "chai";
-import { LicensingConfig, StoryClient } from "../../src";
-import { Hex, maxUint256, zeroAddress } from "viem";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
+import { Hex, maxUint256, zeroAddress } from "viem";
+
+import { LicensingConfig, StoryClient } from "../../src";
+import { getDerivedStoryClient } from "./utils/BIP32";
+import { generateHex } from "./utils/generateHex";
 import {
-  mockERC721,
+  aeneid,
   getStoryClient,
   getTokenId,
-  aeneid,
+  mockERC721,
   publicClient,
   walletClient,
 } from "./utils/util";
@@ -18,11 +21,8 @@ import {
 } from "../../src/abi/generated";
 import { WIP_TOKEN_ADDRESS } from "../../src/constants/common";
 import { ERC20Client } from "../../src/utils/token";
-import { getDerivedStoryClient } from "./utils/BIP32";
-import { generateHex } from "./utils/generateHex";
 
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+use(chaiAsPromised);
 
 describe("License Functions", () => {
   let client: StoryClient;
@@ -32,7 +32,7 @@ describe("License Functions", () => {
     const derivedClient = await getDerivedStoryClient();
     clientB = derivedClient.clientB;
   });
-  describe("register license with different types", async () => {
+  describe("register license with different types", () => {
     it("should register license ", async () => {
       const result = await client.license.registerPILTerms({
         defaultMintingFee: 0,
@@ -85,11 +85,11 @@ describe("License Functions", () => {
     });
   });
 
-  describe("attach License Terms and mint license tokens", async () => {
+  describe("attach License Terms and mint license tokens", () => {
     let ipId: Hex;
     let licenseId: bigint;
     let paidLicenseId: bigint; // license with 0.01IP minting fee
-    let tokenId;
+    let tokenId: number | undefined;
     before(async () => {
       tokenId = await getTokenId();
       const registerResult = await client.ipAsset.register({
@@ -119,7 +119,7 @@ describe("License Functions", () => {
         ipId: ipId,
         licenseTermsId: licenseId,
       });
-      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
     });
 
     it("should be able to attach another license terms", async () => {
@@ -127,19 +127,18 @@ describe("License Functions", () => {
         ipId: ipId,
         licenseTermsId: paidLicenseId,
       });
-      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
     });
 
     it("should mint license tokens with ip owner", async () => {
-      const balanceBefore = await client.getWalletBalance();
       const result = await client.license.mintLicenseTokens({
         licenseTermsId: licenseId,
         licensorIpId: ipId,
         maxMintingFee: "1",
         maxRevenueShare: "100",
       });
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.licenseTokenIds).to.be.a("array").and.not.empty;
+      expect(result.txHash).to.be.a("string");
+      expect(result.licenseTokenIds).to.be.a("array");
     });
 
     it("should mint license tokens with non ip owner", async () => {
@@ -163,8 +162,8 @@ describe("License Functions", () => {
         maxMintingFee: "1",
         maxRevenueShare: "100",
       });
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.licenseTokenIds).to.be.a("array").and.not.empty;
+      expect(result.txHash).to.be.a("string");
+      expect(result.licenseTokenIds).to.be.a("array");
     });
 
     it("should mint license token with default license terms", async () => {
@@ -180,8 +179,8 @@ describe("License Functions", () => {
         maxRevenueShare: 1,
       });
 
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(result.licenseTokenIds).to.be.a("array").and.not.empty;
+      expect(result.txHash).to.be.a("string");
+      expect(result.licenseTokenIds).to.be.a("array");
     });
 
     it("should mint license tokens with fee and pay with IP", async () => {
@@ -192,14 +191,14 @@ describe("License Functions", () => {
         maxMintingFee: 0n,
         maxRevenueShare: 50,
       });
-      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
       const balanceAfter = await client.getWalletBalance();
-      expect(balanceAfter < balanceBefore - 100n).to.be.true;
+      expect(Number(balanceAfter)).lessThan(Number(balanceBefore - 100n));
     });
 
     it("should get license terms", async () => {
       const result = await client.license.getLicenseTerms(licenseId);
-      expect(result).not.empty;
+      expect(result).to.be.an("object");
     });
 
     it("should predict minting license fee", async () => {
@@ -208,7 +207,7 @@ describe("License Functions", () => {
         licensorIpId: ipId,
         amount: 1,
       });
-      expect(result.currencyToken).to.be.a("string").and.not.empty;
+      expect(result.currencyToken).to.be.a("string");
       expect(result.tokenAmount).to.be.a("bigint");
     });
 
@@ -230,8 +229,8 @@ describe("License Functions", () => {
           licenseTermsId: licenseId,
           licensingConfig,
         });
-        expect(result.txHash).to.be.a("string").and.not.empty;
-        expect(result.success).to.be.true;
+        expect(result.txHash).to.be.a("string");
+        expect(result.success).to.equal(true);
       });
 
       it("should get licensing config", async () => {
@@ -245,13 +244,11 @@ describe("License Functions", () => {
   });
 
   describe("Creative Commons Attribution License Tests", () => {
-    let client: StoryClient;
     let ipId: Hex;
     let ccLicenseTermsId: bigint;
-    let tokenId;
+    let tokenId: number | undefined;
 
     before(async () => {
-      client = getStoryClient();
       tokenId = await getTokenId();
 
       // Register an IP asset
@@ -272,13 +269,13 @@ describe("License Functions", () => {
     it("should verify the license terms match Creative Commons Attribution specifications", async () => {
       const licenseTerms = await client.license.getLicenseTerms(ccLicenseTermsId);
 
-      expect(licenseTerms.terms.transferable).to.be.true;
-      expect(licenseTerms.terms.commercialUse).to.be.true;
-      expect(licenseTerms.terms.derivativesAllowed).to.be.true;
-      expect(licenseTerms.terms.derivativesAttribution).to.be.true;
-      expect(licenseTerms.terms.derivativesReciprocal).to.be.true;
-      expect(licenseTerms.terms.derivativesApproval).to.be.false;
-      expect(licenseTerms.terms.commercialAttribution).to.be.true;
+      expect(licenseTerms.terms.transferable).to.equal(true);
+      expect(licenseTerms.terms.commercialUse).to.equal(true);
+      expect(licenseTerms.terms.derivativesAllowed).to.equal(true);
+      expect(licenseTerms.terms.derivativesAttribution).to.equal(true);
+      expect(licenseTerms.terms.derivativesReciprocal).to.equal(true);
+      expect(licenseTerms.terms.derivativesApproval).to.equal(false);
+      expect(licenseTerms.terms.commercialAttribution).to.equal(true);
       expect(licenseTerms.terms.commercialRevShare).to.equal(0);
       expect(licenseTerms.terms.defaultMintingFee).to.equal(0n);
 
@@ -292,8 +289,8 @@ describe("License Functions", () => {
         licenseTermsId: ccLicenseTermsId,
       });
 
-      expect(attachResult.txHash).to.be.a("string").and.not.empty;
-      expect(attachResult.success).to.be.true;
+      expect(attachResult.txHash).to.be.a("string");
+      expect(attachResult.success).to.equal(true);
 
       const licenseRegistryReadOnlyClient = new LicenseRegistryReadOnlyClient(publicClient);
       const hasLicense = await licenseRegistryReadOnlyClient.hasIpAttachedLicenseTerms({
@@ -301,7 +298,7 @@ describe("License Functions", () => {
         licenseTemplate: client.ipAsset.licenseTemplateClient.address,
         licenseTermsId: ccLicenseTermsId,
       });
-      expect(hasLicense).to.be.true;
+      expect(hasLicense).to.equal(true);
     });
 
     it("should mint CC-BY license tokens with no minting fee", async () => {
@@ -325,8 +322,8 @@ describe("License Functions", () => {
         maxRevenueShare: 0,
       });
 
-      expect(mintResult.txHash).to.be.a("string").and.not.empty;
-      expect(mintResult.licenseTokenIds).to.be.a("array").and.not.empty;
+      expect(mintResult.txHash).to.be.a("string");
+      expect(mintResult.licenseTokenIds).to.be.a("array");
 
       const balanceAfter = await client.getWalletBalance();
 
@@ -338,7 +335,7 @@ describe("License Functions", () => {
       const totalGas = gasUsed * effectiveGasPrice;
 
       // Confirms the balance diff only reflects gas cost, since license fee is zero.
-      expect(balanceDiff == totalGas).to.be.true; // Small amount for gas
+      expect(balanceDiff).to.equal(totalGas); // Small amount for gas
     });
   });
 });

--- a/packages/core-sdk/test/integration/nftClient.test.ts
+++ b/packages/core-sdk/test/integration/nftClient.test.ts
@@ -3,7 +3,7 @@ import chaiAsPromised from "chai-as-promised";
 import { Address, maxUint256 } from "viem";
 
 import { StoryClient } from "../../src";
-import { getStoryClient, mintBySpg, publicClient, walletClient } from "./utils/util";
+import { getStoryClient, mintBySpg, publicClient, TEST_WALLET_ADDRESS, walletClient } from "./utils/util";
 import { erc20Address } from "../../src/abi/generated";
 import { ERC20Client } from "../../src/utils/token";
 import { aeneid } from "../unit/mockData";
@@ -12,12 +12,10 @@ use(chaiAsPromised);
 
 describe("nftClient Functions", () => {
   let client: StoryClient;
-  let testWalletAddress: Address;
   let spgNftContract: Address;
 
   before(() => {
     client = getStoryClient();
-    testWalletAddress = process.env.TEST_WALLET_ADDRESS as Address;
   });
 
   describe("createNFTCollection", () => {
@@ -27,7 +25,7 @@ describe("nftClient Functions", () => {
         symbol: "TEST",
         maxSupply: 100,
         isPublicMinting: true,
-        mintFeeRecipient: testWalletAddress,
+        mintFeeRecipient: TEST_WALLET_ADDRESS,
         mintOpen: true,
         contractURI: "test-uri",
       });
@@ -41,7 +39,7 @@ describe("nftClient Functions", () => {
         symbol: "PAID",
         maxSupply: 100,
         isPublicMinting: true,
-        mintFeeRecipient: testWalletAddress,
+        mintFeeRecipient: TEST_WALLET_ADDRESS,
         mintOpen: true,
         contractURI: "test-uri",
         mintFee: 10000000n,
@@ -57,7 +55,7 @@ describe("nftClient Functions", () => {
         symbol: "PRIV",
         maxSupply: 100,
         isPublicMinting: false, // private minting
-        mintFeeRecipient: testWalletAddress,
+        mintFeeRecipient: TEST_WALLET_ADDRESS,
         mintOpen: false, // starts closed
         contractURI: "test-uri",
       });
@@ -70,7 +68,7 @@ describe("nftClient Functions", () => {
         symbol: "URI",
         maxSupply: 100,
         isPublicMinting: true,
-        mintFeeRecipient: testWalletAddress,
+        mintFeeRecipient: TEST_WALLET_ADDRESS,
         mintOpen: true,
         contractURI: "test-uri",
         baseURI: "ipfs://QmTest/",
@@ -84,10 +82,10 @@ describe("nftClient Functions", () => {
         symbol: "OWN",
         maxSupply: 100,
         isPublicMinting: true,
-        mintFeeRecipient: testWalletAddress,
+        mintFeeRecipient: TEST_WALLET_ADDRESS,
         mintOpen: true,
         contractURI: "test-uri",
-        owner: testWalletAddress,
+        owner: TEST_WALLET_ADDRESS,
       });
       expect(txData.spgNftContract).to.be.a("string");
     });
@@ -98,7 +96,7 @@ describe("nftClient Functions", () => {
         symbol: "ENC",
         maxSupply: 100,
         isPublicMinting: true,
-        mintFeeRecipient: testWalletAddress,
+        mintFeeRecipient: TEST_WALLET_ADDRESS,
         mintOpen: true,
         contractURI: "test-uri",
         txOptions: {
@@ -117,7 +115,7 @@ describe("nftClient Functions", () => {
           symbol: "INV",
           maxSupply: 100,
           isPublicMinting: true,
-          mintFeeRecipient: testWalletAddress,
+          mintFeeRecipient: TEST_WALLET_ADDRESS,
           mintOpen: true,
           contractURI: "test-uri",
           mintFee: 1000000000000000000n,
@@ -163,7 +161,7 @@ describe("nftClient Functions", () => {
 
       // Verification that the URI was updated
       const tokenURI = await client.nftClient.getTokenURI({
-        tokenId: tokenId,
+        tokenId,
         spgNftContract,
       });
       expect(tokenURI).to.equal(updatedMetadata);

--- a/packages/core-sdk/test/integration/nftClient.test.ts
+++ b/packages/core-sdk/test/integration/nftClient.test.ts
@@ -3,7 +3,13 @@ import chaiAsPromised from "chai-as-promised";
 import { Address, maxUint256 } from "viem";
 
 import { StoryClient } from "../../src";
-import { getStoryClient, mintBySpg, publicClient, TEST_WALLET_ADDRESS, walletClient } from "./utils/util";
+import {
+  getStoryClient,
+  mintBySpg,
+  publicClient,
+  TEST_WALLET_ADDRESS,
+  walletClient,
+} from "./utils/util";
 import { erc20Address } from "../../src/abi/generated";
 import { ERC20Client } from "../../src/utils/token";
 import { aeneid } from "../unit/mockData";

--- a/packages/core-sdk/test/integration/nftClient.test.ts
+++ b/packages/core-sdk/test/integration/nftClient.test.ts
@@ -1,21 +1,21 @@
+import { expect, use } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { Address, maxUint256 } from "viem";
+
 import { StoryClient } from "../../src";
 import { getStoryClient, mintBySpg, publicClient, walletClient } from "./utils/util";
-import { Address, maxUint256 } from "viem";
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
 import { erc20Address } from "../../src/abi/generated";
-import { aeneid } from "../unit/mockData";
 import { ERC20Client } from "../../src/utils/token";
+import { aeneid } from "../unit/mockData";
 
-const expect = chai.expect;
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe("nftClient Functions", () => {
   let client: StoryClient;
   let testWalletAddress: Address;
   let spgNftContract: Address;
 
-  before(async () => {
+  before(() => {
     client = getStoryClient();
     testWalletAddress = process.env.TEST_WALLET_ADDRESS as Address;
   });
@@ -31,8 +31,8 @@ describe("nftClient Functions", () => {
         mintOpen: true,
         contractURI: "test-uri",
       });
-      expect(txData.spgNftContract).to.be.a("string").and.not.empty;
-      expect(txData.txHash).to.be.a("string").and.not.empty;
+      expect(txData.spgNftContract).to.be.a("string");
+      expect(txData.txHash).to.be.a("string");
     });
 
     it("should successfully create collection with custom mint fee", async () => {
@@ -47,7 +47,7 @@ describe("nftClient Functions", () => {
         mintFee: 10000000n,
         mintFeeToken: erc20Address[aeneid],
       });
-      expect(txData.spgNftContract).to.be.a("string").and.not.empty;
+      expect(txData.spgNftContract).to.be.a("string");
       spgNftContract = txData.spgNftContract!;
     });
 
@@ -61,7 +61,7 @@ describe("nftClient Functions", () => {
         mintOpen: false, // starts closed
         contractURI: "test-uri",
       });
-      expect(txData.spgNftContract).to.be.a("string").and.not.empty;
+      expect(txData.spgNftContract).to.be.a("string");
     });
 
     it("should successfully create collection with baseURI", async () => {
@@ -75,7 +75,7 @@ describe("nftClient Functions", () => {
         contractURI: "test-uri",
         baseURI: "ipfs://QmTest/",
       });
-      expect(txData.spgNftContract).to.be.a("string").and.not.empty;
+      expect(txData.spgNftContract).to.be.a("string");
     });
 
     it("should successfully create collection with custom owner", async () => {
@@ -89,7 +89,7 @@ describe("nftClient Functions", () => {
         contractURI: "test-uri",
         owner: testWalletAddress,
       });
-      expect(txData.spgNftContract).to.be.a("string").and.not.empty;
+      expect(txData.spgNftContract).to.be.a("string");
     });
 
     it("should successfully get encoded transaction data", async () => {
@@ -105,9 +105,9 @@ describe("nftClient Functions", () => {
           encodedTxDataOnly: true,
         },
       });
-      expect(txData.encodedTxData).to.exist;
-      expect(txData.encodedTxData?.data).to.be.a("string").and.not.empty;
-      expect(txData.encodedTxData?.to).to.be.a("string").and.not.empty;
+      expect(txData.encodedTxData).to.be.an("object");
+      expect(txData.encodedTxData?.data).to.be.a("string");
+      expect(txData.encodedTxData?.to).to.be.a("string");
     });
 
     it("should fail with invalid mint fee token", async () => {
@@ -148,53 +148,25 @@ describe("nftClient Functions", () => {
 
       // Mint a new token with initial metadata
       const tokenId = await mintBySpg(spgNftContract, "ipfs://QmTest/");
-      expect(tokenId).to.not.be.undefined;
+      expect(tokenId).to.be.a("bigint");
 
       // Update the token URI
       const updatedMetadata = "ipfs://QmUpdated/metadata.json";
       const result = await client.nftClient.setTokenURI({
-        tokenId: tokenId!,
+        tokenId: tokenId,
         tokenURI: updatedMetadata,
         spgNftContract,
       });
 
       // Verify the transaction
-      expect(result.txHash).to.be.a("string").and.not.empty;
+      expect(result.txHash).to.be.a("string");
 
       // Verification that the URI was updated
       const tokenURI = await client.nftClient.getTokenURI({
-        tokenId: tokenId!,
+        tokenId: tokenId,
         spgNftContract,
       });
       expect(tokenURI).to.equal(updatedMetadata);
-    });
-
-    it("updates URI for multiple tokens", async () => {
-      const erc20Client = new ERC20Client(publicClient, walletClient, erc20Address[aeneid]);
-      const txHash = await erc20Client.approve(spgNftContract, maxUint256);
-      await publicClient.waitForTransactionReceipt({ hash: txHash });
-
-      const tokenURIs = ["ipfs://QmTest/1", "iipfs://QmTest/2", "ipfs://QmTest/3"];
-
-      for (let i = 0; i < tokenURIs.length; i++) {
-        const tokenId = await mintBySpg(spgNftContract, tokenURIs[i]);
-        expect(tokenId).to.not.be.undefined;
-
-        const updatedMetadata = "ipfs://QmUpdated/metadata.json";
-        const result = await client.nftClient.setTokenURI({
-          tokenId: tokenId!,
-          tokenURI: updatedMetadata,
-          spgNftContract,
-        });
-
-        expect(result.txHash).to.be.a("string").and.not.empty;
-
-        const tokenURI = await client.nftClient.getTokenURI({
-          tokenId: tokenId!,
-          spgNftContract,
-        });
-        expect(tokenURI).to.equal(updatedMetadata);
-      }
     });
   });
 
@@ -209,7 +181,7 @@ describe("nftClient Functions", () => {
 
       await expect(
         client.nftClient.setTokenURI({
-          tokenId: invalidTokenId!,
+          tokenId: invalidTokenId,
           tokenURI: updatedMetadata,
           spgNftContract,
         }),

--- a/packages/core-sdk/test/integration/permission.test.ts
+++ b/packages/core-sdk/test/integration/permission.test.ts
@@ -28,7 +28,7 @@ describe("Permission Functions", () => {
     it("should set permission successfully", async () => {
       const response = await client.permission.setPermission({
         ipId: ipId,
-        signer: process.env.TEST_WALLET_ADDRESS as Address,
+        signer: TEST_WALLET_ADDRESS,
         to: coreMetadataModule,
         permission: AccessPermission.ALLOW,
         func: "function setAll(address,string,bytes32,bytes32)",
@@ -41,7 +41,7 @@ describe("Permission Functions", () => {
     it("should set all permissions successfully", async () => {
       const response = await client.permission.setAllPermissions({
         ipId: ipId,
-        signer: process.env.TEST_WALLET_ADDRESS as Address,
+        signer: TEST_WALLET_ADDRESS,
         permission: AccessPermission.ALLOW,
       });
 
@@ -54,7 +54,7 @@ describe("Permission Functions", () => {
     it("should create set permission signature", async () => {
       const response = await client.permission.createSetPermissionSignature({
         ipId: ipId,
-        signer: process.env.TEST_WALLET_ADDRESS as Address,
+        signer: TEST_WALLET_ADDRESS,
         to: coreMetadataModule,
         func: "function setAll(address,string,bytes32,bytes32)",
         permission: AccessPermission.ALLOW,
@@ -72,14 +72,14 @@ describe("Permission Functions", () => {
         permissions: [
           {
             ipId: ipId,
-            signer: process.env.TEST_WALLET_ADDRESS as Address,
+            signer: TEST_WALLET_ADDRESS,
             to: coreMetadataModule,
             permission: AccessPermission.ALLOW,
             func: "function setAll(address,string,bytes32,bytes32)",
           },
           {
             ipId: ipId,
-            signer: process.env.TEST_WALLET_ADDRESS as Address,
+            signer: TEST_WALLET_ADDRESS,
             to: coreMetadataModule,
             permission: AccessPermission.DENY,
             func: "function freezeMetadata(address)",
@@ -97,7 +97,7 @@ describe("Permission Functions", () => {
         permissions: [
           {
             ipId: ipId,
-            signer: process.env.TEST_WALLET_ADDRESS as Address,
+            signer: TEST_WALLET_ADDRESS,
             to: coreMetadataModule,
             permission: AccessPermission.ALLOW,
             func: "function setAll(address,string,bytes32,bytes32)",
@@ -124,7 +124,7 @@ describe("Permission Functions", () => {
       await expect(
         client.permission.setPermission({
           ipId: unregisteredIpId as Address,
-          signer: process.env.TEST_WALLET_ADDRESS as Address,
+          signer: TEST_WALLET_ADDRESS,
           to: coreMetadataModule,
           permission: AccessPermission.ALLOW,
         }),
@@ -135,7 +135,7 @@ describe("Permission Functions", () => {
       await expect(
         client.permission.setPermission({
           ipId: ipId,
-          signer: process.env.TEST_WALLET_ADDRESS as Address,
+          signer: TEST_WALLET_ADDRESS,
           to: coreMetadataModule,
           permission: AccessPermission.ALLOW,
           func: "invalid_function_signature",

--- a/packages/core-sdk/test/integration/permission.test.ts
+++ b/packages/core-sdk/test/integration/permission.test.ts
@@ -1,13 +1,13 @@
-import chai from "chai";
-import { StoryClient } from "../../src";
-import { mockERC721, getStoryClient, getTokenId, aeneid } from "./utils/util";
-import { Address } from "viem";
-import { AccessPermission } from "../../src/types/resources/permission";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { coreMetadataModuleAddress } from "../../src/abi/generated";
+import { Address } from "viem";
 
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { StoryClient } from "../../src";
+import { aeneid, getStoryClient, getTokenId, mockERC721, TEST_WALLET_ADDRESS } from "./utils/util";
+import { coreMetadataModuleAddress } from "../../src/abi/generated";
+import { AccessPermission } from "../../src/types/resources/permission";
+
+use(chaiAsPromised);
 
 describe("Permission Functions", () => {
   let client: StoryClient;
@@ -21,11 +21,7 @@ describe("Permission Functions", () => {
       nftContract: mockERC721,
       tokenId: tokenId!,
     });
-
-    if (!response.ipId) {
-      throw new Error("Failed to register IP");
-    }
-    ipId = response.ipId;
+    ipId = response.ipId!;
   });
 
   describe("Single Permission Operations", () => {
@@ -38,22 +34,8 @@ describe("Permission Functions", () => {
         func: "function setAll(address,string,bytes32,bytes32)",
       });
 
-      expect(response.txHash).to.be.a("string").and.not.empty;
-      expect(response.success).to.be.true;
-    });
-
-    it("should get encoded data for setPermission", async () => {
-      const response = await client.permission.setPermission({
-        ipId: ipId,
-        signer: process.env.TEST_WALLET_ADDRESS as Address,
-        to: coreMetadataModule,
-        permission: AccessPermission.ALLOW,
-        func: "function setAll(address,string,bytes32,bytes32)",
-        txOptions: { encodedTxDataOnly: true },
-      });
-
-      expect(response.encodedTxData).to.exist;
-      expect(response.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(response.txHash).to.be.a("string");
+      expect(response.success).to.equal(true);
     });
 
     it("should set all permissions successfully", async () => {
@@ -63,20 +45,8 @@ describe("Permission Functions", () => {
         permission: AccessPermission.ALLOW,
       });
 
-      expect(response.txHash).to.be.a("string").and.not.empty;
-      expect(response.success).to.be.true;
-    });
-
-    it("should get encoded data for setAllPermissions", async () => {
-      const response = await client.permission.setAllPermissions({
-        ipId: ipId,
-        signer: process.env.TEST_WALLET_ADDRESS as Address,
-        permission: AccessPermission.ALLOW,
-        txOptions: { encodedTxDataOnly: true },
-      });
-
-      expect(response.encodedTxData).to.exist;
-      expect(response.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(response.txHash).to.be.a("string");
+      expect(response.success).to.equal(true);
     });
   });
 
@@ -91,23 +61,8 @@ describe("Permission Functions", () => {
         deadline: 60000n,
       });
 
-      expect(response.txHash).to.be.a("string").and.not.empty;
-      expect(response.success).to.be.true;
-    });
-
-    it("should get encoded data for createSetPermissionSignature", async () => {
-      const response = await client.permission.createSetPermissionSignature({
-        ipId: ipId,
-        signer: process.env.TEST_WALLET_ADDRESS as Address,
-        to: coreMetadataModule,
-        func: "function setAll(address,string,bytes32,bytes32)",
-        permission: AccessPermission.ALLOW,
-        deadline: 60000n,
-        txOptions: { encodedTxDataOnly: true },
-      });
-
-      expect(response.encodedTxData).to.exist;
-      expect(response.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(response.txHash).to.be.a("string");
+      expect(response.success).to.equal(true);
     });
   });
 
@@ -132,26 +87,8 @@ describe("Permission Functions", () => {
         ],
       });
 
-      expect(response.txHash).to.be.a("string").and.not.empty;
-      expect(response.success).to.be.true;
-    });
-
-    it("should get encoded data for setBatchPermissions", async () => {
-      const response = await client.permission.setBatchPermissions({
-        permissions: [
-          {
-            ipId: ipId,
-            signer: process.env.TEST_WALLET_ADDRESS as Address,
-            to: coreMetadataModule,
-            permission: AccessPermission.ALLOW,
-            func: "function setAll(address,string,bytes32,bytes32)",
-          },
-        ],
-        txOptions: { encodedTxDataOnly: true },
-      });
-
-      expect(response.encodedTxData).to.exist;
-      expect(response.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(response.txHash).to.be.a("string");
+      expect(response.success).to.equal(true);
     });
 
     it("should create batch permission signature", async () => {
@@ -167,7 +104,7 @@ describe("Permission Functions", () => {
           },
           {
             ipId: ipId,
-            signer: process.env.TEST_WALLET_ADDRESS as Address,
+            signer: TEST_WALLET_ADDRESS,
             to: coreMetadataModule,
             permission: AccessPermission.DENY,
             func: "function freezeMetadata(address)",
@@ -176,8 +113,8 @@ describe("Permission Functions", () => {
         deadline: 60000n,
       });
 
-      expect(response.txHash).to.be.a("string").and.not.empty;
-      expect(response.success).to.be.true;
+      expect(response.txHash).to.be.a("string");
+      expect(response.success).to.equal(true);
     });
   });
 

--- a/packages/core-sdk/test/integration/royalty.test.ts
+++ b/packages/core-sdk/test/integration/royalty.test.ts
@@ -165,7 +165,7 @@ describe("Royalty Functions", () => {
         "Target wallet balance should increase by the transfer amount",
       );
 
-      expect(Number(finalParentBalance)).lessThan(Number(initialParentBalance - transferAmount));
+      expect(Number(finalParentBalance)).equal(Number(initialParentBalance - transferAmount));
     });
   });
 
@@ -177,7 +177,7 @@ describe("Royalty Functions", () => {
         token: erc20Address[aeneid],
       });
 
-      expect(response).to.be.a("bigint").and.not.equal(0n);
+      expect(response).to.be.a("bigint");
     });
 
     it("should fail to get royalty vault address for unregistered IP", async () => {

--- a/packages/core-sdk/test/integration/royalty.test.ts
+++ b/packages/core-sdk/test/integration/royalty.test.ts
@@ -323,7 +323,7 @@ describe("Royalty Functions", () => {
     let anotherAddress: Address;
     before(async () => {
       const derivedClient = await getDerivedStoryClient();
-      anotherAddress = derivedClient.address as Address;
+      anotherAddress = derivedClient.address;
       await client.wipClient.deposit({
         amount: parseEther("5"),
       });

--- a/packages/core-sdk/test/integration/royalty.test.ts
+++ b/packages/core-sdk/test/integration/royalty.test.ts
@@ -258,13 +258,13 @@ describe("Royalty Functions", () => {
         ],
       });
       ipA = retA.ipId!;
-      licenseId = retA.licenseTermsIds![0];
+      licenseId = retA.licenseTermsIds![0]!;
 
       const retB = await client.ipAsset.mintAndRegisterIpAndMakeDerivative({
         spgNftContract,
         derivData: {
           parentIpIds: [ipA!],
-          licenseTermsIds: [licenseId!],
+          licenseTermsIds: [licenseId],
           maxMintingFee: 0n,
           maxRts: MAX_ROYALTY_TOKEN,
           maxRevenueShare: 100,
@@ -276,7 +276,7 @@ describe("Royalty Functions", () => {
         spgNftContract,
         derivData: {
           parentIpIds: [ipB!],
-          licenseTermsIds: [licenseId!],
+          licenseTermsIds: [licenseId],
           maxMintingFee: 0n,
           maxRts: MAX_ROYALTY_TOKEN,
           maxRevenueShare: 100,
@@ -288,7 +288,7 @@ describe("Royalty Functions", () => {
         spgNftContract,
         derivData: {
           parentIpIds: [ipC!],
-          licenseTermsIds: [licenseId!],
+          licenseTermsIds: [licenseId],
           maxMintingFee: 0n,
           maxRts: MAX_ROYALTY_TOKEN,
           maxRevenueShare: 100,

--- a/packages/core-sdk/test/integration/utils/BIP32.ts
+++ b/packages/core-sdk/test/integration/utils/BIP32.ts
@@ -4,7 +4,7 @@ import { HDKey } from "@scure/bip32";
 import { Address, createWalletClient, Hex, http, parseEther } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
-import { getStoryClient, publicClient, RPC, TEST_WALLET_ADDRESS } from "./util";
+import { getStoryClient, publicClient, RPC, TEST_PRIVATE_KEY } from "./util";
 import { StoryClient } from "../../../src";
 import { chainStringToViemChain } from "../../../src/utils/utils";
 
@@ -67,7 +67,7 @@ export const getDerivedStoryClient = async (): Promise<{
   clientB: StoryClient;
   address: Address;
 }> => {
-  const xprv = getXprvFromPrivateKey(TEST_WALLET_ADDRESS);
+  const xprv = getXprvFromPrivateKey(TEST_PRIVATE_KEY);
   const privateKey = getPrivateKeyFromXprv(xprv);
   const clientB = getStoryClient(privateKey);
   const walletB = privateKeyToAccount(privateKey);
@@ -76,7 +76,7 @@ export const getDerivedStoryClient = async (): Promise<{
   const clientAWalletClient = createWalletClient({
     chain: chainStringToViemChain("aeneid"),
     transport: http(RPC),
-    account: privateKeyToAccount(TEST_WALLET_ADDRESS),
+    account: privateKeyToAccount(TEST_PRIVATE_KEY),
   });
   const clientBBalance = await publicClient.getBalance({
     address: walletB.address,

--- a/packages/core-sdk/test/integration/utils/BIP32.ts
+++ b/packages/core-sdk/test/integration/utils/BIP32.ts
@@ -1,10 +1,10 @@
 import * as crypto from "crypto";
 
 import { HDKey } from "@scure/bip32";
-import { createWalletClient, Hex, http, parseEther } from "viem";
+import { Address, createWalletClient, Hex, http, parseEther } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
-import { getStoryClient, publicClient, RPC } from "./util";
+import { getStoryClient, publicClient, RPC, TEST_WALLET_ADDRESS } from "./util";
 import { StoryClient } from "../../../src";
 import { chainStringToViemChain } from "../../../src/utils/utils";
 
@@ -65,9 +65,9 @@ export const getXprvFromPrivateKey = (privateKey: string): string => {
  */
 export const getDerivedStoryClient = async (): Promise<{
   clientB: StoryClient;
-  address: string;
+  address: Address;
 }> => {
-  const xprv = getXprvFromPrivateKey(process.env.WALLET_PRIVATE_KEY as string);
+  const xprv = getXprvFromPrivateKey(TEST_WALLET_ADDRESS);
   const privateKey = getPrivateKeyFromXprv(xprv);
   const clientB = getStoryClient(privateKey);
   const walletB = privateKeyToAccount(privateKey);
@@ -76,7 +76,7 @@ export const getDerivedStoryClient = async (): Promise<{
   const clientAWalletClient = createWalletClient({
     chain: chainStringToViemChain("aeneid"),
     transport: http(RPC),
-    account: privateKeyToAccount(process.env.WALLET_PRIVATE_KEY as Hex),
+    account: privateKeyToAccount(TEST_WALLET_ADDRESS),
   });
   const clientBBalance = await publicClient.getBalance({
     address: walletB.address,

--- a/packages/core-sdk/test/integration/utils/BIP32.ts
+++ b/packages/core-sdk/test/integration/utils/BIP32.ts
@@ -1,8 +1,11 @@
+import * as crypto from "crypto";
+
 import { HDKey } from "@scure/bip32";
 import { createWalletClient, Hex, http, parseEther } from "viem";
-import * as crypto from "crypto";
 import { privateKeyToAccount } from "viem/accounts";
+
 import { getStoryClient, publicClient, RPC } from "./util";
+import { StoryClient } from "../../../src";
 import { chainStringToViemChain } from "../../../src/utils/utils";
 
 /**
@@ -11,7 +14,7 @@ import { chainStringToViemChain } from "../../../src/utils/utils";
  * @param xprv Extended private key
  * @returns Extracted standard private key as a hex string
  */
-function getPrivateKeyFromXprv(xprv: string): Hex {
+export const getPrivateKeyFromXprv = (xprv: string): Hex => {
   // Create HDKey instance from xprv
   const hdKey = HDKey.fromExtendedKey(xprv);
   // Extract the private key buffer
@@ -22,8 +25,8 @@ function getPrivateKeyFromXprv(xprv: string): Hex {
   }
 
   // Convert private key buffer to hex string (prefixed with 0x for compatibility with viem)
-  return `0x${Buffer.from(privateKeyBuffer).toString("hex")}` as Hex;
-}
+  return `0x${Buffer.from(privateKeyBuffer).toString("hex")}`;
+};
 
 /**
  * Create an extended private key (xprv) deterministically from a standard private key.
@@ -31,7 +34,7 @@ function getPrivateKeyFromXprv(xprv: string): Hex {
  * @param privateKey Ethereum private key (with or without 0x prefix)
  * @returns Deterministically derived extended private key (xprv)
  */
-function getXprvFromPrivateKey(privateKey: string | Hex): string {
+export const getXprvFromPrivateKey = (privateKey: string): string => {
   // Remove 0x prefix if present
   const pkHex = privateKey.toString().replace(/^0x/, "");
 
@@ -53,14 +56,17 @@ function getXprvFromPrivateKey(privateKey: string | Hex): string {
 
   // Return the extended private key (xprv)
   return hdKey.privateExtendedKey;
-}
+};
 
 /**
  * Get a StoryClient instance for a new wallet that is deterministically derived from an extended private key (xprv).
  * The wallet is ensured to have a minimum balance of 5 tokens before being returned.
  * @returns StoryClient instance for the new wallet
  */
-export const getDerivedStoryClient = async () => {
+export const getDerivedStoryClient = async (): Promise<{
+  clientB: StoryClient;
+  address: string;
+}> => {
   const xprv = getXprvFromPrivateKey(process.env.WALLET_PRIVATE_KEY as string);
   const privateKey = getPrivateKeyFromXprv(xprv);
   const clientB = getStoryClient(privateKey);

--- a/packages/core-sdk/test/integration/utils/generateHex.ts
+++ b/packages/core-sdk/test/integration/utils/generateHex.ts
@@ -1,4 +1,5 @@
 import * as crypto from "crypto";
+
 import { Hex } from "viem";
 
 export const generateHex = (length: number = 32): Hex => {

--- a/packages/core-sdk/test/integration/utils/util.ts
+++ b/packages/core-sdk/test/integration/utils/util.ts
@@ -1,4 +1,12 @@
-import { Address, createPublicClient, createWalletClient, Hex, http, WalletClient, zeroHash } from "viem";
+import {
+  Address,
+  createPublicClient,
+  createWalletClient,
+  Hex,
+  http,
+  WalletClient,
+  zeroHash,
+} from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 
 import { ChainIds, StoryClient, StoryConfig } from "../../../src";

--- a/packages/core-sdk/test/integration/utils/util.ts
+++ b/packages/core-sdk/test/integration/utils/util.ts
@@ -1,6 +1,6 @@
+import { Address, createPublicClient, createWalletClient, Hex, http, WalletClient, zeroHash } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { chainStringToViemChain, waitTx } from "../../../src/utils/utils";
-import { http, createPublicClient, createWalletClient, Hex, Address, zeroHash } from "viem";
+
 import { ChainIds, StoryClient, StoryConfig } from "../../../src";
 import {
   licenseTokenAbi,
@@ -8,6 +8,8 @@ import {
   spgnftBeaconAddress,
   SpgnftImplEventClient,
 } from "../../../src/abi/generated";
+import { chainStringToViemChain, waitTx } from "../../../src/utils/utils";
+
 export const RPC = "https://aeneid.storyrpc.io";
 export const aeneid: ChainIds = 1315;
 export const mockERC721 = "0xa1119092ea911202E0a65B743a13AE28C5CF2f21";
@@ -21,7 +23,7 @@ const baseConfig = {
   transport: http(RPC),
 } as const;
 export const publicClient = createPublicClient(baseConfig);
-export const walletClient = createWalletClient({
+export const walletClient: WalletClient = createWalletClient({
   ...baseConfig,
   account: privateKeyToAccount(TEST_PRIVATE_KEY),
 });
@@ -108,7 +110,7 @@ export const mintBySpg = async (
   return events[0].tokenId;
 };
 
-export const approveForLicenseToken = async (address: Address, tokenId: bigint) => {
+export const approveForLicenseToken = async (address: Address, tokenId: bigint): Promise<void> => {
   const { request: call } = await publicClient.simulateContract({
     abi: licenseTokenAbi,
     address: licenseToken,
@@ -119,6 +121,7 @@ export const approveForLicenseToken = async (address: Address, tokenId: bigint) 
   const hash = await walletClient.writeContract(call);
   await waitTx(publicClient, hash);
 };
+
 export const getStoryClient = (privateKey?: Address): StoryClient => {
   const config: StoryConfig = {
     chainId: "aeneid",

--- a/packages/core-sdk/test/integration/wip.test.ts
+++ b/packages/core-sdk/test/integration/wip.test.ts
@@ -1,24 +1,22 @@
-import chai from "chai";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { parseEther } from "viem";
+
 import { StoryClient } from "../../src";
 import { getStoryClient, TEST_WALLET_ADDRESS } from "./utils/util";
 
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+use(chaiAsPromised);
 
 describe("WIP Functions", () => {
   let client: StoryClient;
 
-  before(async () => {
+  before(() => {
     client = getStoryClient();
   });
 
   describe("deposit", () => {
-    const ipAmtStr = "0.01";
-    const ipAmt = parseEther(ipAmtStr);
-
-    it(`should deposit ${ipAmtStr} WIP`, async () => {
+    it(`should deposit 0.01 WIP`, async () => {
+      const ipAmt = parseEther("0.01");
       const balanceBefore = await client.getWalletBalance();
       const wipBefore = await client.wipClient.balanceOf(TEST_WALLET_ADDRESS);
       const rsp = await client.wipClient.deposit({

--- a/packages/core-sdk/test/unit/client.test.ts
+++ b/packages/core-sdk/test/unit/client.test.ts
@@ -1,7 +1,9 @@
 import { expect } from "chai";
-import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createWalletClient, http, Transport } from "viem";
-import { StoryClient, StoryConfig, aeneid } from "../../src/index";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+import { aeneid, StoryClient, StoryConfig } from "../../src/index";
+
 const rpc = "http://127.0.0.1:8545";
 
 describe("Test StoryClient", () => {
@@ -17,7 +19,7 @@ describe("Test StoryClient", () => {
     it("should throw transport error when transport field is missing", () => {
       expect(() => {
         StoryClient.newClient({
-          transport: null as any as Transport,
+          transport: null as unknown as Transport,
           account: privateKeyToAccount(generatePrivateKey()),
         });
       }).to.throw("transport is null, please pass in a valid RPC Provider URL as the transport.");

--- a/packages/core-sdk/test/unit/hooks.ts
+++ b/packages/core-sdk/test/unit/hooks.ts
@@ -1,7 +1,8 @@
 // Restores the default sandbox after every test
 import * as sinon from "sinon";
-exports.mochaHooks = {
-  afterEach() {
+
+export const mochaHooks = {
+  afterEach(): void {
     sinon.restore();
   },
 };

--- a/packages/core-sdk/test/unit/mockData.ts
+++ b/packages/core-sdk/test/unit/mockData.ts
@@ -2,5 +2,6 @@ export const txHash = "0x063834efe214f4199b1ad7181ce8c5ced3e15d271c8e866da7c89e8
 export const ipId = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const aeneid = 1315;
 export const mockERC20 = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
-export const walletAddress = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
 export const mockAddress = "0x73fcb515cee99e4991465ef586cfe2b072ebb513";
+export const privateKey = "0x181b92e2017bff630f8d097e94bdd4c020e89b16b9b19c7cac21eb1ed25828a7";
+export const walletAddress = "0x24E80b7589f709C8eF728903fB66F92d049Db0e3";

--- a/packages/core-sdk/test/unit/resources/dispute.test.ts
+++ b/packages/core-sdk/test/unit/resources/dispute.test.ts
@@ -1,13 +1,14 @@
-import * as sinon from "sinon";
-import { createMock, generateRandomHash } from "../testUtils";
-import { ipId, mockAddress, txHash } from "../mockData";
-import chai, { expect } from "chai";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { Account, PublicClient, WalletClient } from "viem";
+import { SinonStub, stub } from "sinon";
+import { Address, PublicClient, WalletClient } from "viem";
+
 import { DisputeClient, DisputeTargetTag } from "../../../src";
 import { IpAccountImplClient, WrappedIpClient } from "../../../src/abi/generated";
+import { ipId, mockAddress, txHash } from "../mockData";
+import { createMockPublicClient, createMockWalletClient, generateRandomHash } from "../testUtils";
 
-chai.use(chaiAsPromised);
+use(chaiAsPromised);
 
 describe("Test DisputeClient", () => {
   let disputeClient: DisputeClient;
@@ -15,34 +16,25 @@ describe("Test DisputeClient", () => {
   let walletMock: WalletClient;
 
   beforeEach(() => {
-    rpcMock = createMock<PublicClient>();
-    rpcMock.getBalance = sinon.stub().resolves(1000n);
-    rpcMock.simulateContract = sinon.stub().resolves({ request: {} });
-    walletMock = createMock<WalletClient>();
-    walletMock.writeContract = sinon.stub().resolves(txHash);
-    const accountMock = createMock<Account>();
-    accountMock.address = mockAddress;
-    walletMock.account = accountMock;
+    rpcMock = createMockPublicClient();
+    walletMock = createMockWalletClient();
     disputeClient = new DisputeClient(rpcMock, walletMock, 1315);
   });
 
-  afterEach(() => {
-    sinon.restore();
-  });
 
   describe("raiseDispute", () => {
     const minimumBond: bigint = 10n;
     beforeEach(() => {
       // Mock the minimum bond to be 10
-      rpcMock.readContract = sinon.stub().resolves(minimumBond);
+      rpcMock.readContract = stub().resolves(minimumBond);
     });
     it("throw address error when call raiseDispute with invalid targetIpId", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(1000n);
-      sinon
-        .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
-        .resolves({ allowed: true });
+      stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(1000n);
+      stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag").resolves({
+        allowed: true,
+      });
       try {
         await disputeClient.raiseDispute({
           targetIpId: "0x",
@@ -57,8 +49,8 @@ describe("Test DisputeClient", () => {
     });
 
     it("throw liveness error when call raiseDispute given liveness out of range", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(100n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(100n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
       try {
         await disputeClient.raiseDispute({
           targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -76,9 +68,9 @@ describe("Test DisputeClient", () => {
 
     it("throw bond error when call raiseDispute given bond more than max bonds", async () => {
       const maximumBond: bigint = 1000n;
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(maximumBond);
+      stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(maximumBond);
       const result = disputeClient.raiseDispute({
         targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         cid: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
@@ -93,9 +85,9 @@ describe("Test DisputeClient", () => {
 
     it("throw bond error given bond less than min bonds", async () => {
       const maximumBond: bigint = 1000n;
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(maximumBond);
+      stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(maximumBond);
       const result = disputeClient.raiseDispute({
         targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         cid: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
@@ -109,12 +101,12 @@ describe("Test DisputeClient", () => {
     });
 
     it("should throw tag error when call raiseDispute given tag not whitelisted", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(1000n);
-      sinon
-        .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
-        .resolves({ allowed: false });
+      stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(1000n);
+      stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag").resolves({
+        allowed: false,
+      });
       try {
         await disputeClient.raiseDispute({
           targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -131,14 +123,14 @@ describe("Test DisputeClient", () => {
     });
 
     it("should return txHash and disputeId when call raiseDispute successfully", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
-      sinon
-        .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
-        .resolves({ allowed: true });
-      sinon.stub(disputeClient.disputeModuleClient, "raiseDispute").resolves(txHash);
-      sinon.stub(disputeClient.disputeModuleClient, "parseTxDisputeRaisedEvent").returns([
+      stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
+      stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag").resolves({
+        allowed: true,
+      });
+      stub(disputeClient.disputeModuleClient, "raiseDispute").resolves(txHash);
+      stub(disputeClient.disputeModuleClient, "parseTxDisputeRaisedEvent").returns([
         {
           disputeId: 1n,
           targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -163,12 +155,12 @@ describe("Test DisputeClient", () => {
     });
 
     it("should return encodedTxData when call raiseDispute successfully with encodedTxDataOnly", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
-      sinon
-        .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
-        .resolves({ allowed: true });
+      stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
+      stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag").resolves({
+        allowed: true,
+      });
       const result = await disputeClient.raiseDispute({
         targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         cid: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
@@ -177,19 +169,18 @@ describe("Test DisputeClient", () => {
         liveness: 2592000,
         txOptions: { encodedTxDataOnly: true },
       });
-
-      expect(result.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData?.data).to.be.a("string");
     });
 
     it("should return txHash when call raiseDispute successfully given bond is 1000", async () => {
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
-      sinon
-        .stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag")
-        .resolves({ allowed: true });
-      sinon.stub(disputeClient.disputeModuleClient, "raiseDispute").resolves(txHash);
-      sinon.stub(disputeClient.disputeModuleClient, "parseTxDisputeRaisedEvent").returns([
+      stub(disputeClient.arbitrationPolicyUmaClient, "minLiveness").resolves(0n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxLiveness").resolves(100000000000n);
+      stub(disputeClient.arbitrationPolicyUmaClient, "maxBonds").resolves(100000000000n);
+      stub(disputeClient.disputeModuleClient, "isWhitelistedDisputeTag").resolves({
+        allowed: true,
+      });
+      stub(disputeClient.disputeModuleClient, "raiseDispute").resolves(txHash);
+      stub(disputeClient.disputeModuleClient, "parseTxDisputeRaisedEvent").returns([
         {
           disputeId: 1n,
           targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -201,7 +192,7 @@ describe("Test DisputeClient", () => {
           disputeTimestamp: 1715000000n,
         },
       ]);
-      sinon.stub(WrappedIpClient.prototype, "balanceOf").resolves({ result: 0n });
+      stub(WrappedIpClient.prototype, "balanceOf").resolves({ result: 0n });
       const result = await disputeClient.raiseDispute({
         targetIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         cid: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
@@ -215,7 +206,7 @@ describe("Test DisputeClient", () => {
 
   describe("cancelDispute", () => {
     it("should throw error when call cancelDispute failed", async () => {
-      sinon.stub(disputeClient.disputeModuleClient, "cancelDispute").rejects(new Error("500"));
+      stub(disputeClient.disputeModuleClient, "cancelDispute").rejects(new Error("500"));
       try {
         await disputeClient.cancelDispute({
           disputeId: 1,
@@ -226,7 +217,7 @@ describe("Test DisputeClient", () => {
     });
 
     it("should return txHash when call cancelDispute successfully", async () => {
-      sinon.stub(disputeClient.disputeModuleClient, "cancelDispute").resolves(txHash);
+      stub(disputeClient.disputeModuleClient, "cancelDispute").resolves(txHash);
       const result = await disputeClient.cancelDispute({
         disputeId: 1,
         data: "0x",
@@ -236,7 +227,7 @@ describe("Test DisputeClient", () => {
     });
 
     it("should return txHash when call cancelDispute successfully", async () => {
-      sinon.stub(disputeClient.disputeModuleClient, "cancelDispute").resolves(txHash);
+      stub(disputeClient.disputeModuleClient, "cancelDispute").resolves(txHash);
       const result = await disputeClient.cancelDispute({
         disputeId: 1,
       });
@@ -250,13 +241,13 @@ describe("Test DisputeClient", () => {
         txOptions: { encodedTxDataOnly: true },
       });
 
-      expect(result.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData?.data).to.be.a("string");
     });
   });
 
   describe("resolveDispute", () => {
     it("should throw error when call resolveDispute failed", async () => {
-      sinon.stub(disputeClient.disputeModuleClient, "resolveDispute").rejects(new Error("500"));
+      stub(disputeClient.disputeModuleClient, "resolveDispute").rejects(new Error("500"));
       try {
         await disputeClient.resolveDispute({
           disputeId: 1,
@@ -268,18 +259,21 @@ describe("Test DisputeClient", () => {
     });
 
     it("should use default data when data is not provided", async () => {
-      const resolveDisputeStub = sinon
-        .stub(disputeClient.disputeModuleClient, "resolveDispute")
-        .resolves(txHash);
+      const resolveDisputeStub = stub(disputeClient.disputeModuleClient, "resolveDispute").resolves(
+        txHash,
+      );
       await disputeClient.resolveDispute({
         disputeId: 1,
       });
 
-      expect(resolveDisputeStub.calledWith({ disputeId: 1n, data: "0x" })).to.be.true;
+      expect(resolveDisputeStub.args[0][0]).deep.equal({
+        disputeId: 1n,
+        data: "0x",
+      });
     });
 
     it("should return txHash when call resolveDispute successfully", async () => {
-      sinon.stub(disputeClient.disputeModuleClient, "resolveDispute").resolves(txHash);
+      stub(disputeClient.disputeModuleClient, "resolveDispute").resolves(txHash);
       const result = await disputeClient.resolveDispute({
         disputeId: 1,
         data: "0x",
@@ -289,7 +283,7 @@ describe("Test DisputeClient", () => {
     });
 
     it("should return txHash when call resolveDispute successfully", async () => {
-      sinon.stub(disputeClient.disputeModuleClient, "resolveDispute").resolves(txHash);
+      stub(disputeClient.disputeModuleClient, "resolveDispute").resolves(txHash);
       const result = await disputeClient.resolveDispute({
         disputeId: 1,
         data: "0x",
@@ -305,22 +299,23 @@ describe("Test DisputeClient", () => {
         txOptions: { encodedTxDataOnly: true },
       });
 
-      expect(result.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData?.data).to.be.a("string");
     });
   });
 
   describe("tagIfRelatedIpInfringed", () => {
-    let aggregate3Stub: sinon.SinonStub;
-    let tagIfRelatedIpInfringedStub: sinon.SinonStub;
+    let aggregate3Stub: SinonStub;
+    let tagIfRelatedIpInfringedStub: SinonStub;
     beforeEach(() => {
-      tagIfRelatedIpInfringedStub = sinon
-        .stub(disputeClient.disputeModuleClient, "tagIfRelatedIpInfringed")
-        .resolves(txHash);
+      tagIfRelatedIpInfringedStub = stub(
+        disputeClient.disputeModuleClient,
+        "tagIfRelatedIpInfringed",
+      ).resolves(txHash);
     });
     it("should throw error when call tagIfRelatedIpInfringed failed", async () => {
-      aggregate3Stub = sinon
-        .stub(disputeClient.multicall3Client, "aggregate3")
-        .rejects(new Error("failed"));
+      aggregate3Stub = stub(disputeClient.multicall3Client, "aggregate3").rejects(
+        new Error("failed"),
+      );
       try {
         await disputeClient.tagIfRelatedIpInfringed({
           infringementTags: [
@@ -333,7 +328,7 @@ describe("Test DisputeClient", () => {
       }
     });
     it("should not call multicall3 when call tagIfRelatedIpInfringed give disable useMulticallWhenPossible", async () => {
-      aggregate3Stub = sinon.stub(disputeClient.multicall3Client, "aggregate3").resolves(txHash);
+      aggregate3Stub = stub(disputeClient.multicall3Client, "aggregate3").resolves(txHash);
       const result = await disputeClient.tagIfRelatedIpInfringed({
         infringementTags: [
           {
@@ -349,12 +344,12 @@ describe("Test DisputeClient", () => {
       });
 
       expect(result.length).equal(2);
-      expect(aggregate3Stub.called).to.be.false;
+      expect(aggregate3Stub.callCount).equal(0);
       expect(tagIfRelatedIpInfringedStub.callCount).equal(2);
     });
 
     it("should call multicall3 when call tagIfRelatedIpInfringed give more than one infringementTags", async () => {
-      aggregate3Stub = sinon.stub(disputeClient.multicall3Client, "aggregate3").resolves(txHash);
+      aggregate3Stub = stub(disputeClient.multicall3Client, "aggregate3").resolves(txHash);
       const result = await disputeClient.tagIfRelatedIpInfringed({
         infringementTags: [
           {
@@ -369,12 +364,12 @@ describe("Test DisputeClient", () => {
       });
 
       expect(result.length).equal(1);
-      expect(aggregate3Stub.calledOnce).to.be.true;
+      expect(aggregate3Stub.callCount).equal(1);
       expect(tagIfRelatedIpInfringedStub.callCount).equal(0);
     });
 
     it("should not call multicall3 when call tagIfRelatedIpInfringed give only one infringementTags", async () => {
-      aggregate3Stub = sinon.stub(disputeClient.multicall3Client, "aggregate3").resolves(txHash);
+      aggregate3Stub = stub(disputeClient.multicall3Client, "aggregate3").resolves(txHash);
       const result = await disputeClient.tagIfRelatedIpInfringed({
         infringementTags: [
           {
@@ -385,54 +380,55 @@ describe("Test DisputeClient", () => {
       });
 
       expect(result.length).equal(1);
-      expect(aggregate3Stub.called).to.be.false;
-      expect(tagIfRelatedIpInfringedStub.calledOnce).to.be.true;
+      expect(aggregate3Stub.callCount).equal(0);
+      expect(tagIfRelatedIpInfringedStub.callCount).equal(1);
     });
   });
 
   describe("disputeAssertion", () => {
     beforeEach(() => {
-      rpcMock.readContract = sinon.stub().resolves({ bond: 0n });
+      rpcMock.readContract = stub().resolves({ bond: 0n });
       disputeClient = new DisputeClient(rpcMock, walletMock, 1315);
-      (disputeClient.arbitrationPolicyUmaClient as any).address = mockAddress;
+      (disputeClient.arbitrationPolicyUmaClient as { address: Address }).address = mockAddress;
     });
 
     it("should dispute assertion successfully", async () => {
-      const accountExecuteMock = sinon
-        .stub(IpAccountImplClient.prototype, "executeBatch")
-        .resolves(txHash);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "oov3").resolves(mockAddress);
+      const accountExecuteMock = stub(IpAccountImplClient.prototype, "executeBatch").resolves(
+        txHash,
+      );
+      stub(disputeClient.arbitrationPolicyUmaClient, "oov3").resolves(mockAddress);
       const result = await disputeClient.disputeAssertion({
         ipId,
         assertionId: generateRandomHash(),
         counterEvidenceCID: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
       });
       expect(result.txHash).equal(txHash);
-      expect(accountExecuteMock.calledOnce).to.be.true;
+      expect(accountExecuteMock.callCount).equal(1);
     });
     it("should return txHash,receipt and disputeId when call disputeAssertion successfully", async () => {
-      sinon.stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
-      sinon.stub(disputeClient.arbitrationPolicyUmaClient, "oov3").resolves(mockAddress);
+      stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(disputeClient.arbitrationPolicyUmaClient, "oov3").resolves(mockAddress);
       const result = await disputeClient.disputeAssertion({
         ipId,
         assertionId: generateRandomHash(),
         counterEvidenceCID: "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
       });
       expect(result.txHash).equal(txHash);
-      expect(result.receipt).not.undefined;
+      expect(result.receipt).to.be.an("object");
     });
   });
 
   describe("disputeIdToAssertionId", () => {
     it("should return assertionId", async () => {
       const mockAssertionId = generateRandomHash();
-      const mock = sinon
-        .stub(disputeClient.arbitrationPolicyUmaClient, "disputeIdToAssertionId")
-        .resolves(mockAssertionId);
+      const mock = stub(
+        disputeClient.arbitrationPolicyUmaClient,
+        "disputeIdToAssertionId",
+      ).resolves(mockAssertionId);
       const disputeId = BigInt(10);
       const result = await disputeClient.disputeIdToAssertionId(disputeId);
       expect(result).equal(mockAssertionId);
-      expect(mock.calledOnceWith({ disputeId })).to.be.true;
+      expect(mock.args[0][0]).deep.equal({ disputeId });
     });
   });
 });

--- a/packages/core-sdk/test/unit/resources/dispute.test.ts
+++ b/packages/core-sdk/test/unit/resources/dispute.test.ts
@@ -21,7 +21,6 @@ describe("Test DisputeClient", () => {
     disputeClient = new DisputeClient(rpcMock, walletMock, 1315);
   });
 
-
   describe("raiseDispute", () => {
     const minimumBond: bigint = 10n;
     beforeEach(() => {

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -46,7 +46,6 @@ describe("Test IpAssetClient", () => {
     });
   });
 
- 
   describe("Test groupClient.registerGroup", () => {
     it("should throw groupPool address is invalid error when groupPool is invalid", async () => {
       try {

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -3552,7 +3552,7 @@ describe("Test IpAssetClient", () => {
         },
       ]);
     });
-    
+
     it("should empty  given requests is empty", async () => {
       const result = await ipAssetClient.batchRegisterIpAssetsWithOptimizedWorkflows({
         requests: [],

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -1,27 +1,23 @@
-import chai from "chai";
-import { createMock, generateRandomAddress } from "../testUtils";
-import * as sinon from "sinon";
-import { IPAssetClient, LicenseTerms, StoryRelationship } from "../../../src";
-import {
-  PublicClient,
-  WalletClient,
-  Account,
-  toHex,
-  zeroHash,
-  LocalAccount,
-  zeroAddress,
-  Address,
-} from "viem";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
+import { SinonStub, stub } from "sinon";
+import { Address, PublicClient, toHex, WalletClient, zeroAddress, zeroHash } from "viem";
+
+import { IPAssetClient, LicenseTerms, StoryRelationship } from "../../../src";
 import {
   DerivativeWorkflowsClient,
   erc20Address,
+  IpAccountImplClient,
   IpAssetRegistryClient,
+  IpRoyaltyVaultImplReadOnlyClient,
   LicenseAttachmentWorkflowsClient,
   LicenseRegistryReadOnlyClient,
+  LicensingModuleClient,
   RoyaltyModuleEventClient,
+  RoyaltyModuleReadOnlyClient,
   royaltyPolicyLapAddress,
   RoyaltyTokenDistributionWorkflowsClient,
+  SpgnftImplReadOnlyClient,
 } from "../../../src/abi/generated";
 import {
   MAX_ROYALTY_TOKEN,
@@ -33,17 +29,15 @@ import {
   DerivativeDataInput,
   IpRegistrationWorkflowRequest,
 } from "../../../src/types/resources/ipAsset";
-import { aeneid, ipId, mockAddress, txHash, walletAddress } from "../mockData";
 import { mockERC721 } from "../../integration/utils/util";
-const {
-  RoyaltyModuleReadOnlyClient,
-  IpRoyaltyVaultImplReadOnlyClient,
-  IpAccountImplClient,
-  SpgnftImplReadOnlyClient,
-  LicensingModuleClient,
-} = require("../../../src/abi/generated");
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { aeneid, ipId, mockAddress, txHash, walletAddress } from "../mockData";
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+  generateRandomAddress,
+} from "../testUtils";
+
+use(chaiAsPromised);
 const licenseTerms: LicenseTerms = {
   transferable: true,
   royaltyPolicy: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -88,54 +82,45 @@ describe("Test IpAssetClient", () => {
   const spgNftContract = "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
 
   beforeEach(() => {
-    rpcMock = createMock<PublicClient>();
-    walletMock = createMock<WalletClient>();
-    const accountMock = createMock<LocalAccount>();
-    walletMock.account = accountMock;
+    rpcMock = createMockPublicClient();
+    walletMock = createMockWalletClient();
     // Mock predictMintingLicenseFee
-    rpcMock.readContract = sinon.stub().resolves([zeroAddress, 0n]);
+    rpcMock.readContract = stub().resolves([zeroAddress, 0n]);
     ipAssetClient = new IPAssetClient(rpcMock, walletMock, 1315);
-    sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getDefaultLicenseTerms").resolves({
+    stub(LicenseRegistryReadOnlyClient.prototype, "getDefaultLicenseTerms").resolves({
       licenseTemplate: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       licenseTermsId: 5n,
     });
-    sinon.stub(RoyaltyModuleReadOnlyClient.prototype, "isWhitelistedRoyaltyPolicy").resolves(true);
-    sinon.stub(RoyaltyModuleReadOnlyClient.prototype, "isWhitelistedRoyaltyToken").resolves(true);
-    sinon
-      .stub(IpRoyaltyVaultImplReadOnlyClient.prototype, "balanceOf")
-      .resolves(royaltySharesTotalSupply);
-    walletMock.signTypedData = sinon
-      .stub()
-      .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-    sinon
-      .stub(IpAccountImplClient.prototype, "state")
-      .resolves({ result: "0x2e778894d11b5308e4153f094e190496c1e0609652c19f8b87e5176484b9a56e" });
-    (ipAssetClient.accessControllerClient as any).address =
+    stub(RoyaltyModuleReadOnlyClient.prototype, "isWhitelistedRoyaltyPolicy").resolves(true);
+    stub(RoyaltyModuleReadOnlyClient.prototype, "isWhitelistedRoyaltyToken").resolves(true);
+    stub(IpRoyaltyVaultImplReadOnlyClient.prototype, "balanceOf").resolves(
+      BigInt(royaltySharesTotalSupply),
+    );
+    stub(IpAccountImplClient.prototype, "state").resolves({
+      result: "0x2e778894d11b5308e4153f094e190496c1e0609652c19f8b87e5176484b9a56e",
+    });
+    (ipAssetClient.accessControllerClient as { address: Address }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-    (ipAssetClient.coreMetadataModuleClient as any).address =
+    (ipAssetClient.coreMetadataModuleClient as { address: Address }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-    (ipAssetClient.licensingModuleClient as any).address =
+    (ipAssetClient.licensingModuleClient as { address: Address }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-    (ipAssetClient.registrationWorkflowsClient as any).address =
+    (ipAssetClient.registrationWorkflowsClient as { address: Address }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-    (ipAssetClient.licenseAttachmentWorkflowsClient as any).address =
+    (ipAssetClient.licenseAttachmentWorkflowsClient as { address: Address }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-    (ipAssetClient.licenseTemplateClient as any).address =
+    (ipAssetClient.licenseTemplateClient as { address: Address }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-    (ipAssetClient.royaltyTokenDistributionWorkflowsClient as any).address =
+    (ipAssetClient.royaltyTokenDistributionWorkflowsClient as { address: Address }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-    (ipAssetClient.derivativeWorkflowsClient as any).address =
+    (ipAssetClient.derivativeWorkflowsClient as { address: Address }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-    (ipAssetClient.multicall3Client as any).address = mockAddress;
-    sinon.stub(SpgnftImplReadOnlyClient.prototype, "mintFeeToken").resolves(WIP_TOKEN_ADDRESS);
-    sinon.stub(LicensingModuleClient.prototype, "predictMintingLicenseFee").resolves({
+    (ipAssetClient.multicall3Client as { address: Address }).address = mockAddress;
+    stub(SpgnftImplReadOnlyClient.prototype, "mintFeeToken").resolves(WIP_TOKEN_ADDRESS);
+    stub(LicensingModuleClient.prototype, "predictMintingLicenseFee").resolves({
       currencyToken: zeroAddress,
       tokenAmount: 0n,
     });
-  });
-
-  afterEach(() => {
-    sinon.restore();
   });
 
   describe("IP Metadata Functions", () => {
@@ -237,12 +222,12 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.register", async () => {
+  describe("Test ipAssetClient.register", () => {
     it("should return ipId when register given tokenId have registered", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
 
       const res = await ipAssetClient.register({
         nftContract: spgNftContract,
@@ -250,14 +235,14 @@ describe("Test IpAssetClient", () => {
       });
 
       expect(res.ipId).equal("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      expect(res.txHash).to.be.undefined;
+      expect(res.txHash).to.equal(undefined);
     });
 
     it("should throw invalid address error when register given deadline is string", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
       try {
         await ipAssetClient.register({
@@ -275,17 +260,19 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw account error when register given wallet have no signTypedData ", async () => {
-      const walletMock = createMock<WalletClient>();
-      walletMock.account = createMock<Account>();
-      ipAssetClient = new IPAssetClient(rpcMock, walletMock, 1315);
-      (ipAssetClient.registrationWorkflowsClient as any).address =
+      const newWalletMock = createMockWalletClient();
+      const walletWithOptionalMethods = newWalletMock as Partial<typeof newWalletMock>;
+      delete walletWithOptionalMethods.signTypedData;
+      ipAssetClient = new IPAssetClient(rpcMock, newWalletMock, 1315);
+      (ipAssetClient.registrationWorkflowsClient as { address: Address }).address =
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-      (ipAssetClient.coreMetadataModuleClient as any).address =
+      (ipAssetClient.coreMetadataModuleClient as { address: Address }).address =
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await ipAssetClient.register({
           nftContract: spgNftContract,
@@ -303,12 +290,12 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when register given tokenId have no registered", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "register").resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "register").resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -328,12 +315,12 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return ipId and txHash when register a IP and tokenId is not registered ", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "register").resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "register").resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
           chainId: 0n,
@@ -355,12 +342,12 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return ipId and txHash when register a IP given correct args and metadata", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon.stub(ipAssetClient.registrationWorkflowsClient, "registerIp").resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.registrationWorkflowsClient, "registerIp").resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
           chainId: 0n,
@@ -385,47 +372,12 @@ describe("Test IpAssetClient", () => {
       expect(response.ipId).equals("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
     });
 
-    it("should return encoded tx data when register a IP given correct args, encodedTxDataOnly is true and metadata", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(ipAssetClient.registrationWorkflowsClient, "registerIp")
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
-        {
-          ipId: "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
-          chainId: 0n,
-          tokenContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          tokenId: 0n,
-          name: "",
-          uri: "",
-          registrationDate: 0n,
-        },
-      ]);
-      const response = await ipAssetClient.register({
-        nftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-        tokenId: "3",
-        ipMetadata: {
-          ipMetadataURI: "",
-          ipMetadataHash: zeroHash,
-          nftMetadataHash: zeroHash,
-        },
-        txOptions: {
-          encodedTxDataOnly: true,
-        },
-      });
-
-      expect(response.encodedTxData!.data).to.be.a("string").and.not.empty;
-    });
-
     it("should throw error when request fails", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "register").throws(new Error("revert error"));
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "register").throws(new Error("revert error"));
       try {
         await ipAssetClient.register({
           nftContract: spgNftContract,
@@ -437,14 +389,15 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when register a IP given correct args, encodedTxDataOnly is true and metadata", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(ipAssetClient.registrationWorkflowsClient, "registerIp")
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(ipAssetClient.registrationWorkflowsClient, "registerIp").resolves(
+        "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
           chainId: 0n,
@@ -463,13 +416,13 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(response.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(response.encodedTxData!.data).to.be.a("string");
     });
   });
 
-  describe("Test ipAssetClient.registerDerivative", async () => {
+  describe("Test ipAssetClient.registerDerivative", () => {
     it("should throw childIpId error when registerDerivative given childIpId is not registered", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await ipAssetClient.registerDerivative({
           childIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -487,8 +440,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw parentIpId error when registerDerivative given parentIpId is not registered", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
@@ -512,13 +464,12 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw not match error when registerDerivative given parentIds'length is not equal licenseTermsIds'length", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
       try {
@@ -538,7 +489,7 @@ describe("Test IpAssetClient", () => {
     });
     it("should throw maxMintingFee error when registerDerivative given maxMintingFee is less than 0", async () => {
       try {
-        sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+        stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
         await ipAssetClient.registerDerivative({
           childIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           parentIpIds: ["0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4"],
@@ -554,7 +505,7 @@ describe("Test IpAssetClient", () => {
       }
     });
     it(`should throw maxRts error when registerDerivative given maxRts is greater than ${MAX_ROYALTY_TOKEN}`, async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       try {
         await ipAssetClient.registerDerivative({
           childIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -571,18 +522,17 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw maxRevenueShare error when registerDerivative given maxRevenueShare is less than royalty percent", async () => {
-      sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
+      stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
         royaltyPercent: 100000000,
       });
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
       try {
         await ipAssetClient.registerDerivative({
           childIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -599,17 +549,15 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw not attach error when registerDerivative given licenseTermsIds is not attached parentIpIds", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon
-        .stub(LicenseRegistryReadOnlyClient.prototype, "hasIpAttachedLicenseTerms")
-        .resolves(false);
 
-      sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
+      stub(LicenseRegistryReadOnlyClient.prototype, "hasIpAttachedLicenseTerms").resolves(false);
+
+      stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
 
@@ -630,22 +578,20 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when registerDerivative given correct childIpId, parentIpId, licenseTermsIds", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.licensingModuleClient, "registerDerivative").resolves(txHash);
-      sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.licensingModuleClient, "registerDerivative").resolves(txHash);
+      stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
       // Because registerDerivative doesn't call trigger IPRegistered event, but the `handleRegistrationWithFees`
       // will call it, so we need to mock the result of parseTxIpRegisteredEvent to avoid the error.
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([]);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([]);
 
       const res = await ipAssetClient.registerDerivative({
         childIpId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -661,19 +607,18 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when registerDerivative given correct childIpId, parentIpId, licenseTermsIds and encodedTxDataOnly of true ", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon
-        .stub(ipAssetClient.licensingModuleClient, "registerDerivative")
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+
+      stub(ipAssetClient.licensingModuleClient, "registerDerivative").resolves(
+        "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
+      );
+      stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
 
@@ -690,26 +635,25 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(res.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData!.data).to.be.a("string");
     });
 
     it("should call with default values of maxMintingFee, maxRts, maxRevenueShare when registerDerivative given maxMintingFee, maxRts, maxRevenueShare is not provided", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      const registerDerivativeStub = sinon
-        .stub(ipAssetClient.licensingModuleClient, "registerDerivative")
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      const registerDerivativeStub = stub(
+        ipAssetClient.licensingModuleClient,
+        "registerDerivative",
+      ).resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+      stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -733,7 +677,7 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.registerDerivativeWithLicenseTokens", async () => {
+  describe("Test ipAssetClient.registerDerivativeWithLicenseTokens", () => {
     it("should throw maxRts error when registerDerivativeWithLicenseTokens given maxRts is not number", async () => {
       try {
         await ipAssetClient.registerDerivativeWithLicenseTokens({
@@ -748,7 +692,7 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw childIpId error when registerDerivativeWithLicenseTokens given childIpId is not registered", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
       try {
         await ipAssetClient.registerDerivativeWithLicenseTokens({
@@ -791,8 +735,7 @@ describe("Test IpAssetClient", () => {
     });
     it("should throw licenseTokenIds error when registerDerivativeWithLicenseTokens given licenseTokenIds is empty", async () => {
       try {
-        sinon
-          .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+        stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
           .onCall(0)
           .resolves(true)
           .onCall(1)
@@ -809,13 +752,12 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw own error when registerDerivativeWithLicenseTokens given licenseTokenIds is not belongs caller", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon.stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(undefined);
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(undefined);
 
       try {
         await ipAssetClient.registerDerivativeWithLicenseTokens({
@@ -831,18 +773,19 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when registerDerivativeWithLicenseTokens given correct args", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon
-        .stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens")
-        .resolves(txHash);
+
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+
+      stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens").resolves(
+        txHash,
+      );
 
       const res = await ipAssetClient.registerDerivativeWithLicenseTokens({
         childIpId: "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
@@ -854,18 +797,19 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when registerDerivativeWithLicenseTokens given correct args", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon
-        .stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens")
-        .resolves(txHash);
+
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+
+      stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens").resolves(
+        txHash,
+      );
 
       const res = await ipAssetClient.registerDerivativeWithLicenseTokens({
         childIpId: "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
@@ -877,18 +821,19 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when registerDerivativeWithLicenseTokens given correct args and encodedTxDataOnly of true", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onCall(0)
         .resolves(true)
         .onCall(1)
         .resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon
-        .stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens")
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+
+      stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens").resolves(
+        "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
+      );
 
       const res = await ipAssetClient.registerDerivativeWithLicenseTokens({
         childIpId: "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
@@ -899,13 +844,13 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(res.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData!.data).to.be.a("string");
     });
   });
 
-  describe("Test ipAssetClient.createIpAssetWithPilTerms", async () => {
+  describe("Test ipAssetClient.createIpAssetWithPilTerms", () => {
     it("should throw address error when createIpAssetWithPilTerms given spgNftContract is wrong address", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
       try {
         await ipAssetClient.mintAndRegisterIpAssetWithPilTerms({
@@ -926,13 +871,14 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when createIpAssetWithPilTerms given correct args", async () => {
-      sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "mintAndRegisterIpAndAttachPilTerms")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(
+        ipAssetClient.licenseAttachmentWorkflowsClient,
+        "mintAndRegisterIpAndAttachPilTerms",
+      ).resolves(txHash);
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -963,10 +909,11 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return ipId, tokenId, licenseTermsId,txHash when createIpAssetWithPilTerms given correct args", async () => {
-      sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "mintAndRegisterIpAndAttachPilTerms")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(
+        ipAssetClient.licenseAttachmentWorkflowsClient,
+        "mintAndRegisterIpAndAttachPilTerms",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -977,9 +924,10 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 5n });
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 5n,
+      });
       const result = await ipAssetClient.mintAndRegisterIpAssetWithPilTerms({
         spgNftContract,
         licenseTermsData: [
@@ -1001,10 +949,11 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return ipId, tokenId, licenseTermsId,txHash when createIpAssetWithPilTerms given correct args with default license terms id", async () => {
-      sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "mintAndRegisterIpAndAttachPilTerms")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(
+        ipAssetClient.licenseAttachmentWorkflowsClient,
+        "mintAndRegisterIpAndAttachPilTerms",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1015,9 +964,10 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 5n });
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 5n,
+      });
       const result = await ipAssetClient.mintAndRegisterIpAssetWithPilTerms({
         spgNftContract,
         licenseTermsData: [
@@ -1057,14 +1007,15 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData!.data).to.be.a("string");
     });
 
     it("should call with default values when createIpAssetWithPilTerms without providing allowDuplicates, ipMetadata, recipient", async () => {
-      const mintAndRegisterIpAndAttachPilTermsStub = sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "mintAndRegisterIpAndAttachPilTerms")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      const mintAndRegisterIpAndAttachPilTermsStub = stub(
+        ipAssetClient.licenseAttachmentWorkflowsClient,
+        "mintAndRegisterIpAndAttachPilTerms",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1095,12 +1046,12 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.registerDerivativeIp", async () => {
+  describe("Test ipAssetClient.registerDerivativeIp", () => {
     it("should throw ipId have registered error when registerDerivativeIp given tokenId have registered", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
 
       try {
         await ipAssetClient.registerDerivativeIp({
@@ -1116,18 +1067,17 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw not attach error when registerDerivativeIp given licenseTermsIds is not attached parentIpIds", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(IpAssetRegistryClient.prototype, "isRegistered")
         .onFirstCall()
         .resolves(false)
         .onSecondCall()
         .resolves(true);
-      sinon
-        .stub(LicenseRegistryReadOnlyClient.prototype, "hasIpAttachedLicenseTerms")
-        .resolves(false);
+
+      stub(LicenseRegistryReadOnlyClient.prototype, "hasIpAttachedLicenseTerms").resolves(false);
 
       try {
         await ipAssetClient.registerDerivativeIp({
@@ -1142,25 +1092,23 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should return txHash and ipId when registerDerivativeIp given correct args ", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onFirstCall()
         .resolves(false)
         .onSecondCall()
         .resolves(true);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon
-        .stub(ipAssetClient.derivativeWorkflowsClient, "registerIpAndMakeDerivative")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+
+      stub(ipAssetClient.derivativeWorkflowsClient, "registerIpAndMakeDerivative").resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1187,25 +1135,25 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when registerDerivativeIp given correct args and encodedTxDataOnly of true", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onFirstCall()
         .resolves(false)
         .onSecondCall()
         .resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon
-        .stub(ipAssetClient.derivativeWorkflowsClient, "registerIpAndMakeDerivative")
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+
+      stub(ipAssetClient.derivativeWorkflowsClient, "registerIpAndMakeDerivative").resolves(
+        "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1230,16 +1178,16 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(res.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData!.data).to.be.a("string");
     });
   });
 
-  describe("Test ipAssetClient.registerIpAndAttachPilTerms", async () => {
+  describe("Test ipAssetClient.registerIpAndAttachPilTerms", () => {
     it("should throw ipId have registered error when registerIpAndAttachPilTerms given tokenId have registered", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
 
       try {
         await ipAssetClient.registerIpAndAttachPilTerms({
@@ -1265,18 +1213,19 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash and ipId when registerIpAndAttachPilTerms given correct args ", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
-      sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerIpAndAttachPilTerms")
-        .resolves(txHash);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 5n });
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerIpAndAttachPilTerms").resolves(
+        txHash,
+      );
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 5n,
+      });
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1307,16 +1256,18 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when registerIpAndAttachPilTerms given correct args and encodedTxDataOnly of true", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 5n });
-      sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerIpAndAttachPilTerms")
-        .resolves(txHash);
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 5n,
+      });
+
+      stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerIpAndAttachPilTerms").resolves(
+        txHash,
+      );
       const nftContract = generateRandomAddress();
       const result = await ipAssetClient.registerIpAndAttachPilTerms({
         nftContract,
@@ -1335,24 +1286,23 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData!.data).to.be.a("string");
     });
   });
 
-  describe("Test ipAssetClient.mintAndRegisterIpAndMakeDerivative", async () => {
+  describe("Test ipAssetClient.mintAndRegisterIpAndMakeDerivative", () => {
     it("should throw not attach error when call mintAndRegisterIpAndMakeDerivative given licenseTermsIds is not attached parentIpIds", async () => {
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "isRegistered")
+      stub(ipAssetClient.ipAssetRegistryClient, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(IpAssetRegistryClient.prototype, "isRegistered")
         .onFirstCall()
         .resolves(true)
         .onSecondCall()
         .resolves(false);
-      sinon
-        .stub(LicenseRegistryReadOnlyClient.prototype, "hasIpAttachedLicenseTerms")
-        .resolves(false);
+
+      stub(LicenseRegistryReadOnlyClient.prototype, "hasIpAttachedLicenseTerms").resolves(false);
 
       try {
         await ipAssetClient.mintAndRegisterIpAndMakeDerivative({
@@ -1368,25 +1318,25 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash and ipId when call mintAndRegisterIpAndMakeDerivative given correct args ", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onFirstCall()
         .resolves(true)
         .onSecondCall()
         .resolves(false);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon
-        .stub(ipAssetClient.derivativeWorkflowsClient, "mintAndRegisterIpAndMakeDerivative")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+
+      stub(ipAssetClient.derivativeWorkflowsClient, "mintAndRegisterIpAndMakeDerivative").resolves(
+        txHash,
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1414,25 +1364,25 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when call mintAndRegisterIpAndMakeDerivative given correct args and encodedTxDataOnly of true", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onFirstCall()
         .resolves(true)
         .onSecondCall()
         .resolves(false);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon
-        .stub(ipAssetClient.derivativeWorkflowsClient, "mintAndRegisterIpAndMakeDerivative")
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+
+      stub(ipAssetClient.derivativeWorkflowsClient, "mintAndRegisterIpAndMakeDerivative").resolves(
+        "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1456,26 +1406,25 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(res.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData!.data).to.be.a("string");
     });
 
     it("should call with default values when mintAndRegisterIpAndMakeDerivative without providing allowDuplicates, ipMetadata", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onFirstCall()
         .resolves(true)
         .onSecondCall()
         .resolves(false);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1487,9 +1436,10 @@ describe("Test IpAssetClient", () => {
         },
       ]);
 
-      const mintAndRegisterIpAndMakeDerivativeStub = sinon
-        .stub(ipAssetClient.derivativeWorkflowsClient, "mintAndRegisterIpAndMakeDerivative")
-        .resolves(txHash);
+      const mintAndRegisterIpAndMakeDerivativeStub = stub(
+        ipAssetClient.derivativeWorkflowsClient,
+        "mintAndRegisterIpAndMakeDerivative",
+      ).resolves(txHash);
 
       await ipAssetClient.mintAndRegisterIpAndMakeDerivative({
         spgNftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -1506,7 +1456,7 @@ describe("Test IpAssetClient", () => {
       expect(mintAndRegisterIpAndMakeDerivativeStub.args[0][0].recipient).to.equal(walletAddress);
     });
   });
-  describe("Test ipAssetClient.mintAndRegisterIp", async () => {
+  describe("Test ipAssetClient.mintAndRegisterIp", () => {
     it("should throw spgNftContract error when mintAndRegisterIp given spgNftContract is wrong address", async () => {
       try {
         await ipAssetClient.mintAndRegisterIp({
@@ -1543,8 +1493,8 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return ipId,txHash when mintAndRegisterIp given correct args ", async () => {
-      sinon.stub(ipAssetClient.registrationWorkflowsClient, "mintAndRegisterIp").resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.registrationWorkflowsClient, "mintAndRegisterIp").resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1570,7 +1520,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when mintAndRegisterIp given correct args and encodedTxDataOnly of true", async () => {
-      sinon.stub(ipAssetClient.registrationWorkflowsClient, "mintAndRegisterIp").resolves(txHash);
+      stub(ipAssetClient.registrationWorkflowsClient, "mintAndRegisterIp").resolves(txHash);
 
       const result = await ipAssetClient.mintAndRegisterIp({
         spgNftContract,
@@ -1584,14 +1534,15 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData!.data).to.be.a("string");
     });
 
     it("should call with default values when mintAndRegisterIp without providing allowDuplicates, ipMetadata, recipient", async () => {
-      const mintAndRegisterIpStub = sinon
-        .stub(ipAssetClient.registrationWorkflowsClient, "mintAndRegisterIp")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      const mintAndRegisterIpStub = stub(
+        ipAssetClient.registrationWorkflowsClient,
+        "mintAndRegisterIp",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1617,7 +1568,7 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.registerPilTermsAndAttach", async () => {
+  describe("Test ipAssetClient.registerPilTermsAndAttach", () => {
     it("should throw ipId error when registerPilTermsAndAttach given ipId is wrong address", async () => {
       try {
         await ipAssetClient.registerPilTermsAndAttach({
@@ -1637,7 +1588,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw ipId have not registered error when registerPilTermsAndAttach given ipId have not registered", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
       try {
         await ipAssetClient.registerPilTermsAndAttach({
@@ -1657,10 +1608,11 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when registerPilTermsAndAttach given correct args and encodedTxDataOnly of true", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 0n });
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 0n,
+      });
 
       const result = await ipAssetClient.registerPilTermsAndAttach({
         ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -1675,17 +1627,18 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData!.data).to.be.a("string");
     });
 
     it("should return txHash when registerPilTermsAndAttach given correct args ", async () => {
-      sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerPilTermsAndAttach")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 0n });
+      stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerPilTermsAndAttach").resolves(
+        txHash,
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 0n,
+      });
       const result = await ipAssetClient.registerPilTermsAndAttach({
         ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         licenseTermsData: [
@@ -1705,10 +1658,10 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when registerPilTermsAndAttach given correct args ", async () => {
-      sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerPilTermsAndAttach")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerPilTermsAndAttach").resolves(
+        txHash,
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       const result = await ipAssetClient.registerPilTermsAndAttach({
         ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         licenseTermsData: [
@@ -1722,10 +1675,11 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should call with default values of licensingConfig when registerPilTermsAndAttach given licensingConfig is not provided", async () => {
-      const registerPilTermsAndAttachStub = sinon
-        .stub(ipAssetClient.licenseAttachmentWorkflowsClient, "registerPilTermsAndAttach")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      const registerPilTermsAndAttachStub = stub(
+        ipAssetClient.licenseAttachmentWorkflowsClient,
+        "registerPilTermsAndAttach",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
 
       await ipAssetClient.registerPilTermsAndAttach({
         ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -1750,7 +1704,7 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens", async () => {
+  describe("Test ipAssetClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens", () => {
     it("should throw licenseTokens error when mintAndRegisterIpAndMakeDerivativeWithLicenseTokens given licenseTokens empty", async () => {
       try {
         await ipAssetClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
@@ -1767,7 +1721,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw licenseTokens is not owned by caller error when mintAndRegisterIpAndMakeDerivativeWithLicenseTokens given wrong licenseTokens", async () => {
-      sinon.stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(undefined);
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(undefined);
 
       try {
         await ipAssetClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
@@ -1783,16 +1737,15 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should return txHash when mintAndRegisterIpAndMakeDerivativeWithLicenseTokens given correct args", async () => {
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon
-        .stub(
-          ipAssetClient.derivativeWorkflowsClient,
-          "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
-        )
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+
+      stub(
+        ipAssetClient.derivativeWorkflowsClient,
+        "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
+      ).resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 1513n,
@@ -1823,16 +1776,15 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash and ipId when mintAndRegisterIpAndMakeDerivativeWithLicenseTokens given correct args ", async () => {
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon
-        .stub(
-          ipAssetClient.derivativeWorkflowsClient,
-          "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
-        )
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+
+      stub(
+        ipAssetClient.derivativeWorkflowsClient,
+        "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1857,15 +1809,14 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when mintAndRegisterIpAndMakeDerivativeWithLicenseTokens given correct args and encodedTxDataOnly of true", async () => {
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon
-        .stub(
-          ipAssetClient.derivativeWorkflowsClient,
-          "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
-        )
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+
+      stub(
+        ipAssetClient.derivativeWorkflowsClient,
+        "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
+      ).resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
 
       const result = await ipAssetClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
         maxRts: 0,
@@ -1883,20 +1834,18 @@ describe("Test IpAssetClient", () => {
         },
       });
 
-      expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData!.data).to.be.a("string");
     });
 
     it("should call with default values when mintAndRegisterIpAndMakeDerivativeWithLicenseTokens without providing allowDuplicates, ipMetadata, royaltyContext, recipient", async () => {
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      const mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub = sinon
-        .stub(
-          ipAssetClient.derivativeWorkflowsClient,
-          "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
-        )
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+      const mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub = stub(
+        ipAssetClient.derivativeWorkflowsClient,
+        "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -1933,14 +1882,14 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.registerIpAndMakeDerivativeWithLicenseTokens", async () => {
+  describe("Test ipAssetClient.registerIpAndMakeDerivativeWithLicenseTokens", () => {
     beforeEach(() => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
     });
     it("should throw tokenId error when registerIpAndMakeDerivativeWithLicenseTokens given tokenId is registered", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
 
       try {
         await ipAssetClient.registerIpAndMakeDerivativeWithLicenseTokens({
@@ -1957,8 +1906,8 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw licenseTokens error when registerIpAndMakeDerivativeWithLicenseTokens given licenseTokens is not owner of caller", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon.stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(undefined);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(undefined);
 
       try {
         await ipAssetClient.registerIpAndMakeDerivativeWithLicenseTokens({
@@ -1974,17 +1923,17 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should return txHash and ipId when registerIpAndMakeDerivativeWithLicenseTokens given correct args ", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon
-        .stub(
-          ipAssetClient.derivativeWorkflowsClient,
-          "registerIpAndMakeDerivativeWithLicenseTokens",
-        )
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+
+      stub(
+        ipAssetClient.derivativeWorkflowsClient,
+        "registerIpAndMakeDerivativeWithLicenseTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -2006,16 +1955,16 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return encoded tx data when registerIpAndMakeDerivativeWithLicenseTokens given correct args and encodedTxDataOnly of true", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon
-        .stub(
-          ipAssetClient.derivativeWorkflowsClient,
-          "registerIpAndMakeDerivativeWithLicenseTokens",
-        )
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(ipAssetClient.licenseTokenReadOnlyClient, "ownerOf").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+
+      stub(
+        ipAssetClient.derivativeWorkflowsClient,
+        "registerIpAndMakeDerivativeWithLicenseTokens",
+      ).resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
       const result = await ipAssetClient.registerIpAndMakeDerivativeWithLicenseTokens({
         nftContract: spgNftContract,
         tokenId: "3",
@@ -2031,11 +1980,11 @@ describe("Test IpAssetClient", () => {
           encodedTxDataOnly: true,
         },
       });
-      expect(result.encodedTxData!.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData!.data).to.be.a("string");
     });
   });
 
-  describe("Test ipAssetClient.batchMintAndRegisterIpAssetWithPilTerms", async () => {
+  describe("Test ipAssetClient.batchMintAndRegisterIpAssetWithPilTerms", () => {
     it("should throw spgNftContract error when batchMintAndRegisterIpAssetWithPilTerms given spgNftContract is wrong address", async () => {
       try {
         await ipAssetClient.batchMintAndRegisterIpAssetWithPilTerms({
@@ -2064,8 +2013,8 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash and ipId when batchMintAndRegisterIpAssetWithPilTerms given correct args ", async () => {
-      sinon.stub(ipAssetClient.licenseAttachmentWorkflowsClient, "multicall").resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.licenseAttachmentWorkflowsClient, "multicall").resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -2085,9 +2034,10 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 5n });
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 5n,
+      });
       const result = await ipAssetClient.batchMintAndRegisterIpAssetWithPilTerms({
         args: [
           {
@@ -2141,12 +2091,10 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.batchMintAndRegisterIpAndMakeDerivative", async () => {
+  describe("Test ipAssetClient.batchMintAndRegisterIpAndMakeDerivative", () => {
     it("should throw ipId and licenseTerms error when batchMintAndRegisterIpAndMakeDerivative given ipId and licenseTerms is not match", async () => {
-      sinon
-        .stub(LicenseRegistryReadOnlyClient.prototype, "hasIpAttachedLicenseTerms")
-        .resolves(false);
-      sinon.stub(IpAssetRegistryClient.prototype, "isRegistered").resolves(true);
+      stub(LicenseRegistryReadOnlyClient.prototype, "hasIpAttachedLicenseTerms").resolves(false);
+      stub(IpAssetRegistryClient.prototype, "isRegistered").resolves(true);
       try {
         await ipAssetClient.batchMintAndRegisterIpAndMakeDerivative({
           args: [
@@ -2170,15 +2118,14 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash and ipId when batchMintAndRegisterIpAndMakeDerivative given correct args ", async () => {
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(ipAssetClient.derivativeWorkflowsClient, "mintAndRegisterIpAndMakeDerivative")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.derivativeWorkflowsClient, "multicall").resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(ipAssetClient.derivativeWorkflowsClient, "mintAndRegisterIpAndMakeDerivative").resolves(
+        txHash,
+      );
+      stub(ipAssetClient.derivativeWorkflowsClient, "multicall").resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -2198,7 +2145,7 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
       const result = await ipAssetClient.batchMintAndRegisterIpAndMakeDerivative({
@@ -2242,7 +2189,7 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.batchRegister", async () => {
+  describe("Test ipAssetClient.batchRegister", () => {
     it("should throw error when call batchRegister given args have wrong nftContract", async () => {
       try {
         await ipAssetClient.batchRegister({
@@ -2259,16 +2206,16 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txhash and ipId when call batchRegister given correct args ", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon.stub(ipAssetClient.registrationWorkflowsClient, "registerIpEncode").returns({
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.registrationWorkflowsClient, "registerIpEncode").returns({
         data: "0x",
         to: "0x",
       });
-      sinon.stub(ipAssetClient.multicall3Client, "aggregate3").resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.multicall3Client, "aggregate3").resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -2288,7 +2235,7 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon.stub(ipAssetClient.registrationWorkflowsClient, "multicall").resolves(txHash);
+      stub(ipAssetClient.registrationWorkflowsClient, "multicall").resolves(txHash);
       const result = await ipAssetClient.batchRegister({
         args: [
           {
@@ -2313,7 +2260,7 @@ describe("Test IpAssetClient", () => {
       expect(result.results?.length).to.equal(4);
     });
   });
-  describe("Test ipAssetClient.batchRegisterDerivative", async () => {
+  describe("Test ipAssetClient.batchRegisterDerivative", () => {
     it("should throw childIpId error when call batchRegisterDerivative given childIpId is wrong address", async () => {
       try {
         await ipAssetClient.batchRegisterDerivative({
@@ -2336,16 +2283,15 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return results when call batchRegisterDerivative given correct args", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.licensingModuleClient, "registerDerivativeEncode").returns({
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.licensingModuleClient, "registerDerivativeEncode").returns({
         data: "0x",
         to: "0x",
       });
-      sinon.stub(ipAssetClient.multicall3Client, "aggregate3").resolves(txHash);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.multicall3Client, "aggregate3").resolves(txHash);
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
       const result = await ipAssetClient.batchRegisterDerivative({
@@ -2365,18 +2311,17 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return results when call batchRegisterDerivative given correct args ", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.licensingModuleClient, "registerDerivativeEncode").returns({
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.licensingModuleClient, "registerDerivativeEncode").returns({
         data: "0x",
         to: "0x",
       });
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon.stub(ipAssetClient.multicall3Client, "aggregate3").resolves(txHash);
+      stub(ipAssetClient.multicall3Client, "aggregate3").resolves(txHash);
       const result = await ipAssetClient.batchRegisterDerivative({
         args: [
           {
@@ -2394,33 +2339,33 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.isRegistered", async () => {
+  describe("Test ipAssetClient.isRegistered", () => {
     beforeEach(() => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
     });
     it("should return true if IP asset is registered", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-
-      expect(await ipAssetClient.isRegistered("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c")).to.be
-        .true;
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      const result = await ipAssetClient.isRegistered("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
+      expect(result).to.equal(true);
     });
 
     it("should return false if IP asset is not registered", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
-      expect(await ipAssetClient.isRegistered("0x2BCAE3197Bc469Cb97B917aa460a12dD95c6538D")).to.be
-        .false;
+      const result = await ipAssetClient.isRegistered("0x2BCAE3197Bc469Cb97B917aa460a12dD95c6538D");
+      expect(result).to.equal(false);
     });
   });
 
-  describe("Test ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens", async () => {
+  describe("Test ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens", () => {
     it("should throw ipId registered error when registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens given ipId is registered", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
       try {
         await ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2446,7 +2391,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw percentage error when registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens given percentage is less 0", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       try {
         await ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2469,7 +2414,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw percentage error when registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens given percentage is greater 100", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       try {
         await ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2491,7 +2436,7 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw royaltyPolicy and mintFee match error when registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens given royaltyPolicy is zero address and mint fee is more than zero", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       try {
         await ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2519,7 +2464,7 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw percentage error when registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens given total percentage is greater 100", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
 
       try {
         await ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens({
@@ -2543,32 +2488,34 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should return txHash when registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens given correct args", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "registerIpAndAttachPilTermsAndDeployRoyaltyVault",
-        )
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 8n });
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-            ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          },
-        ]);
-      sinon
-        .stub(ipAssetClient.royaltyTokenDistributionWorkflowsClient, "distributeRoyaltyTokens")
-        .resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "registerIpAndAttachPilTermsAndDeployRoyaltyVault",
+      ).resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 8n,
+      });
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "distributeRoyaltyTokens",
+      ).resolves(txHash);
+
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -2603,18 +2550,18 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw error when registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens given IpAccount balance is not enough", async () => {
-      IpRoyaltyVaultImplReadOnlyClient.prototype.balanceOf = sinon.stub().resolves(100);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "registerIpAndAttachPilTermsAndDeployRoyaltyVault",
-        )
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      IpRoyaltyVaultImplReadOnlyClient.prototype.balanceOf = stub().resolves(100);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "registerIpAndAttachPilTermsAndDeployRoyaltyVault",
+      ).resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -2625,20 +2572,22 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 8n });
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-            ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          },
-        ]);
-      sinon
-        .stub(ipAssetClient.royaltyTokenDistributionWorkflowsClient, "distributeRoyaltyTokens")
-        .resolves(txHash);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 8n,
+      });
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "distributeRoyaltyTokens",
+      ).resolves(txHash);
       try {
         await ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2660,17 +2609,17 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should return txHash when registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens given correct args  ", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "registerIpAndAttachPilTermsAndDeployRoyaltyVault",
-        )
-        .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "registerIpAndAttachPilTermsAndDeployRoyaltyVault",
+      ).resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -2681,20 +2630,22 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 8n });
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-            ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          },
-        ]);
-      sinon
-        .stub(ipAssetClient.royaltyTokenDistributionWorkflowsClient, "distributeRoyaltyTokens")
-        .resolves(txHash);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 8n,
+      });
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "distributeRoyaltyTokens",
+      ).resolves(txHash);
 
       const result = await ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens({
         nftContract: spgNftContract,
@@ -2730,16 +2681,16 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens", async () => {
+  describe("Test ipAssetClient.registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens", () => {
     it("should throw ipId registered error when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given ipId is registered", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
       try {
@@ -2764,13 +2715,13 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw maxRts error when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given maxRts is less than 0", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await ipAssetClient.registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2793,13 +2744,13 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw maxRts error when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given maxRts is greater than 100000000", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await ipAssetClient.registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2822,13 +2773,13 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw maxMintingFee error when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given maxMintingFee is less than 0", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await ipAssetClient.registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2851,13 +2802,15 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw parentIpIds and licenseTermsIds not match error when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given parentIpIds and licenseTermsIds not match", async () => {
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent")
-        .resolves({ royaltyPercent: 100 });
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+        royaltyPercent: 100,
+      });
       try {
         await ipAssetClient.registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2884,10 +2837,11 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw parentIpId not registered error when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given parentIpId not registered", async () => {
-      sinon.stub(IpAssetRegistryClient.prototype, "isRegistered").resolves(false);
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
+      stub(IpAssetRegistryClient.prototype, "isRegistered").resolves(false);
+
+      stub(ipAssetClient.ipAssetRegistryClient, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
       try {
         await ipAssetClient.registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2910,21 +2864,20 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw maxRevenueShare error when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given maxRevenueShare is less than royaltyPercent", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon.stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
         royaltyPercent: 1000000000,
       });
-      sinon
-        .stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
+
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered")
         .onFirstCall()
         .resolves(true)
         .onSecondCall()
         .resolves(false);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
       try {
         await ipAssetClient.registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens({
           nftContract: spgNftContract,
@@ -2948,39 +2901,39 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should return txHash when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given correct args", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "isRegistered")
         .onFirstCall()
         .resolves(true)
         .onSecondCall()
         .resolves(false);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "registerIpAndMakeDerivativeAndDeployRoyaltyVault",
-        )
-        .resolves(txHash);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 8n });
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-            ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          },
-        ]);
-      sinon
-        .stub(ipAssetClient.royaltyTokenDistributionWorkflowsClient, "distributeRoyaltyTokens")
-        .resolves(txHash);
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "registerIpAndMakeDerivativeAndDeployRoyaltyVault",
+      ).resolves(txHash);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 8n,
+      });
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "distributeRoyaltyTokens",
+      ).resolves(txHash);
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -2991,7 +2944,7 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
       const result =
@@ -3019,42 +2972,42 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given correct args with waitForTransaction of true", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "isRegistered")
+      stub(IpAssetRegistryClient.prototype, "isRegistered")
         .onFirstCall()
         .resolves(true)
         .onSecondCall()
         .resolves(false);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "ipId")
-        .resolves("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
-      sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "registerIpAndMakeDerivativeAndDeployRoyaltyVault",
-        )
-        .resolves(txHash);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 8n });
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-            ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          },
-        ]);
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "registerIpAndMakeDerivativeAndDeployRoyaltyVault",
+      ).resolves(txHash);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 8n,
+      });
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon
-        .stub(ipAssetClient.royaltyTokenDistributionWorkflowsClient, "distributeRoyaltyTokens")
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "distributeRoyaltyTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -3096,7 +3049,7 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens", async () => {
+  describe("Test ipAssetClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens", () => {
     it("should throw spgNftContract error when mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens given spgNftContract is not correct", async () => {
       try {
         await ipAssetClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens({
@@ -3119,14 +3072,11 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should return txHash when mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens given correct args", async () => {
-      const ipId = "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4";
-      sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens",
-        )
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId,
           chainId: 0n,
@@ -3137,17 +3087,17 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 5n });
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipId,
-            ipRoyaltyVault: zeroAddress,
-          },
-        ]);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 5n,
+      });
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipId,
+          ipRoyaltyVault: zeroAddress,
+        },
+      ]);
       const result =
         await ipAssetClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens({
           spgNftContract,
@@ -3174,13 +3124,11 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens given correct args ", async () => {
-      sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens",
-        )
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -3191,17 +3139,17 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-            ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          },
-        ]);
-      sinon
-        .stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId")
-        .resolves({ selectedLicenseTermsId: 5n });
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 5n,
+      });
       const result =
         await ipAssetClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens({
           spgNftContract,
@@ -3229,13 +3177,11 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should call with default values when mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens without providing allowDuplicates, ipMetadata, recipient", async () => {
-      const mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub = sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens",
-        )
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      const mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub = stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -3246,14 +3192,13 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-            ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          },
-        ]);
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
       await ipAssetClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens({
         spgNftContract,
         licenseTermsData: [
@@ -3284,9 +3229,9 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens", async () => {
+  describe("Test ipAssetClient.mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens", () => {
     it("should throw parent ip id error when mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens given parent ip id is empty", async () => {
-      sinon.stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
         terms: {
           ...licenseTerms,
           commercialUse: true,
@@ -3315,7 +3260,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw license terms id error when mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens given license terms id is empty", async () => {
-      sinon.stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
         terms: {
           ...licenseTerms,
           commercialUse: true,
@@ -3344,7 +3289,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should throw maxRevenueShare error when mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens given maxRevenueShare is greater than 100", async () => {
-      sinon.stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
         terms: {
           ...licenseTerms,
           commercialUse: true,
@@ -3372,7 +3317,7 @@ describe("Test IpAssetClient", () => {
       }
     });
     it("should throw maxRevenueShare error when mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens given maxRevenueShare is less than 0", async () => {
-      sinon.stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
         terms: {
           ...licenseTerms,
           commercialUse: true,
@@ -3401,23 +3346,21 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return txHash when mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens given correct args ", async () => {
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens",
-        )
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
         terms: licenseTerms,
       });
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -3428,14 +3371,13 @@ describe("Test IpAssetClient", () => {
           registrationDate: 0n,
         },
       ]);
-      sinon
-        .stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent")
-        .returns([
-          {
-            ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-            ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-          },
-        ]);
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
       const result =
         await ipAssetClient.mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens({
           spgNftContract,
@@ -3470,23 +3412,20 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should call with default values when mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens without providing allowDuplicates, ipMetadata, recipient", async () => {
-      sinon.stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
-      sinon
-        .stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms")
-        .resolves(true);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
+
+      stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTerms").resolves({
         terms: licenseTerms,
       });
-      const mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub = sinon
-        .stub(
-          ipAssetClient.royaltyTokenDistributionWorkflowsClient,
-          "mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens",
-        )
-        .resolves(txHash);
-      sinon.stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+      const mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub = stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           chainId: 0n,
@@ -3528,48 +3467,49 @@ describe("Test IpAssetClient", () => {
     });
   });
 
-  describe("Test ipAssetClient.batchRegisterIpAssetsWithOptimizedWorkflows", async () => {
+  describe("Test ipAssetClient.batchRegisterIpAssetsWithOptimizedWorkflows", () => {
     /**
      * We need to mock the entire module instead of individual methods because
      * the code needs to access the `address` property from workflow clients,
      * which is impossible to mock individually. This approach ensures all
      * required properties and methods are properly mocked for testing.
      */
-
+    //Need to mock the entire module instead of individual methods
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-require-imports
     const contractModules = require("../../../src/abi/generated");
-    let royaltyTokenDistributionWorkflowsMulticallStub: sinon.SinonStub;
-    let derivativeWorkflowsMulticallStub: sinon.SinonStub;
-    let licenseAttachmentWorkflowsMulticallStub: sinon.SinonStub;
-    let mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub: sinon.SinonStub;
-    let mintAndRegisterIpAndMakeDerivativeStub: sinon.SinonStub;
-    let registerIpAndMakeDerivativeStub: sinon.SinonStub;
-    let registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub: sinon.SinonStub;
-    let distributeRoyaltyTokensStub: sinon.SinonStub;
+    let royaltyTokenDistributionWorkflowsMulticallStub: SinonStub;
+    let derivativeWorkflowsMulticallStub: SinonStub;
+    let licenseAttachmentWorkflowsMulticallStub: SinonStub;
+    let mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub: SinonStub;
+    let mintAndRegisterIpAndMakeDerivativeStub: SinonStub;
+    let registerIpAndMakeDerivativeStub: SinonStub;
+    let registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub: SinonStub;
+    let distributeRoyaltyTokensStub: SinonStub;
 
     beforeEach(() => {
-      rpcMock.getBalance = sinon.stub().resolves(10n);
+      rpcMock.getBalance = stub().resolves(10n);
       // Mock deposit with WIP
-      rpcMock.simulateContract = sinon.stub().resolves({ request: {} });
-      walletMock.writeContract = sinon.stub().resolves(txHash);
-      sinon.stub(IpAssetRegistryClient.prototype, "ipId").resolves(ipId);
+      rpcMock.simulateContract = stub().resolves({ request: {} });
+      walletMock.writeContract = stub().resolves(txHash);
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(ipId);
       // RoyaltyTokenDistributionWorkflowsClient
-      mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub = sinon.stub(
+      mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensStub = stub(
         RoyaltyTokenDistributionWorkflowsClient.prototype,
         "mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens",
       );
-      royaltyTokenDistributionWorkflowsMulticallStub = sinon.stub(
+      royaltyTokenDistributionWorkflowsMulticallStub = stub(
         RoyaltyTokenDistributionWorkflowsClient.prototype,
         "multicall",
       );
-      registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub = sinon.stub(
+      registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub = stub(
         RoyaltyTokenDistributionWorkflowsClient.prototype,
         "registerIpAndMakeDerivativeAndDeployRoyaltyVault",
       );
-      distributeRoyaltyTokensStub = sinon.stub(
+      distributeRoyaltyTokensStub = stub(
         RoyaltyTokenDistributionWorkflowsClient.prototype,
         "distributeRoyaltyTokens",
       );
-      sinon.stub(contractModules, "RoyaltyTokenDistributionWorkflowsClient").returns({
+      stub(contractModules, "RoyaltyTokenDistributionWorkflowsClient").returns({
         multicall: royaltyTokenDistributionWorkflowsMulticallStub.resolves(txHash),
         address: mockAddress + 1,
         mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens:
@@ -3579,50 +3519,45 @@ describe("Test IpAssetClient", () => {
         distributeRoyaltyTokens: distributeRoyaltyTokensStub.resolves(txHash),
       });
       // DerivativeWorkflowsClient
-      registerIpAndMakeDerivativeStub = sinon.stub(
+      registerIpAndMakeDerivativeStub = stub(
         DerivativeWorkflowsClient.prototype,
         "registerIpAndMakeDerivative",
       );
-      mintAndRegisterIpAndMakeDerivativeStub = sinon.stub(
+      mintAndRegisterIpAndMakeDerivativeStub = stub(
         DerivativeWorkflowsClient.prototype,
         "mintAndRegisterIpAndMakeDerivative",
       );
-      derivativeWorkflowsMulticallStub = sinon.stub(
-        DerivativeWorkflowsClient.prototype,
-        "multicall",
-      );
-      sinon.stub(contractModules, "DerivativeWorkflowsClient").returns({
+      derivativeWorkflowsMulticallStub = stub(DerivativeWorkflowsClient.prototype, "multicall");
+      stub(contractModules, "DerivativeWorkflowsClient").returns({
         multicall: derivativeWorkflowsMulticallStub.resolves(txHash),
         address: mockAddress + 2,
         mintAndRegisterIpAndMakeDerivative: mintAndRegisterIpAndMakeDerivativeStub.resolves(txHash),
         registerIpAndMakeDerivative: registerIpAndMakeDerivativeStub.resolves(txHash),
       });
       // LicenseAttachmentWorkflowsClient
-      licenseAttachmentWorkflowsMulticallStub = sinon.stub(
+      licenseAttachmentWorkflowsMulticallStub = stub(
         LicenseAttachmentWorkflowsClient.prototype,
         "multicall",
       );
-      sinon.stub(contractModules, "LicenseAttachmentWorkflowsClient").returns({
+      stub(contractModules, "LicenseAttachmentWorkflowsClient").returns({
         multicall: licenseAttachmentWorkflowsMulticallStub.resolves(txHash),
         address: mockAddress + 3,
       });
 
       //RoyaltyModuleEventClient.parseTxIpRoyaltyVaultDeployedEvent
-      sinon.stub(RoyaltyModuleEventClient.prototype, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+      stub(RoyaltyModuleEventClient.prototype, "parseTxIpRoyaltyVaultDeployedEvent").returns([
         {
           ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
           ipId: ipId,
         },
       ]);
     });
-    afterEach(() => {
-      sinon.reset();
-    });
+    afterEach(() => {});
     it("should empty  given requests is empty", async () => {
       const result = await ipAssetClient.batchRegisterIpAssetsWithOptimizedWorkflows({
         requests: [],
       });
-      expect(result.distributeRoyaltyTokensTxHashes).to.undefined;
+      expect(result.distributeRoyaltyTokensTxHashes).to.equal(undefined);
       expect(result.registrationResults).to.deep.equal([]);
     });
 
@@ -3649,8 +3584,7 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should success given requests are the nft contracts", async () => {
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "parseTxIpRegisteredEvent")
+      stub(IpAssetRegistryClient.prototype, "parseTxIpRegisteredEvent")
         .onFirstCall()
         .returns([
           {
@@ -3903,14 +3837,19 @@ describe("Test IpAssetClient", () => {
         requests,
       });
       expect(royaltyTokenDistributionWorkflowsMulticallStub.callCount).to.equal(2); // nft contracts + distribute royalty tokens
-      expect(royaltyTokenDistributionWorkflowsMulticallStub.args[0][0].data.length).to.equal(4);
       expect(
-        royaltyTokenDistributionWorkflowsMulticallStub.secondCall.args[0].data.length,
+        (royaltyTokenDistributionWorkflowsMulticallStub.args[0][0] as { data: [] }).data.length,
+      ).to.equal(4);
+      expect(
+        (royaltyTokenDistributionWorkflowsMulticallStub.secondCall.args[0] as { data: [] }).data
+          .length,
       ).to.equal(4); // distribute royalty tokens
       expect(derivativeWorkflowsMulticallStub.callCount).to.equal(1);
-      expect(derivativeWorkflowsMulticallStub.args[0][0].data.length).to.equal(2);
+      expect((derivativeWorkflowsMulticallStub.args[0][0] as { data: [] }).data.length).to.equal(2);
       expect(licenseAttachmentWorkflowsMulticallStub.callCount).to.equal(1);
-      expect(licenseAttachmentWorkflowsMulticallStub.args[0][0].data.length).to.equal(1);
+      expect(
+        (licenseAttachmentWorkflowsMulticallStub.args[0][0] as { data: [] }).data.length,
+      ).to.equal(1);
       expect(result.distributeRoyaltyTokensTxHashes).to.deep.equal([txHash]);
       expect(result.registrationResults).to.deep.equal([
         {
@@ -3969,15 +3908,14 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return success given request are the spg contracts", async () => {
-      sinon
-        .stub(SpgnftImplReadOnlyClient.prototype, "publicMinting")
+      stub(SpgnftImplReadOnlyClient.prototype, "publicMinting")
         .onFirstCall()
-        .returns(false)
+        .resolves(false)
         .onSecondCall()
-        .returns(false)
-        .returns(true);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "parseTxIpRegisteredEvent")
+        .resolves(false)
+        .resolves(true);
+
+      stub(IpAssetRegistryClient.prototype, "parseTxIpRegisteredEvent")
         .onFirstCall()
         .returns([
           {
@@ -4186,7 +4124,7 @@ describe("Test IpAssetClient", () => {
       expect(licenseAttachmentWorkflowsMulticallStub.args.length).to.equal(1);
       expect(royaltyTokenDistributionWorkflowsMulticallStub.callCount).to.equal(1);
       expect(royaltyTokenDistributionWorkflowsMulticallStub.args.length).to.equal(1);
-      expect(result.distributeRoyaltyTokensTxHashes).to.undefined;
+      expect(result.distributeRoyaltyTokensTxHashes).to.equal(undefined);
       expect(result.registrationResults).to.deep.equal([
         {
           ipIdAndTokenId: [
@@ -4256,10 +4194,10 @@ describe("Test IpAssetClient", () => {
     });
 
     it("should return success given request are mixed of spg and non-spg contracts and disableMulticallWhenPossible is true", async () => {
-      sinon.stub(SpgnftImplReadOnlyClient.prototype, "publicMinting").returns(true);
-      sinon.stub(SpgnftImplReadOnlyClient.prototype, "mintFee").returns(10n);
-      sinon
-        .stub(IpAssetRegistryClient.prototype, "parseTxIpRegisteredEvent")
+      stub(SpgnftImplReadOnlyClient.prototype, "publicMinting").resolves(true);
+      stub(SpgnftImplReadOnlyClient.prototype, "mintFee").resolves(10n);
+
+      stub(IpAssetRegistryClient.prototype, "parseTxIpRegisteredEvent")
         .onFirstCall()
         .returns([
           {

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -3552,7 +3552,7 @@ describe("Test IpAssetClient", () => {
         },
       ]);
     });
-    afterEach(() => {});
+    
     it("should empty  given requests is empty", async () => {
       const result = await ipAssetClient.batchRegisterIpAssetsWithOptimizedWorkflows({
         requests: [],

--- a/packages/core-sdk/test/unit/resources/permission.test.ts
+++ b/packages/core-sdk/test/unit/resources/permission.test.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai";
-import { createMock } from "../testUtils";
-import * as sinon from "sinon";
+import { stub } from "sinon";
+import { PublicClient, WalletClient, zeroAddress } from "viem";
+
 import { PermissionClient } from "../../../src";
-import { PublicClient, WalletClient, LocalAccount, zeroAddress } from "viem";
+import { IpAccountImplClient } from "../../../src/abi/generated";
 import { AccessPermission } from "../../../src/types/resources/permission";
-const { IpAccountImplClient } = require("../../../src/abi/generated");
+import { createMockPublicClient, createMockWalletClient } from "../testUtils";
 
 describe("Test Permission", () => {
   let permissionClient: PermissionClient;
@@ -13,33 +14,25 @@ describe("Test Permission", () => {
   const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
 
   beforeEach(function () {
-    rpcMock = createMock<PublicClient>();
-    walletMock = createMock<WalletClient>();
-    const accountMock = createMock<LocalAccount>();
-    walletMock.account = accountMock;
-    walletMock.signTypedData = sinon
-      .stub()
-      .resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+    rpcMock = createMockPublicClient();
+    walletMock = createMockWalletClient();
     permissionClient = new PermissionClient(rpcMock, walletMock, 1315);
-    sinon
-      .stub(IpAccountImplClient.prototype, "state")
-      .resolves({ result: "0x2e778894d11b5308e4153f094e190496c1e0609652c19f8b87e5176484b9a5e" });
-    sinon.stub(IpAccountImplClient.prototype, "executeWithSig").resolves(txHash);
-    sinon.stub(IpAccountImplClient.prototype, "executeWithSigEncode").returns({
+
+    stub(IpAccountImplClient.prototype, "state").resolves({
+      result: "0x2e778894d11b5308e4153f094e190496c1e0609652c19f8b87e5176484b9a5e",
+    });
+    stub(IpAccountImplClient.prototype, "executeWithSig").resolves(txHash);
+    stub(IpAccountImplClient.prototype, "executeWithSigEncode").returns({
       data: "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
       to: "0x",
     });
-    (permissionClient.accessControllerClient as any).address =
+    (permissionClient.accessControllerClient as { address: string }).address =
       "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
-  });
-
-  afterEach(() => {
-    sinon.restore();
   });
 
   describe("Test permission.setPermission", () => {
     it("should throw IpId error when call setPermission given ipId is not registered ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await permissionClient.setPermission({
           ipId: zeroAddress,
@@ -55,9 +48,8 @@ describe("Test Permission", () => {
     });
 
     it("should return hash when call setPermission given ipId is registered ", async () => {
-      const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setPermission").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setPermission").resolves(txHash);
 
       const res = await permissionClient.setPermission({
         ipId: zeroAddress,
@@ -70,9 +62,8 @@ describe("Test Permission", () => {
     });
 
     it("should return txHash and success when call setPermission given correct args ", async () => {
-      const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setPermission").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setPermission").resolves(txHash);
 
       const res = await permissionClient.setPermission({
         ipId: zeroAddress,
@@ -85,8 +76,8 @@ describe("Test Permission", () => {
     });
 
     it("should return encodedTxData when call setPermission given correct args and encodedTxDataOnly of true", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setPermission").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setPermission").resolves(txHash);
 
       const res = await permissionClient.setPermission({
         ipId: zeroAddress,
@@ -97,13 +88,13 @@ describe("Test Permission", () => {
           encodedTxDataOnly: true,
         },
       });
-      expect(res.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData?.data).to.be.a("string");
     });
   });
 
-  describe("Test permission.setAllPermissions", async () => {
+  describe("Test permission.setAllPermissions", () => {
     it("should throw IpId error when call setAllPermissions given ipId is not registered ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await permissionClient.setAllPermissions({
           ipId: zeroAddress,
@@ -118,9 +109,8 @@ describe("Test Permission", () => {
     });
 
     it("should return hash when call setAllPermissions given ipId is registered ", async () => {
-      const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setAllPermissions").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setAllPermissions").resolves(txHash);
 
       const res = await permissionClient.setAllPermissions({
         ipId: zeroAddress,
@@ -131,8 +121,8 @@ describe("Test Permission", () => {
     });
 
     it("should return txHash and success when call setAllPermissions given correct args ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setAllPermissions").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setAllPermissions").resolves(txHash);
 
       const res = await permissionClient.setAllPermissions({
         ipId: zeroAddress,
@@ -144,8 +134,8 @@ describe("Test Permission", () => {
     });
 
     it("should return encodedTxData when call setAllPermissions given correct args and encodedTxDataOnly of true", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setAllPermissions").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setAllPermissions").resolves(txHash);
 
       const res = await permissionClient.setAllPermissions({
         ipId: zeroAddress,
@@ -155,13 +145,13 @@ describe("Test Permission", () => {
           encodedTxDataOnly: true,
         },
       });
-      expect(res.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData?.data).to.be.a("string");
     });
   });
 
-  describe("Test permission.createSetPermissionSignature", async () => {
+  describe("Test permission.createSetPermissionSignature", () => {
     it("should throw IpId error when call createSetPermissionSignature given ipId is not registered ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await permissionClient.createSetPermissionSignature({
           ipId: zeroAddress,
@@ -177,7 +167,7 @@ describe("Test Permission", () => {
     });
 
     it("should throw deadline error when call createSetPermissionSignature given deadline is not number", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       try {
         await permissionClient.createSetPermissionSignature({
           ipId: zeroAddress,
@@ -194,7 +184,7 @@ describe("Test Permission", () => {
     });
 
     it("should throw deadline error when call createSetPermissionSignature given deadline is less than 0", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       try {
         await permissionClient.createSetPermissionSignature({
           ipId: zeroAddress,
@@ -212,10 +202,10 @@ describe("Test Permission", () => {
     });
 
     it("should wallet error when call createSetPermissionSignature given wallet has no signTypedData method", async () => {
-      walletMock = createMock<WalletClient>();
+      walletMock = createMockWalletClient();
       permissionClient = new PermissionClient(rpcMock, walletMock, 1315);
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      (permissionClient.accessControllerClient as any).address =
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      (permissionClient.accessControllerClient as { address: string }).address =
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
 
       try {
@@ -234,7 +224,7 @@ describe("Test Permission", () => {
     });
 
     it("should return txHash and success when call createSetPermissionSignature given correct args ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
 
       const res = await permissionClient.createSetPermissionSignature({
         ipId: zeroAddress,
@@ -249,7 +239,7 @@ describe("Test Permission", () => {
     });
 
     it("should return encodedTxData when call createSetPermissionSignature given correct args and encodedTxDataOnly of true", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
 
       const res = await permissionClient.createSetPermissionSignature({
         ipId: zeroAddress,
@@ -260,13 +250,13 @@ describe("Test Permission", () => {
           encodedTxDataOnly: true,
         },
       });
-      expect(res.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData?.data).to.be.a("string");
     });
   });
 
-  describe("Test permission.setBatchPermissions", async () => {
+  describe("Test permission.setBatchPermissions", () => {
     it("should throw IpId error when call setBatchPermissions given ipId is not registered ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await permissionClient.setBatchPermissions({
           permissions: [
@@ -287,8 +277,8 @@ describe("Test Permission", () => {
     });
 
     it("should return hash when call setBatchPermissions given correct args", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setBatchPermissions").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setBatchPermissions").resolves(txHash);
 
       const res = await permissionClient.setBatchPermissions({
         permissions: [
@@ -304,8 +294,8 @@ describe("Test Permission", () => {
     });
 
     it("should return txHash and success when call setBatchPermissions given correct args ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setBatchPermissions").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setBatchPermissions").resolves(txHash);
 
       const res = await permissionClient.setBatchPermissions({
         permissions: [
@@ -323,8 +313,8 @@ describe("Test Permission", () => {
     });
 
     it("should return encodedTxData when call setBatchPermissions given correct args and encodedTxDataOnly of true", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(permissionClient.accessControllerClient, "setBatchPermissions").resolves(txHash);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.accessControllerClient, "setBatchPermissions").resolves(txHash);
 
       const res = await permissionClient.setBatchPermissions({
         permissions: [
@@ -339,13 +329,13 @@ describe("Test Permission", () => {
           encodedTxDataOnly: true,
         },
       });
-      expect(res.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData?.data).to.be.a("string");
     });
   });
 
-  describe("Test permission.createSetBatchPermissionsSignature", async () => {
+  describe("Test permission.createSetBatchPermissionsSignature", () => {
     it("should throw IpId error when call createSetBatchPermissionsSignature given ipId is not registered ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       try {
         await permissionClient.createBatchPermissionSignature({
           ipId: zeroAddress,
@@ -367,7 +357,7 @@ describe("Test Permission", () => {
     });
 
     it("should return txHash and success when call createSetBatchPermissionsSignature given correct args ", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       const res = await permissionClient.createBatchPermissionSignature({
         ipId: zeroAddress,
         deadline: 2000,
@@ -386,7 +376,7 @@ describe("Test Permission", () => {
     });
 
     it("should return encodedTxData when call createSetBatchPermissionsSignature given correct args and encodedTxDataOnly of true", async () => {
-      sinon.stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       const res = await permissionClient.createBatchPermissionSignature({
         ipId: zeroAddress,
         permissions: [
@@ -401,7 +391,7 @@ describe("Test Permission", () => {
           encodedTxDataOnly: true,
         },
       });
-      expect(res.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(res.encodedTxData?.data).to.be.a("string");
     });
   });
 });

--- a/packages/core-sdk/test/unit/resources/permission.test.ts
+++ b/packages/core-sdk/test/unit/resources/permission.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { stub } from "sinon";
-import { PublicClient, WalletClient, zeroAddress } from "viem";
+import { Address, PublicClient, WalletClient, zeroAddress } from "viem";
 
 import { PermissionClient } from "../../../src";
 import { IpAccountImplClient } from "../../../src/abi/generated";
@@ -205,7 +205,7 @@ describe("Test Permission", () => {
       walletMock = createMockWalletClient();
       permissionClient = new PermissionClient(rpcMock, walletMock, 1315);
       stub(permissionClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      (permissionClient.accessControllerClient as { address: string }).address =
+      (permissionClient.accessControllerClient as { address: Address }).address =
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c";
 
       try {

--- a/packages/core-sdk/test/unit/resources/royalty.test.ts
+++ b/packages/core-sdk/test/unit/resources/royalty.test.ts
@@ -1,22 +1,26 @@
-import chai from "chai";
-import { createMock, generateRandomAddress } from "../testUtils";
-import * as sinon from "sinon";
-import { PublicClient, WalletClient, Account, Hex } from "viem";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { RoyaltyClient } from "../../../src/resources/royalty";
+import { stub } from "sinon";
+import { Address, PublicClient, WalletClient } from "viem";
+
 import {
+  erc20Address,
   IpAccountImplClient,
   IpRoyaltyVaultImplReadOnlyClient,
-  erc20Address,
 } from "../../../src/abi/generated";
-import { aeneid } from "../../integration/utils/util";
-import { ERC20Client, WipTokenClient } from "../../../src/utils/token";
-import { ipId, mockAddress, walletAddress } from "../mockData";
 import { WIP_TOKEN_ADDRESS } from "../../../src/constants/common";
+import { RoyaltyClient } from "../../../src/resources/royalty";
 import { NativeRoyaltyPolicy } from "../../../src/types/resources/royalty";
-chai.use(chaiAsPromised);
-const expect = chai.expect;
-const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
+import { ERC20Client, WipTokenClient } from "../../../src/utils/token";
+import { aeneid } from "../../integration/utils/util";
+import { ipId, mockAddress, txHash, walletAddress } from "../mockData";
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+  generateRandomAddress,
+} from "../testUtils";
+
+use(chaiAsPromised);
 
 describe("Test RoyaltyClient", () => {
   let royaltyClient: RoyaltyClient;
@@ -24,31 +28,24 @@ describe("Test RoyaltyClient", () => {
   let walletMock: WalletClient;
 
   beforeEach(() => {
-    rpcMock = createMock<PublicClient>();
-    walletMock = createMock<WalletClient>();
-    const accountMock = createMock<Account>();
-    accountMock.address = "0x73fcb515cee99e4991465ef586cfe2b072ebb512";
-    walletMock.account = accountMock;
+    rpcMock = createMockPublicClient();
+    walletMock = createMockWalletClient();
     royaltyClient = new RoyaltyClient(rpcMock, walletMock, 1315);
   });
 
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  describe("Test royaltyClient.payRoyaltyOnBehalf", async () => {
+  describe("Test royaltyClient.payRoyaltyOnBehalf", () => {
     beforeEach(() => {
-      sinon.stub(ERC20Client.prototype, "balanceOf").resolves(1n);
-      sinon.stub(ERC20Client.prototype, "allowance").resolves(10000n);
-      sinon.stub(ERC20Client.prototype, "approve").resolves(txHash);
-      sinon.stub(WipTokenClient.prototype, "balanceOf").resolves(1n);
-      sinon.stub(WipTokenClient.prototype, "allowance").resolves(1n);
-      sinon.stub(WipTokenClient.prototype, "approve").resolves(txHash);
-      sinon.stub(WipTokenClient.prototype, "address").get(() => WIP_TOKEN_ADDRESS);
+      stub(ERC20Client.prototype, "balanceOf").resolves(1n);
+      stub(ERC20Client.prototype, "allowance").resolves(10000n);
+      stub(ERC20Client.prototype, "approve").resolves(txHash);
+      stub(WipTokenClient.prototype, "balanceOf").resolves(1n);
+      stub(WipTokenClient.prototype, "allowance").resolves(1n);
+      stub(WipTokenClient.prototype, "approve").resolves(txHash);
+      stub(WipTokenClient.prototype, "address").get(() => WIP_TOKEN_ADDRESS);
     });
 
     it("should throw receiverIpId error when call payRoyaltyOnBehalf given receiverIpId is not registered", async () => {
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
       try {
         await royaltyClient.payRoyaltyOnBehalf({
@@ -78,8 +75,7 @@ describe("Test RoyaltyClient", () => {
       }
     });
     it("should throw payerIpId error when call payRoyaltyOnBehalf given payerIpId is not registered", async () => {
-      sinon
-        .stub(royaltyClient.ipAssetRegistryClient, "isRegistered")
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered")
         .onFirstCall()
         .resolves(true)
         .onSecondCall()
@@ -100,8 +96,8 @@ describe("Test RoyaltyClient", () => {
     });
 
     it("should return txHash when call payRoyaltyOnBehalf given correct args with erc20", async () => {
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(royaltyClient.royaltyModuleClient, "payRoyaltyOnBehalf").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(royaltyClient.royaltyModuleClient, "payRoyaltyOnBehalf").resolves(txHash);
       const result = await royaltyClient.payRoyaltyOnBehalf({
         receiverIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
         payerIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
@@ -112,27 +108,25 @@ describe("Test RoyaltyClient", () => {
       expect(result.txHash).equals(txHash);
     });
     it("should convert IP to WIP when paying WIP via payRoyaltyOnBehalf", async () => {
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-
-      rpcMock.getBalance = sinon.stub().resolves(150n);
-      const simulateContractStub = sinon.stub().resolves({ request: {} });
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      rpcMock.getBalance = stub().resolves(150n);
+      const simulateContractStub = stub().resolves({ request: {} });
       rpcMock.simulateContract = simulateContractStub;
-      walletMock.writeContract = sinon.stub().resolves(txHash);
       const result = await royaltyClient.payRoyaltyOnBehalf({
         receiverIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
         payerIpId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
         token: WIP_TOKEN_ADDRESS,
         amount: 100n,
       });
-      expect(result.txHash).to.be.a("string").and.not.empty;
-      expect(simulateContractStub.calledOnce).to.be.true;
-      const calls = simulateContractStub.firstCall.args[0].args[0];
-      expect(calls.length).to.equal(2); // deposit and payRoyaltyOnBehalf
+      expect(result.txHash).equals(txHash);
+      expect(simulateContractStub.callCount).equals(1);
+      const calls = (simulateContractStub.firstCall.args[0] as { args: unknown[] }).args[0];
+      expect(calls).to.have.length(3); // deposit, approve and payRoyaltyOnBehalf
     });
 
     it("should return encodedData when call payRoyaltyOnBehalf given correct args and encodedTxDataOnly is true", async () => {
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon.stub(royaltyClient.royaltyModuleClient, "payRoyaltyOnBehalfEncode").returns({
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(royaltyClient.royaltyModuleClient, "payRoyaltyOnBehalfEncode").returns({
         data: "0x",
         to: "0x",
       });
@@ -145,13 +139,13 @@ describe("Test RoyaltyClient", () => {
         txOptions: { encodedTxDataOnly: true },
       });
 
-      expect(result.encodedTxData?.data).to.be.a("string").and.not.empty;
+      expect(result.encodedTxData?.data).to.be.a("string");
     });
   });
 
-  describe("Test royaltyClient.claimableRevenue", async () => {
+  describe("Test royaltyClient.claimableRevenue", () => {
     it("should throw ipId error when call claimableRevenue given ipId is not registered", async () => {
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
       try {
         await royaltyClient.claimableRevenue({
@@ -167,10 +161,11 @@ describe("Test RoyaltyClient", () => {
     });
 
     it("should throw royaltyVaultAddress error when call claimableRevenue given royalty vault address is 0x", async () => {
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(false);
-      sinon
-        .stub(royaltyClient.royaltyModuleClient, "ipRoyaltyVaults")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(royaltyClient.royaltyModuleClient, "ipRoyaltyVaults").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
       try {
         await royaltyClient.claimableRevenue({
           ipId: "0x",
@@ -185,11 +180,12 @@ describe("Test RoyaltyClient", () => {
     });
 
     it("should return txHash when call claimableRevenue given correct args", async () => {
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.royaltyModuleClient, "ipRoyaltyVaults")
-        .resolves("0x73fcb515cee99e4991465ef586cfe2b072ebb512");
-      sinon.stub(IpRoyaltyVaultImplReadOnlyClient.prototype, "claimableRevenue").resolves(1n);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.royaltyModuleClient, "ipRoyaltyVaults").resolves(
+        "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
+      );
+      stub(IpRoyaltyVaultImplReadOnlyClient.prototype, "claimableRevenue").resolves(1n);
 
       const result = await royaltyClient.claimableRevenue({
         ipId: "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
@@ -200,7 +196,7 @@ describe("Test RoyaltyClient", () => {
     });
   });
 
-  describe("Test royaltyClient.claimAllRevenue", async () => {
+  describe("Test royaltyClient.claimAllRevenue", () => {
     it("should throw error when call claimAllRevenue given claimer address is wrong", async () => {
       try {
         await royaltyClient.claimAllRevenue({
@@ -216,22 +212,19 @@ describe("Test RoyaltyClient", () => {
     });
 
     it("should call transfer and unwrap method when call claimAllRevenue given claimer is an IP owned by the wallet", async () => {
-      sinon.stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      const executeBatchStub = sinon
-        .stub(IpAccountImplClient.prototype, "executeBatch")
-        .resolves(txHash);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          {
-            token: WIP_TOKEN_ADDRESS,
-            amount: 1n,
-            claimer: ipId,
-          },
-        ]);
-      const withdrawStub = sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      const executeBatchStub = stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        {
+          token: WIP_TOKEN_ADDRESS,
+          amount: 1n,
+          claimer: ipId,
+        },
+      ]);
+      const withdrawStub = stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
       const result = await royaltyClient.claimAllRevenue({
         ancestorIpId: ipId,
         claimer: ipId,
@@ -239,28 +232,25 @@ describe("Test RoyaltyClient", () => {
         royaltyPolicies: [mockAddress],
         currencyTokens: [WIP_TOKEN_ADDRESS],
       });
-      expect(executeBatchStub.calledOnce).to.be.true;
-      expect(withdrawStub.calledOnce).to.be.true;
+      expect(executeBatchStub.callCount).equals(1);
+      expect(withdrawStub.callCount).equals(1);
       expect(result.txHashes).to.be.an("array").and.lengthOf(3);
     });
 
     it("should only unwrap token when call claimAllRevenue given autoTransfer is false", async () => {
-      sinon.stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      const executeBatchStub = sinon
-        .stub(IpAccountImplClient.prototype, "executeBatch")
-        .resolves(txHash);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          {
-            token: WIP_TOKEN_ADDRESS,
-            amount: 1n,
-            claimer: ipId,
-          },
-        ]);
-      const withdrawStub = sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      const executeBatchStub = stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        {
+          token: WIP_TOKEN_ADDRESS,
+          amount: 1n,
+          claimer: ipId,
+        },
+      ]);
+      const withdrawStub = stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       const result = await royaltyClient.claimAllRevenue({
         ancestorIpId: ipId,
@@ -271,27 +261,24 @@ describe("Test RoyaltyClient", () => {
         claimOptions: { autoTransferAllClaimedTokensFromIp: false },
       });
       expect(result.txHashes).to.be.an("array").and.lengthOf(2);
-      expect(executeBatchStub.calledOnce).to.be.false;
-      expect(withdrawStub.calledOnce).to.be.true;
+      expect(executeBatchStub.callCount).equals(0);
+      expect(withdrawStub.callCount).equals(1);
     });
 
     it("should not unwrap token when call claimAllRevenue given autoUnwrapIpTokens is false", async () => {
-      sinon.stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          {
-            token: WIP_TOKEN_ADDRESS,
-            amount: 1n,
-            claimer: ipId,
-          },
-        ]);
-      const executeBatchStub = sinon
-        .stub(IpAccountImplClient.prototype, "executeBatch")
-        .resolves(txHash);
-      const withdrawStub = sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        {
+          token: WIP_TOKEN_ADDRESS,
+          amount: 1n,
+          claimer: ipId,
+        },
+      ]);
+      const executeBatchStub = stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      const withdrawStub = stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       const result = await royaltyClient.claimAllRevenue({
         ancestorIpId: ipId,
@@ -302,25 +289,24 @@ describe("Test RoyaltyClient", () => {
         claimOptions: { autoTransferAllClaimedTokensFromIp: true, autoUnwrapIpTokens: false },
       });
       expect(result.txHashes).to.be.an("array").and.lengthOf(2);
-      expect(withdrawStub.calledOnce).to.be.false;
-      expect(executeBatchStub.calledOnce).to.be.true;
+      expect(withdrawStub.callCount).equals(0);
+      expect(executeBatchStub.callCount).equals(1);
     });
 
     it("should not call unwrap when call claimAllRevenue given token is not wip", async () => {
-      sinon.stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          {
-            token: mockAddress,
-            amount: 1n,
-            claimer: ipId,
-          },
-        ]);
-      sinon.stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
-      const withdrawStub = sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        {
+          token: mockAddress,
+          amount: 1n,
+          claimer: ipId,
+        },
+      ]);
+      stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      const withdrawStub = stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       await royaltyClient.claimAllRevenue({
         ancestorIpId: ipId,
@@ -329,29 +315,28 @@ describe("Test RoyaltyClient", () => {
         royaltyPolicies: [mockAddress],
         currencyTokens: [mockAddress],
       });
-      expect(withdrawStub.calledOnce).to.be.false;
+      expect(withdrawStub.callCount).equals(0);
     });
 
     it("should throw error when call claimAllRevenue given multiple wip tokens", async () => {
-      sinon.stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          {
-            token: WIP_TOKEN_ADDRESS,
-            amount: 1n,
-            claimer: ipId,
-          },
-          {
-            token: WIP_TOKEN_ADDRESS,
-            amount: 1n,
-            claimer: ipId,
-          },
-        ]);
-      sinon.stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
-      sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue").resolves(txHash);
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        {
+          token: WIP_TOKEN_ADDRESS,
+          amount: 1n,
+          claimer: ipId,
+        },
+        {
+          token: WIP_TOKEN_ADDRESS,
+          amount: 1n,
+          claimer: ipId,
+        },
+      ]);
+      stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
       try {
         await royaltyClient.claimAllRevenue({
           ancestorIpId: ipId,
@@ -368,7 +353,7 @@ describe("Test RoyaltyClient", () => {
     });
   });
 
-  describe("Test royaltyClient.batchClaimAllRevenue", async () => {
+  describe("Test royaltyClient.batchClaimAllRevenue", () => {
     it("should throw error when call batchClaimAllRevenue given claimer address is wrong", async () => {
       try {
         await royaltyClient.batchClaimAllRevenue({
@@ -390,25 +375,25 @@ describe("Test RoyaltyClient", () => {
     });
 
     it("should directly call claimAllRevenue when call batchClaimAllRevenue given only one ancestorIp", async () => {
-      const claimAllRevenueStub = sinon
-        .stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue")
-        .resolves(txHash);
-      const multicallStub = sinon
-        .stub(royaltyClient.royaltyWorkflowsClient, "multicall")
-        .resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      sinon.stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          {
-            token: WIP_TOKEN_ADDRESS,
-            amount: 1n,
-            claimer: ipId,
-          },
-        ]);
-      sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      const claimAllRevenueStub = stub(
+        royaltyClient.royaltyWorkflowsClient,
+        "claimAllRevenue",
+      ).resolves(txHash);
+      const multicallStub = stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(
+        txHash,
+      );
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        {
+          token: WIP_TOKEN_ADDRESS,
+          amount: 1n,
+          claimer: ipId,
+        },
+      ]);
+      stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       await royaltyClient.batchClaimAllRevenue({
         ancestorIps: [
@@ -421,30 +406,30 @@ describe("Test RoyaltyClient", () => {
           },
         ],
       });
-      expect(claimAllRevenueStub.calledOnce).to.be.true;
-      expect(multicallStub.calledOnce).to.be.false;
+      expect(claimAllRevenueStub.callCount).equals(1);
+      expect(multicallStub.callCount).equals(0);
     });
 
     it("should directly call claimAllRevenue when call batchClaimAllRevenue given useMulticallWhenPossible is false", async () => {
-      const claimAllRevenueStub = sinon
-        .stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue")
-        .resolves(txHash);
-      const multicallStub = sinon
-        .stub(royaltyClient.royaltyWorkflowsClient, "multicall")
-        .resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      sinon.stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          {
-            token: WIP_TOKEN_ADDRESS,
-            amount: 1n,
-            claimer: ipId,
-          },
-        ]);
-      sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      const claimAllRevenueStub = stub(
+        royaltyClient.royaltyWorkflowsClient,
+        "claimAllRevenue",
+      ).resolves(txHash);
+      const multicallStub = stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(
+        txHash,
+      );
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        {
+          token: WIP_TOKEN_ADDRESS,
+          amount: 1n,
+          claimer: ipId,
+        },
+      ]);
+      stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       await royaltyClient.batchClaimAllRevenue({
         ancestorIps: [
@@ -465,24 +450,26 @@ describe("Test RoyaltyClient", () => {
         ],
         options: { useMulticallWhenPossible: false },
       });
-      expect(claimAllRevenueStub.calledTwice).to.be.true;
-      expect(multicallStub.calledOnce).to.be.false;
+      expect(claimAllRevenueStub.callCount).equals(2);
+      expect(multicallStub.callCount).equals(0);
     });
 
     it("should not return claimedTokens when call batchClaimAllRevenue given claimer is neither an IP owned by the wallet nor the wallet address itself", async () => {
-      const claimAllRevenueStub = sinon
-        .stub(royaltyClient.royaltyWorkflowsClient, "claimAllRevenue")
-        .resolves(txHash);
-      const multicallStub = sinon
-        .stub(royaltyClient.royaltyWorkflowsClient, "multicall")
-        .resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(mockAddress);
-      sinon.stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([{ token: WIP_TOKEN_ADDRESS, amount: 1n, claimer: ipId }]);
-      sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      const claimAllRevenueStub = stub(
+        royaltyClient.royaltyWorkflowsClient,
+        "claimAllRevenue",
+      ).resolves(txHash);
+      const multicallStub = stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(
+        txHash,
+      );
+      stub(IpAccountImplClient.prototype, "owner").resolves(mockAddress);
+      stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        { token: WIP_TOKEN_ADDRESS, amount: 1n, claimer: ipId },
+      ]);
+      stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       const result = await royaltyClient.batchClaimAllRevenue({
         ancestorIps: [
@@ -504,21 +491,20 @@ describe("Test RoyaltyClient", () => {
       });
       expect(result.txHashes).to.be.an("array").and.lengthOf(1);
       expect(result.receipts).to.be.an("array").and.lengthOf(1);
-      expect(claimAllRevenueStub.calledOnce).to.be.false;
-      expect(multicallStub.calledOnce).to.be.true;
+      expect(claimAllRevenueStub.callCount).equals(0);
+      expect(multicallStub.callCount).equals(1);
     });
 
     it("should not call transfer when call batchClaimAllRevenue given autoTransferAllClaimedTokensFromIp is false", async () => {
-      sinon.stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      const executeBatchStub = sinon
-        .stub(IpAccountImplClient.prototype, "executeBatch")
-        .resolves(txHash);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([{ token: WIP_TOKEN_ADDRESS, amount: 1n, claimer: ipId }]);
-      const withdrawStub = sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(txHash);
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      const executeBatchStub = stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        { token: WIP_TOKEN_ADDRESS, amount: 1n, claimer: walletAddress },
+      ]);
+      const withdrawStub = stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       const result = await royaltyClient.batchClaimAllRevenue({
         ancestorIps: [
@@ -542,27 +528,24 @@ describe("Test RoyaltyClient", () => {
       expect(result.txHashes).to.be.an("array").and.lengthOf(2);
       expect(result.receipts).to.be.an("array").and.lengthOf(1);
       expect(result.claimedTokens).to.be.deep.equal([
-        { token: WIP_TOKEN_ADDRESS, amount: 1n, claimer: ipId },
+        { token: WIP_TOKEN_ADDRESS, amount: 1n, claimer: walletAddress },
       ]);
-      expect(executeBatchStub.calledOnce).to.be.false;
-      expect(withdrawStub.calledOnce).to.be.true;
+      expect(executeBatchStub.callCount).equals(0);
+      expect(withdrawStub.callCount).equals(1);
     });
 
     it("should not unwrap token when call batchClaimAllRevenue given autoUnwrapIpTokens is false", async () => {
-      sinon.stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      const executeBatchStub = sinon
-        .stub(IpAccountImplClient.prototype, "executeBatch")
-        .resolves(txHash);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          { token: WIP_TOKEN_ADDRESS, amount: 1n, claimer: ipId },
-          { token: mockAddress, amount: 0n, claimer: ipId },
-          { token: mockAddress, amount: 1n, claimer: walletAddress },
-        ]);
-      const withdrawStub = sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(txHash);
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      const executeBatchStub = stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        { token: WIP_TOKEN_ADDRESS, amount: 1n, claimer: ipId },
+        { token: mockAddress, amount: 0n, claimer: ipId },
+        { token: mockAddress, amount: 1n, claimer: walletAddress },
+      ]);
+      const withdrawStub = stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       const result = await royaltyClient.batchClaimAllRevenue({
         ancestorIps: [
@@ -590,27 +573,24 @@ describe("Test RoyaltyClient", () => {
         ],
         claimOptions: { autoUnwrapIpTokens: false },
       });
-      expect(result.txHashes).to.be.an("array").and.lengthOf(2);
+      expect(result.txHashes).to.be.an("array").and.lengthOf(3);
       expect(result.receipts).to.be.an("array").and.lengthOf(1);
-      expect(executeBatchStub.calledOnce).to.be.true;
-      expect(withdrawStub.calledOnce).to.be.false;
+      expect(executeBatchStub.callCount).equals(2);
+      expect(withdrawStub.callCount).equals(0);
     });
 
     it("should return claimedTokens when call batchClaimAllRevenue", async () => {
-      sinon.stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(txHash);
-      sinon.stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
-      const executeBatchStub = sinon
-        .stub(IpAccountImplClient.prototype, "executeBatch")
-        .resolves(txHash);
-      sinon.stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      sinon
-        .stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent")
-        .returns([
-          { token: mockAddress, amount: 1n, claimer: walletAddress },
-          { token: WIP_TOKEN_ADDRESS, amount: 0n, claimer: walletAddress },
-          { token: mockAddress, amount: 1n, claimer: walletAddress },
-        ]);
-      const withdrawStub = sinon.stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(royaltyClient.royaltyWorkflowsClient, "multicall").resolves(txHash);
+      stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
+      const executeBatchStub = stub(IpAccountImplClient.prototype, "executeBatch").resolves(txHash);
+      stub(royaltyClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      stub(royaltyClient.ipRoyaltyVaultImplEventClient, "parseTxRevenueTokenClaimedEvent").returns([
+        { token: mockAddress, amount: 1n, claimer: walletAddress },
+        { token: WIP_TOKEN_ADDRESS, amount: 0n, claimer: walletAddress },
+        { token: mockAddress, amount: 1n, claimer: walletAddress },
+      ]);
+      const withdrawStub = stub(royaltyClient.wrappedIpClient, "withdraw").resolves(txHash);
 
       const result = await royaltyClient.batchClaimAllRevenue({
         ancestorIps: [
@@ -641,19 +621,18 @@ describe("Test RoyaltyClient", () => {
         { token: mockAddress, amount: 2n, claimer: walletAddress },
         { token: WIP_TOKEN_ADDRESS, amount: 0n, claimer: walletAddress },
       ]);
-      expect(executeBatchStub.calledOnce).to.be.true;
-      // withdraw is not called because amount is 0
-      expect(withdrawStub.calledOnce).to.be.false;
+      expect(executeBatchStub.callCount).equals(1);
+      expect(withdrawStub.callCount).equals(0);
       expect(result.txHashes).to.be.an("array").and.lengthOf(2);
       expect(result.receipts).to.be.an("array").and.lengthOf(1);
     });
   });
 
-  describe("Test royaltyClient.transferToVault", async () => {
+  describe("Test royaltyClient.transferToVault", () => {
     it("returns txHash when successful", async () => {
-      const simulateContractStub = sinon.stub().resolves({ request: {} });
+      const simulateContractStub = stub().resolves({ request: {} });
       rpcMock.simulateContract = simulateContractStub;
-      walletMock.writeContract = sinon.stub().resolves(txHash);
+      walletMock.writeContract = stub().resolves(txHash);
       const result = await royaltyClient.transferToVault({
         ipId,
         ancestorIpId: generateRandomAddress(),
@@ -664,18 +643,23 @@ describe("Test RoyaltyClient", () => {
     });
 
     it("throws if invalid input addresses", async () => {
-      const invalidAddress: Hex = "0x123";
-      const validAddress: Hex = ipId;
+      const invalidAddress: Address = "0x123" as Address;
+      const validAddress: Address = ipId;
       const validPolicy = NativeRoyaltyPolicy.LAP;
       const testCases = [
-        { ipId: invalidAddress, ancestorIpId: validAddress, token: validAddress },
-        { ipId: validAddress, ancestorIpId: invalidAddress, token: validAddress },
-        { ipId: validAddress, ancestorIpId: validAddress, token: invalidAddress },
+        { testIpId: invalidAddress, testAncestorIpId: validAddress, testToken: validAddress },
+        { testIpId: validAddress, testAncestorIpId: invalidAddress, testToken: validAddress },
+        { testIpId: validAddress, testAncestorIpId: validAddress, testToken: invalidAddress },
       ];
 
-      for (const { ipId, ancestorIpId, token } of testCases) {
+      for (const { testIpId, testAncestorIpId, testToken } of testCases) {
         await expect(
-          royaltyClient.transferToVault({ ipId, ancestorIpId, token, royaltyPolicy: validPolicy }),
+          royaltyClient.transferToVault({
+            ipId: testIpId,
+            ancestorIpId: testAncestorIpId,
+            token: testToken,
+            royaltyPolicy: validPolicy,
+          }),
         ).to.be.rejectedWith(`Invalid address: ${invalidAddress}`);
       }
     });

--- a/packages/core-sdk/test/unit/resources/wip.test.ts
+++ b/packages/core-sdk/test/unit/resources/wip.test.ts
@@ -1,36 +1,28 @@
-import { PublicClient, WalletClient } from "viem";
-import { WipClient } from "../../../src/resources/wip";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import chai from "chai";
-import * as sinon from "sinon";
-import { createMock } from "../testUtils";
-chai.use(chaiAsPromised);
-const expect = chai.expect;
-const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
+import { stub } from "sinon";
+import { PublicClient, WalletClient } from "viem";
+
+import { WipClient } from "../../../src/resources/wip";
+import { txHash } from "../mockData";
+import { createMockPublicClient, createMockWalletClient } from "../testUtils";
+
+use(chaiAsPromised);
 
 describe("WIP Functions", () => {
   let wipClient: WipClient;
   let rpcMock: PublicClient;
   let walletMock: WalletClient;
 
-  before(async () => {
-    rpcMock = createMock<PublicClient>();
-    walletMock = createMock<WalletClient>();
+  before(() => {
+    rpcMock = createMockPublicClient();
+    walletMock = createMockWalletClient();
     wipClient = new WipClient(rpcMock, walletMock);
-  });
-
-  afterEach(() => {
-    sinon.restore();
   });
 
   describe("deposit", () => {
     before(() => {
-      rpcMock.simulateContract = sinon.stub().resolves({ request: {} });
-      walletMock.writeContract = sinon.stub().resolves(txHash);
       wipClient = new WipClient(rpcMock, walletMock);
-    });
-    after(() => {
-      sinon.restore();
     });
 
     it("should throw an error when call deposit give amount is less than 0", async () => {
@@ -45,13 +37,6 @@ describe("WIP Functions", () => {
       }
     });
     it("should deposit successfully when call deposit given amount is 1 ", async () => {
-      const rsp = await wipClient.deposit({
-        amount: 1,
-      });
-      expect(rsp.txHash).to.be.a("string");
-    });
-
-    it("should deposit successfully when call deposit given amount is 1", async () => {
       const rsp = await wipClient.deposit({
         amount: 1,
       });
@@ -73,15 +58,7 @@ describe("WIP Functions", () => {
     });
 
     it("should withdraw successfully when call withdraw given amount is 1", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "withdraw").resolves(txHash);
-      const rsp = await wipClient.withdraw({
-        amount: 1,
-      });
-      expect(rsp.txHash).to.be.a("string");
-    });
-
-    it("should withdraw successfully when call withdraw given amount is 1", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "withdraw").resolves(txHash);
+      stub(wipClient.wrappedIpClient, "withdraw").resolves(txHash);
       const rsp = await wipClient.withdraw({
         amount: 1,
       });
@@ -104,7 +81,7 @@ describe("WIP Functions", () => {
     });
 
     it("should approve successfully when call approve given amount is 1", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "approve").resolves(txHash);
+      stub(wipClient.wrappedIpClient, "approve").resolves(txHash);
       const rsp = await wipClient.approve({
         amount: 1,
         spender: "0x12fcbf7d94388da4D4a38bEF15B19289a00e6c91",
@@ -113,7 +90,7 @@ describe("WIP Functions", () => {
     });
 
     it("should approve successfully when call approve given amount is 1", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "approve").resolves(txHash);
+      stub(wipClient.wrappedIpClient, "approve").resolves(txHash);
       const rsp = await wipClient.approve({
         amount: 1,
         spender: "0x12fcbf7d94388da4D4a38bEF15B19289a00e6c91",
@@ -132,7 +109,7 @@ describe("WIP Functions", () => {
     });
 
     it("should get balance successfully when call getBalance given address is valid", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "balanceOf").resolves({ result: 0n });
+      stub(wipClient.wrappedIpClient, "balanceOf").resolves({ result: 0n });
       const rsp = await wipClient.balanceOf("0x12fcbf7d94388da4D4a38bEF15B19289a00e6c91");
       expect(rsp).to.be.a("bigint");
     });
@@ -153,21 +130,12 @@ describe("WIP Functions", () => {
     });
 
     it("should transfer successfully when call transfer given amount is 1", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "transfer").resolves(txHash);
+      stub(wipClient.wrappedIpClient, "transfer").resolves(txHash);
       const rsp = await wipClient.transfer({
         amount: 1,
         to: "0x12fcbf7d94388da4D4a38bEF15B19289a00e6c91",
       });
 
-      expect(rsp.txHash).to.be.a("string");
-    });
-
-    it("should transfer successfully when call transfer given amount is 1", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "transfer").resolves(txHash);
-      const rsp = await wipClient.transfer({
-        amount: 1,
-        to: "0x12fcbf7d94388da4D4a38bEF15B19289a00e6c91",
-      });
       expect(rsp.txHash).to.be.a("string");
     });
   });
@@ -188,17 +156,7 @@ describe("WIP Functions", () => {
     });
 
     it("should transfer successfully when call transferFrom given amount is 1", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "transferFrom").resolves(txHash);
-      const rsp = await wipClient.transferFrom({
-        amount: 1,
-        from: "0x12fcbf7d94388da4D4a38bEF15B19289a00e6c91",
-        to: "0x12fcbf7d94388da4D4a38bEF15B19289a00e6c91",
-      });
-      expect(rsp.txHash).to.be.a("string");
-    });
-
-    it("should transfer successfully when call transferFrom given amount is 1", async () => {
-      sinon.stub(wipClient.wrappedIpClient, "transferFrom").resolves(txHash);
+      stub(wipClient.wrappedIpClient, "transferFrom").resolves(txHash);
       const rsp = await wipClient.transferFrom({
         amount: 1,
         from: "0x12fcbf7d94388da4D4a38bEF15B19289a00e6c91",

--- a/packages/core-sdk/test/unit/testUtils.ts
+++ b/packages/core-sdk/test/unit/testUtils.ts
@@ -45,9 +45,9 @@ export const createMockWalletClient = (): WalletClient => {
     account: privateKeyToAccount(privateKey),
   });
   walletClient.writeContract = stub().resolves(txHash);
-  walletClient.signTypedData = stub().resolves({
-    signature: "0x123",
-  });
+  walletClient.signTypedData = stub().resolves(
+    "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997",
+  );
   return walletClient;
 };
 

--- a/packages/core-sdk/test/unit/utils/errors.test.ts
+++ b/packages/core-sdk/test/unit/utils/errors.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+
 import { handleError } from "../../../src/utils/errors";
 
 describe("Test handleError", () => {

--- a/packages/core-sdk/test/unit/utils/feeUtils.test.ts
+++ b/packages/core-sdk/test/unit/utils/feeUtils.test.ts
@@ -1,50 +1,53 @@
-import chai from "chai";
-import * as sinon from "sinon";
+import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { Address, LocalAccount, PublicClient, WalletClient, maxUint256, parseEther } from "viem";
-import {
-  royaltyModuleAddress,
-  derivativeWorkflowsAddress,
-  multicall3Address,
-  erc20Address,
-} from "../../../src/abi/generated";
-import { createMock, generateRandomAddress, generateRandomHash } from "../testUtils";
-import { aeneid, txHash } from "../mockData";
-import { TEST_WALLET_ADDRESS } from "../../integration/utils/util";
-import { TransactionResponse, WIP_TOKEN_ADDRESS } from "../../../src";
-import { ContractCallWithFees } from "../../../src/types/utils/wip";
-import { ERC20Client, WipTokenClient } from "../../../src/utils/token";
-import { contractCallWithFees } from "../../../src/utils/feeUtils";
+import { restore, SinonStub, stub } from "sinon";
+import { Address, maxUint256, parseEther, PublicClient, WalletClient } from "viem";
 
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+import { WIP_TOKEN_ADDRESS } from "../../../src";
+import {
+  derivativeWorkflowsAddress,
+  erc20Address,
+  multicall3Address,
+  royaltyModuleAddress,
+} from "../../../src/abi/generated";
+import { ContractCallWithFees } from "../../../src/types/utils/wip";
+import { contractCallWithFees } from "../../../src/utils/feeUtils";
+import { ERC20Client, WipTokenClient } from "../../../src/utils/token";
+import { TEST_WALLET_ADDRESS } from "../../integration/utils/util";
+import { aeneid, txHash } from "../mockData";
+import {
+  createMockPublicClient,
+  createMockWalletClient,
+  createMockWithAddress,
+  generateRandomAddress,
+  generateRandomHash,
+} from "../testUtils";
+
+use(chaiAsPromised);
 
 describe("Erc20 Token Fee Utilities", () => {
   let rpcMock: PublicClient;
   let walletMock: WalletClient;
-  let contractCallMock: sinon.SinonStub;
-  let rpcWaitForTxMock: sinon.SinonStub;
-  let walletBalanceMock: sinon.SinonStub;
+  let contractCallMock: SinonStub;
+  let rpcWaitForTxMock: SinonStub;
+  let walletBalanceMock: SinonStub;
 
   beforeEach(() => {
-    rpcMock = createMock<PublicClient>();
-    walletBalanceMock = sinon.stub().resolves(0);
+    rpcMock = createMockPublicClient();
+    walletBalanceMock = stub().resolves(0);
     rpcMock.getBalance = walletBalanceMock;
-    walletMock = createMock<WalletClient>();
-    const accountMock = createMock<LocalAccount>();
-    walletMock.account = accountMock;
-    walletMock.writeContract = sinon.stub().resolves(generateRandomHash());
-    rpcWaitForTxMock = rpcMock.waitForTransactionReceipt as sinon.SinonStub;
-    sinon.stub(WipTokenClient.prototype, "address").get(() => WIP_TOKEN_ADDRESS);
+    walletMock = createMockWalletClient();
+    rpcWaitForTxMock = rpcMock.waitForTransactionReceipt as SinonStub;
+    createMockWithAddress<WipTokenClient>();
   });
 
   afterEach(() => {
-    sinon.restore();
+    restore();
   });
 
-  function getDefaultParams(overrides: Partial<ContractCallWithFees>): ContractCallWithFees {
+  const getDefaultParams = (overrides: Partial<ContractCallWithFees>): ContractCallWithFees => {
     const hash = generateRandomHash();
-    contractCallMock = sinon.stub().resolves(hash);
+    contractCallMock = stub().resolves(hash);
     return {
       rpcClient: rpcMock,
       wallet: walletMock,
@@ -64,14 +67,14 @@ describe("Erc20 Token Fee Utilities", () => {
       },
       ...overrides,
     };
-  }
+  };
   describe("No Fees", () => {
     it("should call contract directly if no fees", async () => {
       const params = getDefaultParams({ totalFees: 0n });
       const txResponse = await contractCallWithFees(params);
-      const { txHash } = txResponse as TransactionResponse;
-      expect(contractCallMock.calledOnce).to.be.true;
-      expect(txHash).not.to.be.empty;
+      const { txHash: result } = txResponse;
+      expect(contractCallMock.callCount).equals(1);
+      expect(result).to.be.a("string");
     });
 
     it("should support wait for tx", async () => {
@@ -79,23 +82,23 @@ describe("Erc20 Token Fee Utilities", () => {
         totalFees: 0n,
       });
       const txResponse = await contractCallWithFees(params);
-      const { txHash } = txResponse as TransactionResponse;
-      expect(contractCallMock.calledOnce).to.be.true;
-      expect(rpcWaitForTxMock.calledOnce).to.be.true;
-      expect(txHash).not.to.be.empty;
+      const { txHash: result } = txResponse;
+      expect(contractCallMock.callCount).equals(1);
+      expect(rpcWaitForTxMock.callCount).equals(1);
+      expect(result).to.be.a("string");
     });
   });
 
   describe("contractCallWithFees with wip", () => {
-    let approveMock: sinon.SinonStub;
+    let approveMock: SinonStub;
 
     beforeEach(() => {
-      approveMock = sinon.stub(WipTokenClient.prototype, "approve").resolves(txHash);
+      approveMock = stub(WipTokenClient.prototype, "approve").resolves(txHash);
     });
 
     describe("Enough WIP", () => {
       beforeEach(() => {
-        sinon.stub(WipTokenClient.prototype, "balanceOf").resolves(200n);
+        stub(WipTokenClient.prototype, "balanceOf").resolves(200n);
       });
       it("should not call approval if disabled via enableAutoApprove", async () => {
         const params = getDefaultParams({
@@ -103,10 +106,10 @@ describe("Erc20 Token Fee Utilities", () => {
           options: { erc20Options: { enableAutoApprove: false } },
         });
         const txResponse = await contractCallWithFees(params);
-        const { txHash } = txResponse as TransactionResponse;
-        expect(contractCallMock.calledOnce).to.be.true;
-        expect(approveMock.notCalled).to.be.true;
-        expect(txHash).not.to.be.empty;
+        const { txHash: result } = txResponse;
+        expect(contractCallMock.callCount).equals(1);
+        expect(approveMock.callCount).equals(0);
+        expect(result).to.be.a("string");
       });
 
       it("should skip approvals if all spenders have enough allowance", async () => {
@@ -123,21 +126,22 @@ describe("Erc20 Token Fee Utilities", () => {
             },
           ],
         });
-        const allowanceMock = sinon.stub(WipTokenClient.prototype, "allowance").resolves(50n);
+        const allowanceMock = stub(WipTokenClient.prototype, "allowance").resolves(50n);
 
         const txResponse = await contractCallWithFees(params);
-        const { txHash } = txResponse as TransactionResponse;
-        expect(allowanceMock.calledTwice).to.be.true;
-        expect(
-          allowanceMock.firstCall.calledWith(TEST_WALLET_ADDRESS, params.tokenSpenders[0].address),
-        ).to.be.true;
-
-        expect(
-          allowanceMock.secondCall.calledWith(TEST_WALLET_ADDRESS, params.tokenSpenders[1].address),
-        ).to.be.true;
-        expect(contractCallMock.calledOnce).to.be.true;
-        expect(approveMock.notCalled).to.be.true;
-        expect(txHash).not.to.be.empty;
+        const { txHash: result } = txResponse;
+        expect(allowanceMock.callCount).equals(2);
+        expect(allowanceMock.firstCall.args).to.deep.eq([
+          TEST_WALLET_ADDRESS,
+          params.tokenSpenders[0].address,
+        ]);
+        expect(allowanceMock.secondCall.args).to.deep.eq([
+          TEST_WALLET_ADDRESS,
+          params.tokenSpenders[1].address,
+        ]);
+        expect(contractCallMock.callCount).equals(1);
+        expect(approveMock.callCount).equals(0);
+        expect(result).to.be.a("string");
       });
 
       it("should call separate approvals for each spender address if not enough allowance", async () => {
@@ -154,29 +158,30 @@ describe("Erc20 Token Fee Utilities", () => {
             },
           ],
         });
-        sinon.stub(WipTokenClient.prototype, "allowance").resolves(15n);
+        stub(WipTokenClient.prototype, "allowance").resolves(15n);
         const txResponse = await contractCallWithFees(params);
-        const { txHash, receipt } = txResponse as TransactionResponse;
-        expect(receipt).not.to.be.undefined;
-        expect(contractCallMock.calledOnce).to.be.true;
-        expect(approveMock.calledOnce).to.be.true;
-        expect(approveMock.firstCall.calledWith(derivativeWorkflowsAddress[aeneid], maxUint256)).to
-          .be.true;
-        expect(rpcWaitForTxMock.callCount).to.equal(2); // 1 approval + 1 contract call
-        expect(txHash).not.to.be.empty;
+        const { txHash: result } = txResponse;
+        expect(contractCallMock.callCount).equals(1);
+        expect(approveMock.callCount).equals(1);
+        expect(approveMock.firstCall.args).to.deep.eq([
+          derivativeWorkflowsAddress[aeneid],
+          maxUint256,
+        ]);
+        expect(rpcWaitForTxMock.callCount).equals(2); // 1 approval + 1 contract call
+        expect(result).to.be.a("string");
       });
     });
 
     describe("Enough IP, not enough WIP", () => {
-      let simulateContractMock: sinon.SinonStub;
+      let simulateContractMock: SinonStub;
       let params: ContractCallWithFees;
 
       beforeEach(() => {
-        sinon.stub(WipTokenClient.prototype, "balanceOf").resolves(1n);
+        stub(WipTokenClient.prototype, "balanceOf").resolves(1n);
         walletBalanceMock.resolves(1_000);
-        simulateContractMock = sinon.stub().resolves({ request: {} });
+        simulateContractMock = stub().resolves({ request: {} });
         rpcMock.simulateContract = simulateContractMock;
-        rpcMock;
+
         params = getDefaultParams({
           totalFees: 100n,
           tokenSpenders: [
@@ -190,7 +195,7 @@ describe("Erc20 Token Fee Utilities", () => {
             },
           ],
         });
-        sinon.stub(WipTokenClient.prototype, "allowance").resolves(50n);
+        stub(WipTokenClient.prototype, "allowance").resolves(50n);
       });
 
       it("should error if enableAutoWrapIp is false", async () => {
@@ -208,23 +213,21 @@ describe("Erc20 Token Fee Utilities", () => {
             ...params,
             options: { wipOptions: { useMulticallWhenPossible: false } },
           });
-          const { txHash } = txResponse as TransactionResponse;
-          expect(simulateContractMock.calledOnce).to.be.true;
+          const { txHash: result } = txResponse;
+          expect(simulateContractMock.callCount).equals(1);
           expect(simulateContractMock.firstCall.args[0]).to.include({
             functionName: "deposit",
             value: 100n,
             address: WIP_TOKEN_ADDRESS,
           });
-          expect(approveMock.calledOnce).to.be.true;
-          expect(
-            approveMock.firstCall.calledWith({
-              spender: derivativeWorkflowsAddress[aeneid],
-              amount: maxUint256,
-            }),
-          );
-          expect(contractCallMock.calledOnce).to.be.true;
-          expect(rpcWaitForTxMock.callCount).to.equal(3); // 1 deposit + 1 approval + 1 contract call
-          expect(txHash).not.to.be.empty;
+          expect(approveMock.callCount).equals(1);
+          expect(approveMock.firstCall.args).to.deep.eq([
+            derivativeWorkflowsAddress[aeneid],
+            maxUint256,
+          ]);
+          expect(contractCallMock.callCount).equals(1);
+          expect(rpcWaitForTxMock.callCount).equals(3); // 1 deposit + 1 approval + 1 contract call
+          expect(result).to.be.a("string");
         });
 
         it("should support wait for tx", async () => {
@@ -234,13 +237,12 @@ describe("Erc20 Token Fee Utilities", () => {
               wipOptions: { useMulticallWhenPossible: false },
             },
           });
-          const { txHash, receipt } = txResponse as TransactionResponse;
-          expect(receipt).not.to.be.undefined;
-          expect(txHash).not.to.be.empty;
-          expect(simulateContractMock.calledOnce).to.be.true;
-          expect(approveMock.calledOnce).to.be.true;
-          expect(contractCallMock.calledOnce).to.be.true;
-          expect(rpcWaitForTxMock.callCount).to.equal(3);
+          const { txHash: result } = txResponse;
+          expect(simulateContractMock.callCount).equals(1);
+          expect(approveMock.callCount).equals(1);
+          expect(contractCallMock.callCount).equals(1);
+          expect(rpcWaitForTxMock.callCount).equals(3);
+          expect(result).to.be.a("string");
         });
 
         it("should not call approval if enableAutoApprove is false", async () => {
@@ -250,12 +252,12 @@ describe("Erc20 Token Fee Utilities", () => {
               wipOptions: { enableAutoApprove: false, useMulticallWhenPossible: false },
             },
           });
-          const { txHash } = txResponse as TransactionResponse;
-          expect(txHash).not.to.be.empty;
-          expect(simulateContractMock.calledOnce).to.be.true;
-          expect(approveMock.notCalled).to.be.true;
-          expect(contractCallMock.calledOnce).to.be.true;
-          expect(rpcWaitForTxMock.callCount).to.equal(2); // 1 deposit + 1 contract call
+          const { txHash: result } = txResponse;
+          expect(simulateContractMock.callCount).equals(1);
+          expect(approveMock.callCount).equals(0);
+          expect(contractCallMock.callCount).equals(1);
+          expect(rpcWaitForTxMock.callCount).equals(2); // 1 deposit + 1 contract call
+          expect(result).to.be.a("string");
         });
 
         it("should not call approval if spender has enough allowance", async () => {
@@ -275,25 +277,25 @@ describe("Erc20 Token Fee Utilities", () => {
               wipOptions: { useMulticallWhenPossible: false },
             },
           });
-          const { txHash } = txResponse as TransactionResponse;
-          expect(txHash).not.to.be.empty;
-          expect(simulateContractMock.calledOnce).to.be.true;
-          expect(approveMock.notCalled).to.be.true;
-          expect(contractCallMock.calledOnce).to.be.true;
-          expect(rpcWaitForTxMock.callCount).to.equal(2); // 1 deposit + 1 contract call
+          const { txHash: result } = txResponse;
+          expect(result).to.be.a("string");
+          expect(simulateContractMock.callCount).equals(1);
+          expect(approveMock.callCount).equals(0);
+          expect(contractCallMock.callCount).equals(1);
+          expect(rpcWaitForTxMock.callCount).equals(2); // 1 deposit + 1 contract call
         });
       });
 
       describe("multicall", () => {
-        let depositEncodeMock: sinon.SinonStub;
-        let approveEncodeMock: sinon.SinonStub;
+        let depositEncodeMock: SinonStub;
+        let approveEncodeMock: SinonStub;
 
         beforeEach(() => {
-          depositEncodeMock = sinon.stub(WipTokenClient.prototype, "depositEncode").returns({
+          depositEncodeMock = stub(WipTokenClient.prototype, "depositEncode").returns({
             to: generateRandomAddress(),
             data: txHash,
           });
-          approveEncodeMock = sinon.stub(WipTokenClient.prototype, "approveEncode").returns({
+          approveEncodeMock = stub(WipTokenClient.prototype, "approveEncode").returns({
             to: generateRandomAddress(),
             data: txHash,
           });
@@ -301,20 +303,24 @@ describe("Erc20 Token Fee Utilities", () => {
 
         it("should deposit, approve, and call contract in one multicall", async () => {
           const txResponse = await contractCallWithFees(params);
-          const { txHash } = txResponse as TransactionResponse;
-          expect(txHash).not.to.be.empty;
-          expect(depositEncodeMock.calledOnce).to.be.true;
-          expect(approveEncodeMock.calledOnce).to.be.true;
-          expect(simulateContractMock.calledOnce).to.be.true;
+          const { txHash: result } = txResponse;
+          expect(result).to.be.a("string");
+          expect(depositEncodeMock.callCount).equals(1);
+          expect(approveEncodeMock.callCount).equals(1);
+          expect(simulateContractMock.callCount).equals(1);
           expect(simulateContractMock.firstCall.args[0]).to.include({
             functionName: "aggregate3Value",
             value: 100n,
           });
-          const calls = simulateContractMock.firstCall.args[0].args[0];
+          const calls = (
+            simulateContractMock.firstCall.args[0] as {
+              args: { target: Address }[];
+            }
+          ).args[0] as unknown as { target: Address }[];
           expect(calls).to.have.length(3); // 1 deposit, 1 approve, 1 call
-          expect(calls.map((c: { target: Address }) => c.target)).to.deep.eq([
-            depositEncodeMock.returnValues[0].to,
-            approveEncodeMock.returnValues[0].to,
+          expect(calls.map((c) => c.target)).to.deep.eq([
+            (depositEncodeMock.returnValues[0] as { to: Address }).to,
+            (approveEncodeMock.returnValues[0] as { to: Address }).to,
             params.encodedTxs[0].to,
           ]);
         });
@@ -323,11 +329,15 @@ describe("Erc20 Token Fee Utilities", () => {
           const txResponse = await contractCallWithFees({
             ...params,
           });
-          const { txHash } = txResponse as TransactionResponse;
-          expect(txHash).not.to.be.empty;
-          expect(simulateContractMock.calledOnce).to.be.true;
-          expect(rpcWaitForTxMock.callCount).to.equal(2);
-          const calls = simulateContractMock.firstCall.args[0].args[0];
+          const { txHash: result } = txResponse;
+          expect(result).to.be.a("string");
+          expect(simulateContractMock.callCount).equals(1);
+          expect(rpcWaitForTxMock.callCount).equals(2);
+          const calls = (
+            simulateContractMock.firstCall.args[0] as {
+              args: { target: Address }[];
+            }
+          ).args[0];
           expect(calls).to.have.length(3);
         });
 
@@ -338,11 +348,15 @@ describe("Erc20 Token Fee Utilities", () => {
               wipOptions: { enableAutoApprove: false },
             },
           });
-          const { txHash } = txResponse as TransactionResponse;
-          expect(txHash).not.to.be.empty;
-          expect(simulateContractMock.calledOnce).to.be.true;
-          expect(approveEncodeMock.notCalled).to.be.true;
-          const calls = simulateContractMock.firstCall.args[0].args[0];
+          const { txHash: result } = txResponse;
+          expect(result).to.be.a("string");
+          expect(simulateContractMock.callCount).equals(1);
+          expect(approveEncodeMock.callCount).equals(0);
+          const calls = (
+            simulateContractMock.firstCall.args[0] as {
+              args: { target: Address }[];
+            }
+          ).args[0];
           expect(calls).to.have.length(2); // 1 deposit, 1 call, no approves
         });
 
@@ -360,11 +374,15 @@ describe("Erc20 Token Fee Utilities", () => {
               },
             ],
           });
-          const { txHash } = txResponse as TransactionResponse;
-          expect(txHash).not.to.be.empty;
-          expect(simulateContractMock.calledOnce).to.be.true;
-          expect(approveEncodeMock.notCalled).to.be.true;
-          const calls = simulateContractMock.firstCall.args[0].args[0];
+          const { txHash: result } = txResponse;
+          expect(result).to.be.a("string");
+          expect(simulateContractMock.callCount).equals(1);
+          expect(approveEncodeMock.callCount).equals(0);
+          const calls = (
+            simulateContractMock.firstCall.args[0] as {
+              args: { target: Address }[];
+            }
+          ).args[0];
           expect(calls).to.have.length(2); // 1 deposit, 1 call
         });
       });
@@ -375,7 +393,7 @@ describe("Erc20 Token Fee Utilities", () => {
 
       beforeEach(() => {
         walletBalanceMock.resolves(parseEther("0.1"));
-        sinon.stub(WipTokenClient.prototype, "balanceOf").resolves(0n);
+        stub(WipTokenClient.prototype, "balanceOf").resolves(0n);
       });
 
       it("should throw error indicating not enough wip funds to complete given token is wip", async () => {
@@ -392,9 +410,9 @@ describe("Erc20 Token Fee Utilities", () => {
     let allowanceMock: sinon.SinonStub;
 
     beforeEach(() => {
-      approveMock = sinon.stub(ERC20Client.prototype, "approve").resolves(txHash);
-      allowanceMock = sinon.stub(ERC20Client.prototype, "allowance").resolves(0n);
-      sinon.stub(ERC20Client.prototype, "balanceOf").resolves(100n);
+      approveMock = stub(ERC20Client.prototype, "approve").resolves(txHash);
+      allowanceMock = stub(ERC20Client.prototype, "allowance").resolves(0n);
+      stub(ERC20Client.prototype, "balanceOf").resolves(100n);
     });
 
     it("should not call approval if disabled via enableAutoApprove and enough erc20 token", async () => {
@@ -406,10 +424,10 @@ describe("Erc20 Token Fee Utilities", () => {
         },
       });
       const txResponse = await contractCallWithFees(params);
-      const { txHash, receipt } = txResponse as TransactionResponse;
-      expect(contractCallMock.calledOnce).to.be.true;
-      expect(approveMock.notCalled).to.be.true;
-      expect(txHash).not.to.be.empty;
+      const { txHash: result } = txResponse;
+      expect(contractCallMock.callCount).equals(1);
+      expect(approveMock.callCount).equals(0);
+      expect(result).to.be.a("string");
     });
 
     it("should skip approvals if all spenders have sufficient allowance and enough erc20 token", async () => {
@@ -430,18 +448,19 @@ describe("Erc20 Token Fee Utilities", () => {
       allowanceMock.resolves(1001n);
 
       const txResponse = await contractCallWithFees(params);
-      const { txHash, receipt } = txResponse as TransactionResponse;
-      expect(allowanceMock.calledTwice).to.be.true;
-      expect(
-        allowanceMock.firstCall.calledWith(TEST_WALLET_ADDRESS, params.tokenSpenders[0].address),
-      ).to.be.true;
-
-      expect(
-        allowanceMock.secondCall.calledWith(TEST_WALLET_ADDRESS, params.tokenSpenders[1].address),
-      ).to.be.true;
-      expect(contractCallMock.calledOnce).to.be.true;
-      expect(approveMock.notCalled).to.be.true;
-      expect(txHash).not.to.be.empty;
+      const { txHash: result } = txResponse;
+      expect(allowanceMock.callCount).equals(2);
+      expect(allowanceMock.firstCall.args).to.deep.eq([
+        TEST_WALLET_ADDRESS,
+        params.tokenSpenders[0].address,
+      ]);
+      expect(allowanceMock.secondCall.args).to.deep.eq([
+        TEST_WALLET_ADDRESS,
+        params.tokenSpenders[1].address,
+      ]);
+      expect(contractCallMock.callCount).equals(1);
+      expect(approveMock.callCount).equals(0);
+      expect(result).to.be.a("string");
     });
 
     it("should call separate approvals for each spender address if not enough allowance and enough erc20 token", async () => {
@@ -465,13 +484,12 @@ describe("Erc20 Token Fee Utilities", () => {
       });
       allowanceMock.resolves(15n);
       const txResponse = await contractCallWithFees(params);
-      const { txHash, receipt } = txResponse as TransactionResponse;
-      expect(receipt).not.to.be.undefined;
-      expect(contractCallMock.calledOnce).to.be.true;
-      expect(approveMock.calledTwice).to.be.true;
-      expect(approveMock.firstCall.calledWith(royaltyModuleAddress[aeneid], maxUint256)).to.be.true;
-      expect(rpcWaitForTxMock.callCount).to.equal(3); // 2 approval + 1 contract call
-      expect(txHash).not.to.be.empty;
+      const { txHash: result } = txResponse;
+      expect(contractCallMock.callCount).equals(1);
+      expect(approveMock.callCount).equals(2);
+      expect(approveMock.firstCall.args).to.deep.eq([royaltyModuleAddress[aeneid], maxUint256]);
+      expect(rpcWaitForTxMock.callCount).equals(3); // 2 approval + 1 contract call
+      expect(result).to.be.a("string");
     });
 
     it("should throw not enough erc20 token when call contractCallWithFees given erc20 token is not enough", async () => {

--- a/packages/core-sdk/test/unit/utils/getFunctionSignature.test.ts
+++ b/packages/core-sdk/test/unit/utils/getFunctionSignature.test.ts
@@ -3,7 +3,6 @@ import { expect } from "chai";
 import { coreMetadataModuleAbi, groupingWorkflowsAbi } from "../../../src/abi/generated";
 import { getFunctionSignature } from "../../../src/utils/getFunctionSignature";
 
-
 describe("Test getFunctionSignature", () => {
   it("should return function signature", () => {
     const signature = getFunctionSignature(coreMetadataModuleAbi, "setAll");

--- a/packages/core-sdk/test/unit/utils/getFunctionSignature.test.ts
+++ b/packages/core-sdk/test/unit/utils/getFunctionSignature.test.ts
@@ -1,7 +1,8 @@
+import { expect } from "chai";
+
 import { coreMetadataModuleAbi, groupingWorkflowsAbi } from "../../../src/abi/generated";
 import { getFunctionSignature } from "../../../src/utils/getFunctionSignature";
 
-import { expect } from "chai";
 
 describe("Test getFunctionSignature", () => {
   it("should return function signature", () => {

--- a/packages/core-sdk/test/unit/utils/ipfs.test.ts
+++ b/packages/core-sdk/test/unit/utils/ipfs.test.ts
@@ -1,5 +1,7 @@
 import { expect } from "chai";
+
 import { convertCIDtoHashIPFS, convertHashIPFStoCID } from "../../../src/utils/ipfs";
+
 describe("IPFS", () => {
   it("should return hash when call convertCIDtoHashIPFS given CID with v0", async () => {
     const result = convertCIDtoHashIPFS("QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR");

--- a/packages/core-sdk/test/unit/utils/ipfs.test.ts
+++ b/packages/core-sdk/test/unit/utils/ipfs.test.ts
@@ -3,19 +3,19 @@ import { expect } from "chai";
 import { convertCIDtoHashIPFS, convertHashIPFStoCID } from "../../../src/utils/ipfs";
 
 describe("IPFS", () => {
-  it("should return hash when call convertCIDtoHashIPFS given CID with v0", async () => {
+  it("should return hash when call convertCIDtoHashIPFS given CID with v0", () => {
     const result = convertCIDtoHashIPFS("QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR");
     expect(result).to.equal("0xc3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a");
   });
 
-  it("should return hash when call convertCIDtoHashIPFS given CID with v1", async () => {
+  it("should return hash when call convertCIDtoHashIPFS given CID with v1", () => {
     const result = convertCIDtoHashIPFS(
       "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku",
     );
     expect(result).to.equal("0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
   });
 
-  it("should return CID when call convertHashIPFStoCID given hash with v0", async () => {
+  it("should return CID when call convertHashIPFStoCID given hash with v0", () => {
     const result = convertHashIPFStoCID(
       "0xc3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a",
       "v0",
@@ -23,7 +23,7 @@ describe("IPFS", () => {
     expect(result).to.equal("QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR");
   });
 
-  it("should return CID when call convertHashIPFStoCID given hash with v1", async () => {
+  it("should return CID when call convertHashIPFStoCID given hash with v1", () => {
     const result = convertHashIPFStoCID(
       "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "v1",

--- a/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
+++ b/packages/core-sdk/test/unit/utils/licenseTermsHelper.test.ts
@@ -1,38 +1,40 @@
+import { expect, use } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { restore, SinonStub, stub } from "sinon";
 import { Hex, PublicClient, zeroAddress } from "viem";
+
+import { RoyaltyModuleReadOnlyClient } from "../../../src/abi/generated";
 import { LicenseTerms, PIL_TYPE } from "../../../src/types/resources/license";
 import {
   getLicenseTermByType,
   getRevenueShare,
   validateLicenseTerms,
 } from "../../../src/utils/licenseTermsHelper";
-import chai from "chai";
-import sinon from "sinon";
-import { createMock } from "../testUtils";
-import chaiAsPromised from "chai-as-promised";
-import { RoyaltyModuleReadOnlyClient } from "../../../src/abi/generated";
 import { mockAddress } from "../mockData";
+import { createMockPublicClient } from "../testUtils";
 
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+use(chaiAsPromised);
 
 describe("License Terms Helper", () => {
-  let isWhitelistedRoyaltyTokenStub: sinon.SinonStub;
-  let isWhitelistedRoyaltyPolicyStub: sinon.SinonStub;
+  let isWhitelistedRoyaltyTokenStub: SinonStub;
+  let isWhitelistedRoyaltyPolicyStub: SinonStub;
   beforeEach(() => {
-    isWhitelistedRoyaltyTokenStub = sinon
-      .stub(RoyaltyModuleReadOnlyClient.prototype, "isWhitelistedRoyaltyToken")
-      .resolves(true);
-    isWhitelistedRoyaltyPolicyStub = sinon
-      .stub(RoyaltyModuleReadOnlyClient.prototype, "isWhitelistedRoyaltyPolicy")
-      .resolves(true);
+    isWhitelistedRoyaltyTokenStub = stub(
+      RoyaltyModuleReadOnlyClient.prototype,
+      "isWhitelistedRoyaltyToken",
+    ).resolves(true);
+    isWhitelistedRoyaltyPolicyStub = stub(
+      RoyaltyModuleReadOnlyClient.prototype,
+      "isWhitelistedRoyaltyPolicy",
+    ).resolves(true);
   });
 
   afterEach(() => {
-    sinon.restore();
+    restore();
   });
 
   describe("getLicenseTermByType", () => {
-    it("it should return no commercial license terms when call getLicenseTermByType given NON_COMMERCIAL_REMIX", async () => {
+    it("it should return no commercial license terms when call getLicenseTermByType given NON_COMMERCIAL_REMIX", () => {
       const result = getLicenseTermByType(PIL_TYPE.NON_COMMERCIAL_REMIX);
       expect(result).to.deep.include({
         transferable: true,
@@ -56,13 +58,13 @@ describe("License Terms Helper", () => {
     });
 
     describe("Get Commercial License Terms", () => {
-      it("it should throw when call getLicenseTermByType given COMMERCIAL_USE without terms", async () => {
+      it("it should throw when call getLicenseTermByType given COMMERCIAL_USE without terms", () => {
         expect(() => getLicenseTermByType(PIL_TYPE.COMMERCIAL_USE)).to.throw(
           "DefaultMintingFee, currency are required for commercial use PIL.",
         );
       });
 
-      it("it should throw when call getLicenseTermByType given COMMERCIAL_USE without mintFee", async () => {
+      it("it should throw when call getLicenseTermByType given COMMERCIAL_USE without mintFee", () => {
         expect(() =>
           getLicenseTermByType(PIL_TYPE.COMMERCIAL_USE, {
             currency: zeroAddress,
@@ -71,7 +73,7 @@ describe("License Terms Helper", () => {
         ).to.throw("DefaultMintingFee, currency are required for commercial use PIL.");
       });
 
-      it("it should throw when call getLicenseTermByType given COMMERCIAL_USE without currency", async () => {
+      it("it should throw when call getLicenseTermByType given COMMERCIAL_USE without currency", () => {
         expect(() =>
           getLicenseTermByType(PIL_TYPE.COMMERCIAL_USE, {
             royaltyPolicyAddress: zeroAddress,
@@ -80,7 +82,7 @@ describe("License Terms Helper", () => {
         ).to.throw("DefaultMintingFee, currency are required for commercial use PIL.");
       });
 
-      it("it should return commercial license terms when call getLicenseTermByType given COMMERCIAL_USE and correct args", async () => {
+      it("it should return commercial license terms when call getLicenseTermByType given COMMERCIAL_USE and correct args", () => {
         const result = getLicenseTermByType(PIL_TYPE.COMMERCIAL_USE, {
           royaltyPolicyAddress: zeroAddress,
           defaultMintingFee: "1",
@@ -109,13 +111,13 @@ describe("License Terms Helper", () => {
     });
 
     describe("Get Commercial remix License Terms", () => {
-      it("it should throw when call getLicenseTermByType given COMMERCIAL_REMIX without terms", async () => {
+      it("it should throw when call getLicenseTermByType given COMMERCIAL_REMIX without terms", () => {
         expect(() => getLicenseTermByType(PIL_TYPE.COMMERCIAL_REMIX)).to.throw(
           "MintingFee, currency and commercialRevShare are required for commercial remix PIL.",
         );
       });
 
-      it("it should throw when call getLicenseTermByType given COMMERCIAL_REMIX without mintFee", async () => {
+      it("it should throw when call getLicenseTermByType given COMMERCIAL_REMIX without mintFee", () => {
         expect(() =>
           getLicenseTermByType(PIL_TYPE.COMMERCIAL_REMIX, {
             currency: zeroAddress,
@@ -127,7 +129,7 @@ describe("License Terms Helper", () => {
         );
       });
 
-      it("it should throw when call getLicenseTermByType given COMMERCIAL_REMIX without currency", async () => {
+      it("it should throw when call getLicenseTermByType given COMMERCIAL_REMIX without currency", () => {
         expect(() =>
           getLicenseTermByType(PIL_TYPE.COMMERCIAL_REMIX, {
             royaltyPolicyAddress: zeroAddress,
@@ -139,7 +141,7 @@ describe("License Terms Helper", () => {
         );
       });
 
-      it("it should throw when call getLicenseTermByType given COMMERCIAL_REMIX without commercialRevShare ", async () => {
+      it("it should throw when call getLicenseTermByType given COMMERCIAL_REMIX without commercialRevShare ", () => {
         expect(() =>
           getLicenseTermByType(PIL_TYPE.COMMERCIAL_REMIX, {
             royaltyPolicyAddress: "wrong" as Hex,
@@ -151,7 +153,7 @@ describe("License Terms Helper", () => {
         );
       });
 
-      it("it should return commercial license terms when call getLicenseTermByType given COMMERCIAL_REMIX and correct args", async () => {
+      it("it should return commercial license terms when call getLicenseTermByType given COMMERCIAL_REMIX and correct args", () => {
         const result = getLicenseTermByType(PIL_TYPE.COMMERCIAL_REMIX, {
           royaltyPolicyAddress: zeroAddress,
           defaultMintingFee: "1",
@@ -178,7 +180,7 @@ describe("License Terms Helper", () => {
           uri: "https://github.com/piplabs/pil-document/blob/ad67bb632a310d2557f8abcccd428e4c9c798db1/off-chain-terms/CommercialRemix.json",
         });
       });
-      it("it throw commercialRevShare error when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is less than 0 ", async () => {
+      it("it throw commercialRevShare error when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is less than 0 ", () => {
         expect(() =>
           getLicenseTermByType(PIL_TYPE.COMMERCIAL_REMIX, {
             royaltyPolicyAddress: zeroAddress,
@@ -189,7 +191,7 @@ describe("License Terms Helper", () => {
         ).to.throw(`CommercialRevShare must be between 0 and 100.`);
       });
 
-      it("it throw commercialRevShare error  when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is greater than 100", async () => {
+      it("it throw commercialRevShare error  when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is greater than 100", () => {
         expect(() =>
           getLicenseTermByType(PIL_TYPE.COMMERCIAL_REMIX, {
             royaltyPolicyAddress: zeroAddress,
@@ -200,7 +202,7 @@ describe("License Terms Helper", () => {
         ).to.throw(`CommercialRevShare must be between 0 and 100.`);
       });
 
-      it("it get commercialRevShare correct value when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is 10", async () => {
+      it("it get commercialRevShare correct value when call getLicenseTermByType given COMMERCIAL_REMIX and commercialRevShare is 10", () => {
         const result = getLicenseTermByType(PIL_TYPE.COMMERCIAL_REMIX, {
           royaltyPolicyAddress: zeroAddress,
           defaultMintingFee: "1",
@@ -214,7 +216,7 @@ describe("License Terms Helper", () => {
     });
 
     describe("Get Creative Commons Attribution License Terms", () => {
-      it("should throw error when call getLicenseTermByType given CREATIVE_COMMONS_ATTRIBUTION without currency", async () => {
+      it("should throw error when call getLicenseTermByType given CREATIVE_COMMONS_ATTRIBUTION without currency", () => {
         expect(() =>
           getLicenseTermByType(PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION, {
             royaltyPolicyAddress: mockAddress,
@@ -224,13 +226,13 @@ describe("License Terms Helper", () => {
         );
       });
 
-      it("should throw error when call getLicenseTermByType without args", async () => {
+      it("should throw error when call getLicenseTermByType without args", () => {
         expect(() => getLicenseTermByType(PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION)).to.throw(
           "royaltyPolicyAddress and currency are required for creative commons attribution PIL.",
         );
       });
 
-      it("should return creative commons attribution license terms when given correct args", async () => {
+      it("should return creative commons attribution license terms when given correct args", () => {
         const result = getLicenseTermByType(PIL_TYPE.CREATIVE_COMMONS_ATTRIBUTION, {
           royaltyPolicyAddress: mockAddress,
           currency: mockAddress,
@@ -261,7 +263,7 @@ describe("License Terms Helper", () => {
   describe("validateLicenseTerms", () => {
     let rpcMock: PublicClient;
     beforeEach(() => {
-      rpcMock = createMock<PublicClient>();
+      rpcMock = createMockPublicClient();
     });
     const licenseTerms: LicenseTerms = {
       defaultMintingFee: 1513n,
@@ -540,21 +542,21 @@ describe("License Terms Helper", () => {
   });
 
   describe("getRevenueShare", () => {
-    it("should throw error when call getRevenueShare given revShare is not a number", async () => {
+    it("should throw error when call getRevenueShare given revShare is not a number", () => {
       expect(() => getRevenueShare("not a number")).to.throw(
         "CommercialRevShare must be a valid number.",
       );
     });
 
-    it("should throw error when call getRevenueShare given revShare is less than 0", async () => {
+    it("should throw error when call getRevenueShare given revShare is less than 0", () => {
       expect(() => getRevenueShare(-1)).to.throw("CommercialRevShare must be between 0 and 100.");
     });
 
-    it("should throw error when call getRevenueShare given revShare is greater than 100", async () => {
+    it("should throw error when call getRevenueShare given revShare is greater than 100", () => {
       expect(() => getRevenueShare(101)).to.throw("CommercialRevShare must be between 0 and 100.");
     });
 
-    it("should return correct value when call getRevenueShare given revShare is 10", async () => {
+    it("should return correct value when call getRevenueShare given revShare is 10", () => {
       expect(getRevenueShare(10)).to.equal(10000000);
     });
   });

--- a/packages/core-sdk/test/unit/utils/sign.test.ts
+++ b/packages/core-sdk/test/unit/utils/sign.test.ts
@@ -1,9 +1,10 @@
 import { expect } from "chai";
-import { getDeadline, getPermissionSignature } from "../../../src/utils/sign";
-import { Hex, WalletClient, createWalletClient, http, zeroAddress } from "viem";
+import { createWalletClient, Hex, http, WalletClient, zeroAddress } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { aeneid } from "../../integration/utils/util";
+
+import { getDeadline, getPermissionSignature } from "../../../src/utils/sign";
 import { chainStringToViemChain } from "../../../src/utils/utils";
+import { aeneid } from "../../integration/utils/util";
 
 describe("Sign", () => {
   describe("Get Permission Signature", () => {
@@ -63,8 +64,8 @@ describe("Sign", () => {
         wallet: walletClient,
         chainId: aeneid,
       });
-      expect(result.signature).is.a("string").and.not.empty;
-      expect(result.nonce).is.a("string").and.not.empty;
+      expect(result.signature).to.be.a("string");
+      expect(result.nonce).to.be.a("string");
     });
 
     it("should return signature when call getPermissionSignature given account support signTypedData and multiple permissions", async () => {
@@ -90,8 +91,8 @@ describe("Sign", () => {
         wallet: walletClient,
         chainId: aeneid,
       });
-      expect(result.signature).is.a("string").and.not.empty;
-      expect(result.nonce).is.a("string").and.not.empty;
+      expect(result.signature).to.be.a("string");
+      expect(result.nonce).to.be.a("string");
     });
   });
   describe("Get Deadline", () => {

--- a/packages/core-sdk/test/unit/utils/utils.test.ts
+++ b/packages/core-sdk/test/unit/utils/utils.test.ts
@@ -1,29 +1,26 @@
 import { expect } from "chai";
-import sinon from "sinon";
+import { stub } from "sinon";
 import * as viem from "viem";
+
+import { aeneid, mainnet } from "../../../src";
+import { licensingModuleAbi } from "../../../src/abi/generated";
 import { SupportedChainIds } from "../../../src/types/config";
 import {
-  waitTxAndFilterLog,
   chainStringToViemChain,
-  waitTx,
   validateAddress,
   validateAddresses,
+  waitTx,
+  waitTxAndFilterLog,
 } from "../../../src/utils/utils";
-import { createMock } from "../testUtils";
-import { licensingModuleAbi } from "../../../src/abi/generated";
-import { aeneid, mainnet } from "../../../src";
 import { mockAddress } from "../mockData";
+import { createMockPublicClient } from "../testUtils";
 
 describe("Test waitTxAndFilterLog", () => {
   const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
-  let rpcMock: viem.PublicClient = createMock<viem.PublicClient>();
-  afterEach(() => {
-    sinon.restore();
-  });
+  const rpcMock = createMockPublicClient();
+
   it("should throw waitForTransactionReceipt if waitForTransactionReceipt throws an error", async () => {
-    rpcMock.waitForTransactionReceipt = sinon
-      .stub()
-      .throws(new Error("waitForTransactionReceipt error"));
+    rpcMock.waitForTransactionReceipt = stub().throws(new Error("waitForTransactionReceipt error"));
     const params = {
       abi: licensingModuleAbi as viem.Abi,
       eventName: "TransferSingle",
@@ -36,7 +33,7 @@ describe("Test waitTxAndFilterLog", () => {
   });
 
   it("should throw not found event error if decodeEventLog throws an error", async () => {
-    rpcMock.waitForTransactionReceipt = sinon.stub().resolves({
+    rpcMock.waitForTransactionReceipt = stub().resolves({
       logs: [
         {
           type: "event",
@@ -52,7 +49,7 @@ describe("Test waitTxAndFilterLog", () => {
         },
       ],
     });
-    sinon.stub(viem, "decodeEventLog").throws(new Error("decodeEventLog error"));
+    stub(viem, "decodeEventLog").throws(new Error("decodeEventLog error"));
 
     const params = {
       from: "0x0000000000000000000000000000000000000001" as `0x${string}`,
@@ -69,7 +66,7 @@ describe("Test waitTxAndFilterLog", () => {
   });
 
   it("should not throw error if param.from exists and addresses in logs are same with params.address", async () => {
-    rpcMock.waitForTransactionReceipt = sinon.stub().resolves({
+    rpcMock.waitForTransactionReceipt = stub().resolves({
       logs: [
         {
           address: "0x176d33cc80ed3390256033bbf7fd651c9c5a364f",
@@ -177,8 +174,8 @@ describe("Test chainStringToViemChain", () => {
 describe("Test waitTx", () => {
   it("should return txHash when call waitTx", async () => {
     const txHash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997";
-    let rpcMock: viem.PublicClient = createMock<viem.PublicClient>();
-    const spyWaitForTransactionReceipt = sinon.spy();
+    const rpcMock = createMockPublicClient();
+    const spyWaitForTransactionReceipt = stub();
     rpcMock.waitForTransactionReceipt = spyWaitForTransactionReceipt;
 
     await waitTx(rpcMock, txHash);

--- a/packages/core-sdk/test/unit/utils/validateLicenseConfig.test.ts
+++ b/packages/core-sdk/test/unit/utils/validateLicenseConfig.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { zeroAddress, zeroHash } from "viem";
+
 import { validateLicenseConfig } from "../../../src/utils/validateLicenseConfig";
 
 describe("validateLicenseConfig", () => {


### PR DESCRIPTION
## Description
- Fix lint issue in the unit tests
- Create `createMockPublicClient` and `createMockWalletClient` methods
- Open ESLint, run tests

## Related Issue
#558


## Notes

I created two PRs to fix lint issues between unit tests and integration tests:
- Fix unit tests lint issue #563
- Fix integration tests #569 

Due to the big changes, I created two PRs to track. Once the two PRs are approved, I will merge #569 into this PR to ensure everything is good and merge it into main.