### PR TITLE
chore: bump version to 1.3.3

### DIFF
--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-protocol/core-sdk",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Story Protocol Core SDK",
   "main": "dist/story-protocol-core-sdk.cjs.js",
   "module": "dist/story-protocol-core-sdk.esm.js",


### PR DESCRIPTION
## Description

### Version Bump: 1.3.2 → 1.3.3

This PR introduces a patch version increment for the `@story-protocol/core-sdk` package.

#### What Changed
- **Package:** `@story-protocol/core-sdk`
- **Previous Version:** `1.3.2`
- **New Version:** `1.3.3`
- **Change Type:** Patch (backward compatible)

#### Files Modified
- `packages/core-sdk/package.json` - Version number update