### PR TITLE
Fix commercialRevShare re-transfer

### DIFF
--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -527,12 +527,6 @@ export class IPAssetClient {
     request: MintAndRegisterIpAssetWithPilTermsRequest,
   ): Promise<MintAndRegisterIpAssetWithPilTermsResponse> {
     try {
-      const { licenseTerms } = await validateLicenseTermsData(
-        request.licenseTermsData,
-        this.rpcClient,
-        this.chainId,
-      );
-
       const { transformRequest } =
         await transformRegistrationRequest<LicenseAttachmentWorkflowsMintAndRegisterIpAndAttachPilTermsRequest>(
           {
@@ -564,7 +558,9 @@ export class IPAssetClient {
         contractCall,
         txOptions: request.txOptions,
       });
-      const computedLicenseTermsIds = await this.getLicenseTermsId(licenseTerms);
+      const computedLicenseTermsIds = await this.getLicenseTermsId(
+        transformRequest.licenseTermsData.map((data) => data.terms),
+      );
       const maxLicenseTokensTxHashes = await this.setMaxLicenseTokens({
         maxLicenseTokensData: request.licenseTermsData,
         licensorIpId: rsp.ipId!,

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -560,6 +560,7 @@ export class LicenseClient {
     licenseTerms: LicenseTerms,
     txOptions?: TxOptions,
   ): Promise<RegisterPILResponse> {
+    licenseTerms.commercialRevShare = getRevenueShare(licenseTerms.commercialRevShare);
     if (txOptions?.encodedTxDataOnly) {
       return {
         encodedTxData: this.licenseTemplateClient.registerLicenseTermsEncode({

--- a/packages/core-sdk/src/utils/pilFlavor.ts
+++ b/packages/core-sdk/src/utils/pilFlavor.ts
@@ -1,7 +1,7 @@
 import { zeroAddress } from "viem";
 
 import { PILFlavorError } from "./errors";
-import { getRevenueShare, royaltyPolicyInputToAddress } from "./royalty";
+import { royaltyPolicyInputToAddress } from "./royalty";
 import { SupportedChainIds } from "../types/config";
 import { LicenseTerms, LicenseTermsInput } from "../types/resources/license";
 import {
@@ -218,10 +218,6 @@ export class PILFlavor {
     // Validate commercial use and derivatives
     this.verifyCommercialUse(normalized);
     this.verifyDerivatives(normalized);
-
-    // Validate and normalize commercialRevShare
-    normalized.commercialRevShare = getRevenueShare(normalized.commercialRevShare);
-
     return normalized;
   };
 

--- a/packages/core-sdk/src/utils/pilFlavor.ts
+++ b/packages/core-sdk/src/utils/pilFlavor.ts
@@ -218,6 +218,10 @@ export class PILFlavor {
     // Validate commercial use and derivatives
     this.verifyCommercialUse(normalized);
     this.verifyDerivatives(normalized);
+
+    if (normalized.commercialRevShare > 100 || normalized.commercialRevShare < 0) {
+      throw new PILFlavorError("commercialRevShare must be between 0 and 100.");
+    }
     return normalized;
   };
 

--- a/packages/core-sdk/src/utils/registrationUtils/registerValidation.ts
+++ b/packages/core-sdk/src/utils/registrationUtils/registerValidation.ts
@@ -51,6 +51,7 @@ export const validateLicenseTermsData = async (
   const maxLicenseTokens: bigint[] = [];
   for (let i = 0; i < licenseTermsData.length; i++) {
     const licenseTerm = PILFlavor.validateLicenseTerms(licenseTermsData[i].terms, chainId);
+    licenseTerm.commercialRevShare = getRevenueShare(licenseTerm.commercialRevShare);
     const royaltyModuleReadOnlyClient = new RoyaltyModuleReadOnlyClient(rpcClient);
     if (validateAddress(licenseTerm.royaltyPolicy) !== zeroAddress) {
       const isWhitelistedArbitrationPolicy =

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -2,7 +2,12 @@ import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Address, Hex, maxUint256, toHex, zeroAddress, zeroHash } from "viem";
 
-import { IpRegistrationWorkflowRequest, PILFlavor, StoryClient } from "../../src";
+import {
+  IpRegistrationWorkflowRequest,
+  NativeRoyaltyPolicy,
+  PILFlavor,
+  StoryClient,
+} from "../../src";
 import { getDerivedStoryClient } from "./utils/BIP32";
 import {
   aeneid,
@@ -2229,25 +2234,18 @@ describe("IP Asset Functions", () => {
               maxLicenseTokens: 1000n,
             },
             {
-              terms: {
-                transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
-                defaultMintingFee: 3n,
-                expiration: 0n,
-                commercialUse: true,
-                commercialAttribution: false,
-                commercializerChecker: zeroAddress,
-                commercializerCheckerData: zeroAddress,
-                commercialRevShare: 90,
-                commercialRevCeiling: 0n,
-                derivativesAllowed: true,
-                derivativesAttribution: true,
-                derivativesApproval: false,
-                derivativesReciprocal: true,
-                derivativeRevCeiling: 0n,
+              terms: PILFlavor.commercialUse({
                 currency: WIP_TOKEN_ADDRESS,
-                uri: "",
-              },
+                royaltyPolicy: NativeRoyaltyPolicy.LAP,
+                defaultMintingFee: 3n,
+                override: {
+                  commercialRevShare: 90,
+                  derivativesAllowed: true,
+                  derivativesAttribution: true,
+                  derivativesReciprocal: true,
+                  commercialAttribution: false,
+                },
+              }),
               licensingConfig: {
                 isSet: true,
                 mintingFee: 3n,
@@ -2272,25 +2270,18 @@ describe("IP Asset Functions", () => {
           allowDuplicates: true,
           licenseTermsData: [
             {
-              terms: {
-                transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
-                defaultMintingFee: 0n,
-                expiration: 0n,
-                commercialUse: true,
-                commercialAttribution: false,
-                commercializerChecker: zeroAddress,
-                commercializerCheckerData: zeroAddress,
-                commercialRevShare: 90,
-                commercialRevCeiling: 0n,
-                derivativesAllowed: true,
-                derivativesAttribution: true,
-                derivativesApproval: false,
-                derivativesReciprocal: true,
-                derivativeRevCeiling: 0n,
+              terms: PILFlavor.commercialRemix({
                 currency: WIP_TOKEN_ADDRESS,
-                uri: "",
-              },
+                royaltyPolicy: NativeRoyaltyPolicy.LAP,
+                defaultMintingFee: 0n,
+                commercialRevShare: 90,
+                override: {
+                  derivativesAllowed: true,
+                  derivativesAttribution: true,
+                  derivativesReciprocal: true,
+                  commercialAttribution: false,
+                },
+              }),
               licensingConfig: {
                 isSet: true,
                 mintingFee: 0n,
@@ -2379,25 +2370,17 @@ describe("IP Asset Functions", () => {
               maxLicenseTokens: 80n,
             },
             {
-              terms: {
-                transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
-                defaultMintingFee: 100n,
-                expiration: 1000n,
-                commercialUse: true,
-                commercialAttribution: false,
-                commercializerChecker: zeroAddress,
-                commercializerCheckerData: zeroAddress,
-                commercialRevShare: 0,
-                commercialRevCeiling: 0n,
-                derivativesAllowed: true,
-                derivativesAttribution: true,
-                derivativesApproval: false,
-                derivativesReciprocal: true,
-                derivativeRevCeiling: 0n,
+              terms: PILFlavor.commercialRemix({
                 currency: WIP_TOKEN_ADDRESS,
-                uri: "test case",
-              },
+                royaltyPolicy: NativeRoyaltyPolicy.LAP,
+                defaultMintingFee: 100n,
+                commercialRevShare: 0,
+                override: {
+                  derivativesReciprocal: true,
+                  commercialAttribution: false,
+                  expiration: 1000n,
+                },
+              }),
               maxLicenseTokens: 10n,
             },
           ],
@@ -2417,25 +2400,13 @@ describe("IP Asset Functions", () => {
           spgNftContract: spgNftContractWithPrivateMinting,
           licenseTermsData: [
             {
-              terms: {
-                transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
-                defaultMintingFee: 10000n,
-                expiration: 1000n,
-                commercialUse: true,
-                commercialAttribution: false,
-                commercializerChecker: zeroAddress,
-                commercializerCheckerData: zeroAddress,
-                commercialRevShare: 0,
-                commercialRevCeiling: 0n,
-                derivativesAllowed: true,
-                derivativesAttribution: true,
-                derivativesApproval: false,
-                derivativesReciprocal: true,
-                derivativeRevCeiling: 0n,
+              terms: PILFlavor.creativeCommonsAttribution({
                 currency: WIP_TOKEN_ADDRESS,
-                uri: "test case",
-              },
+                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
+                override: {
+                  defaultMintingFee: 10000n,
+                },
+              }),
             },
           ],
           royaltyShares: [
@@ -2581,25 +2552,12 @@ describe("IP Asset Functions", () => {
           deadline: 1000n,
           licenseTermsData: [
             {
-              terms: {
-                transferable: true,
-                royaltyPolicy: zeroAddress,
-                defaultMintingFee: 0n,
-                expiration: 0n,
-                commercialUse: false,
-                commercialAttribution: false,
-                commercializerChecker: zeroAddress,
-                commercializerCheckerData: zeroAddress,
-                commercialRevShare: 0,
-                commercialRevCeiling: 0n,
-                derivativesAllowed: true,
-                derivativesAttribution: true,
-                derivativesApproval: false,
-                derivativesReciprocal: true,
-                derivativeRevCeiling: 0n,
+              terms: PILFlavor.commercialRemix({
                 currency: WIP_TOKEN_ADDRESS,
-                uri: "",
-              },
+                royaltyPolicy: NativeRoyaltyPolicy.LAP,
+                defaultMintingFee: 0n,
+                commercialRevShare: 100,
+              }),
               licensingConfig: {
                 isSet: true,
                 mintingFee: 0n,
@@ -2689,25 +2647,10 @@ describe("IP Asset Functions", () => {
               maxLicenseTokens: 10n,
             },
             {
-              terms: {
-                transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
-                defaultMintingFee: 0n,
-                expiration: 1000n,
-                commercialUse: true,
-                commercialAttribution: false,
-                commercializerChecker: zeroAddress,
-                commercializerCheckerData: zeroAddress,
-                commercialRevShare: 0,
-                commercialRevCeiling: 0n,
-                derivativesAllowed: true,
-                derivativesAttribution: true,
-                derivativesApproval: false,
-                derivativesReciprocal: true,
-                derivativeRevCeiling: 0n,
+              terms: PILFlavor.creativeCommonsAttribution({
                 currency: erc20Address[aeneid],
-                uri: "test case",
-              },
+                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
+              }),
               licensingConfig: {
                 isSet: true,
                 mintingFee: 6n,
@@ -3042,25 +2985,12 @@ describe("IP Asset Functions", () => {
           deadline: 1000n,
           licenseTermsData: [
             {
-              terms: {
-                transferable: true,
-                royaltyPolicy: zeroAddress,
-                defaultMintingFee: 0n,
-                expiration: 0n,
-                commercialUse: false,
-                commercialAttribution: false,
-                commercializerChecker: zeroAddress,
-                commercializerCheckerData: zeroAddress,
-                commercialRevShare: 0,
-                commercialRevCeiling: 0n,
-                derivativesAllowed: true,
-                derivativesAttribution: true,
-                derivativesApproval: false,
-                derivativesReciprocal: true,
-                derivativeRevCeiling: 0n,
+              terms: PILFlavor.commercialRemix({
                 currency: WIP_TOKEN_ADDRESS,
-                uri: "",
-              },
+                royaltyPolicy: NativeRoyaltyPolicy.LAP,
+                defaultMintingFee: 0n,
+                commercialRevShare: 100,
+              }),
               licensingConfig: {
                 isSet: true,
                 mintingFee: 0n,

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -381,25 +381,10 @@ describe("IP Asset Functions", () => {
             },
           },
           {
-            terms: {
-              transferable: true,
-              royaltyPolicy: royaltyPolicyLapAddress[aeneid],
+            terms: PILFlavor.commercialUse({
               defaultMintingFee: 10000n,
-              expiration: 1000n,
-              commercialUse: true,
-              commercialAttribution: false,
-              commercializerChecker: zeroAddress,
-              commercializerCheckerData: zeroAddress,
-              commercialRevShare: 0,
-              commercialRevCeiling: 0n,
-              derivativesAllowed: true,
-              derivativesAttribution: true,
-              derivativesApproval: false,
-              derivativesReciprocal: true,
-              derivativeRevCeiling: 0n,
               currency: WIP_TOKEN_ADDRESS,
-              uri: "test case",
-            },
+            }),
             licensingConfig: {
               isSet: true,
               mintingFee: 10000n,

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -547,11 +547,14 @@ describe("IP Asset Functions", () => {
               expectGroupRewardPool: zeroAddress,
             },
           },
+          {
+            terms: PILFlavor.nonCommercialSocialRemixing(),
+          },
         ],
         deadline: 1000n,
       });
       expect(result.txHash).to.be.a("string");
-      expect(result.licenseTermsIds).to.be.an("array");
+      expect(result.licenseTermsIds?.length).to.be.equal(2);
       expect(result.maxLicenseTokensTxHashes).to.be.an("undefined");
     });
     it("should register PIL terms and attach with license terms max limit", async () => {

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -763,6 +763,13 @@ describe("IP Asset Functions", () => {
                 expectGroupRewardPool: zeroAddress,
               },
             },
+            {
+              terms: PILFlavor.creativeCommonsAttribution({
+                currency: WIP_TOKEN_ADDRESS,
+                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
+              }),
+              maxLicenseTokens: 10,
+            },
           ],
           ipMetadata: {
             ipMetadataURI: "test-uri",
@@ -777,12 +784,11 @@ describe("IP Asset Functions", () => {
           ],
         },
       );
-
       expect(result.registerIpAndAttachPilTermsAndDeployRoyaltyVaultTxHash).to.be.a("string");
       expect(result.distributeRoyaltyTokensTxHash).to.be.a("string");
       expect(result.ipId).to.be.a("string");
-      expect(result.licenseTermsIds).to.be.an("array");
-      expect(result.maxLicenseTokensTxHashes).to.be.an("undefined");
+      expect(result.licenseTermsIds?.length).to.be.equal(2);
+      expect(result.maxLicenseTokensTxHashes?.length).to.be.equal(1);
     });
 
     it("should register IP and attach license terms and distribute royalty tokens with license terms max limit", async () => {

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -2,7 +2,7 @@ import { expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Address, Hex, maxUint256, toHex, zeroAddress, zeroHash } from "viem";
 
-import { IpRegistrationWorkflowRequest, StoryClient } from "../../src";
+import { IpRegistrationWorkflowRequest, PILFlavor, StoryClient } from "../../src";
 import { getDerivedStoryClient } from "./utils/BIP32";
 import {
   aeneid,
@@ -1432,12 +1432,21 @@ describe("IP Asset Functions", () => {
               expectGroupRewardPool: pool,
             },
           },
+          {
+            terms: PILFlavor.commercialRemix({
+              defaultMintingFee: 6n,
+              currency: WIP_TOKEN_ADDRESS,
+              commercialRevShare: 90,
+            }),
+            maxLicenseTokens: 100,
+          },
         ],
       });
       expect(result.ipId).to.be.a("string");
       expect(result.tokenId).to.be.a("bigint");
       expect(result.txHash).to.be.a("string");
-      expect(result.maxLicenseTokensTxHashes).to.be.an("undefined");
+      expect(result.maxLicenseTokensTxHashes).to.be.an("array");
+      expect(result.licenseTermsIds?.length).to.be.equal(2);
       parentIpId = result.ipId!;
       licenseTermsId = result.licenseTermsIds![0];
     });
@@ -1815,25 +1824,11 @@ describe("IP Asset Functions", () => {
                 maxLicenseTokens: 100,
               },
               {
-                terms: {
-                  transferable: true,
-                  royaltyPolicy: royaltyPolicyLapAddress[aeneid],
-                  defaultMintingFee: 80n,
-                  expiration: 0n,
-                  commercialUse: true,
-                  commercialAttribution: false,
-                  commercializerChecker: zeroAddress,
-                  commercializerCheckerData: zeroAddress,
-                  commercialRevShare: 0,
-                  commercialRevCeiling: 0n,
-                  derivativesAllowed: true,
-                  derivativesAttribution: true,
-                  derivativesApproval: false,
-                  derivativesReciprocal: true,
-                  derivativeRevCeiling: 0n,
+                terms: PILFlavor.commercialRemix({
+                  defaultMintingFee: 100n,
+                  commercialRevShare: 10,
                   currency: WIP_TOKEN_ADDRESS,
-                  uri: "",
-                },
+                }),
                 licensingConfig: {
                   isSet: true,
                   mintingFee: 100n,

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -1094,25 +1094,10 @@ describe("IP Asset Functions", () => {
               },
             },
             {
-              terms: {
-                transferable: true,
-                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
-                defaultMintingFee: 10000n,
-                expiration: 1000n,
-                commercialUse: true,
-                commercialAttribution: false,
-                commercializerChecker: zeroAddress,
-                commercializerCheckerData: zeroAddress,
-                commercialRevShare: 0,
-                commercialRevCeiling: 0n,
-                derivativesAllowed: true,
-                derivativesAttribution: true,
-                derivativesApproval: false,
-                derivativesReciprocal: true,
-                derivativeRevCeiling: 0n,
+              terms: PILFlavor.creativeCommonsAttribution({
                 currency: WIP_TOKEN_ADDRESS,
-                uri: "test case",
-              },
+                royaltyPolicy: royaltyPolicyLapAddress[aeneid],
+              }),
             },
             {
               terms: {
@@ -1156,7 +1141,7 @@ describe("IP Asset Functions", () => {
 
       expect(result.txHash).to.be.a("string");
       expect(result.ipId).to.be.a("string");
-      expect(result.licenseTermsIds).to.be.an("array");
+      expect(result.licenseTermsIds?.length).to.be.equal(3);
       expect(result.maxLicenseTokensTxHashes).to.be.an("array");
       expect(result.maxLicenseTokensTxHashes?.length).to.be.equal(1);
     });

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -1930,6 +1930,26 @@ describe("Test IpAssetClient", () => {
         expectGroupRewardPool: zeroAddress,
       });
     });
+
+    it.only("should be called with expected values given PILFlavor.nonCommercialSocialRemixing", async () => {
+      const registerPilTermsAndAttachStub = stub(
+        ipAssetClient.licenseAttachmentWorkflowsClient,
+        "registerPilTermsAndAttach",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+
+      await ipAssetClient.registerPilTermsAndAttach({
+        ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        licenseTermsData: [
+          {
+            terms: PILFlavor.nonCommercialSocialRemixing(),
+          },
+        ],
+      });
+      expect(registerPilTermsAndAttachStub.args[0][0].licenseTermsData[0].terms).to.deep.equal(
+        PILFlavor.nonCommercialSocialRemixing(),
+      );
+    });
   });
 
   describe("Test ipAssetClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens", () => {

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -3010,7 +3010,7 @@ describe("Test IpAssetClient", () => {
       });
     });
 
-    it.only("should be called with expected values given PILFlavor.creativeCommonsAttribution", async () => {
+    it("should be called with expected values given PILFlavor.creativeCommonsAttribution", async () => {
       stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
 
       stub(IpAssetRegistryClient.prototype, "ipId").resolves(
@@ -3703,6 +3703,67 @@ describe("Test IpAssetClient", () => {
       expect(
         mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub.args[0][0].recipient,
       ).to.equal(walletAddress);
+    });
+    it("should call with expected license terms with PILFlavor.creativeCommonsAttribution", async () => {
+      const mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub = stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens",
+      ).resolves(txHash);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+        {
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          chainId: 0n,
+          tokenContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          tokenId: 0n,
+          name: "",
+          uri: "",
+          registrationDate: 0n,
+        },
+      ]);
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+      await ipAssetClient.mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens({
+        spgNftContract,
+        licenseTermsData: [
+          {
+            terms: PILFlavor.creativeCommonsAttribution({
+              currency: mockAddress,
+              royaltyPolicy: mockAddress,
+            }),
+          },
+        ],
+        royaltyShares: [
+          { recipient: "0x73fcb515cee99e4991465ef586cfe2b072ebb512", percentage: 100 },
+        ],
+      });
+
+      expect(
+        mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokensStub.args[0][0]
+          .licenseTermsData[0].terms,
+      ).to.deep.equal({
+        commercialUse: true,
+        commercialAttribution: true,
+        commercializerChecker: zeroAddress,
+        commercializerCheckerData: zeroAddress,
+        commercialRevShare: 0,
+        commercialRevCeiling: 0n,
+        derivativesAllowed: true,
+        derivativesAttribution: true,
+        derivativesApproval: false,
+        derivativesReciprocal: true,
+        derivativeRevCeiling: 0n,
+        currency: mockAddress,
+        uri: "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/CC-BY.json",
+        defaultMintingFee: 0n,
+        expiration: 0n,
+        royaltyPolicy: mockAddress,
+        transferable: true,
+      });
     });
   });
 

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -1931,7 +1931,7 @@ describe("Test IpAssetClient", () => {
       });
     });
 
-    it.only("should be called with expected values given PILFlavor.nonCommercialSocialRemixing", async () => {
+    it("should be called with expected values given PILFlavor.nonCommercialSocialRemixing", async () => {
       const registerPilTermsAndAttachStub = stub(
         ipAssetClient.licenseAttachmentWorkflowsClient,
         "registerPilTermsAndAttach",
@@ -3007,6 +3007,89 @@ describe("Test IpAssetClient", () => {
         ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         licenseTermsIds: [8n, 8n],
         ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      });
+    });
+
+    it.only("should be called with expected values given PILFlavor.creativeCommonsAttribution", async () => {
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+
+      stub(IpAssetRegistryClient.prototype, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+
+      const registerIpAndAttachPilTermsAndDeployRoyaltyVaultStub = stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "registerIpAndAttachPilTermsAndDeployRoyaltyVault",
+      ).resolves("0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997");
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+        {
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          chainId: 0n,
+          tokenContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          tokenId: 0n,
+          name: "",
+          uri: "",
+          registrationDate: 0n,
+        },
+      ]);
+
+      stub(ipAssetClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: 8n,
+      });
+
+      stub(ipAssetClient.royaltyModuleEventClient, "parseTxIpRoyaltyVaultDeployedEvent").returns([
+        {
+          ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+
+      stub(
+        ipAssetClient.royaltyTokenDistributionWorkflowsClient,
+        "distributeRoyaltyTokens",
+      ).resolves(txHash);
+
+      await ipAssetClient.registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens({
+        nftContract: spgNftContract,
+        tokenId: "1",
+        licenseTermsData: [
+          {
+            terms: PILFlavor.creativeCommonsAttribution({
+              currency: mockAddress,
+              royaltyPolicy: mockAddress,
+            }),
+          },
+        ],
+        royaltyShares: [
+          { recipient: "0x73fcb515cee99e4991465ef586cfe2b072ebb512", percentage: 100 },
+        ],
+        ipMetadata: {
+          ipMetadataURI: "",
+          ipMetadataHash: toHex(0, { size: 32 }),
+          nftMetadataHash: toHex("nftMetadata", { size: 32 }),
+          nftMetadataURI: "",
+        },
+      });
+      expect(
+        registerIpAndAttachPilTermsAndDeployRoyaltyVaultStub.args[0][0].licenseTermsData[0].terms,
+      ).to.deep.equal({
+        commercialUse: true,
+        commercialAttribution: true,
+        commercializerChecker: zeroAddress,
+        commercializerCheckerData: zeroAddress,
+        commercialRevShare: 0,
+        commercialRevCeiling: 0n,
+        derivativesAllowed: true,
+        derivativesAttribution: true,
+        derivativesApproval: false,
+        derivativesReciprocal: true,
+        derivativeRevCeiling: 0n,
+        currency: mockAddress,
+        uri: "https://github.com/piplabs/pil-document/blob/998c13e6ee1d04eb817aefd1fe16dfe8be3cd7a2/off-chain-terms/CC-BY.json",
+        defaultMintingFee: 0n,
+        expiration: 0n,
+        royaltyPolicy: mockAddress,
+        transferable: true,
       });
     });
   });

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -248,6 +248,59 @@ describe("Test LicenseClient", () => {
         (registerLicenseTermsStub.firstCall.args[0] as { terms: LicenseTerms }).terms,
       ).to.have.property("royaltyPolicy", "0x9156e603C949481883B1d3355c6f1132D191fC41");
     });
+    it("should throw error when commercialRevShare is more than 100", async () => {
+      stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: BigInt(0),
+      });
+      await expect(
+        licenseClient.registerPILTerms({
+          ...licenseTerms,
+          commercialRevShare: 101,
+        }),
+      ).to.be.rejectedWith(
+        "Failed to register license terms: commercialRevShare must be between 0 and 100.",
+      );
+    });
+    it("should throw error when commercialRevShare is less than 0", async () => {
+      stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: BigInt(0),
+      });
+      await expect(
+        licenseClient.registerPILTerms({
+          ...licenseTerms,
+          commercialRevShare: -1,
+        }),
+      ).to.be.rejectedWith(
+        "Failed to register license terms: commercialRevShare must be between 0 and 100.",
+      );
+    });
+
+    it("should transfer commercialRevShare when commercialRevShare is not normalized", async () => {
+      stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: BigInt(0),
+      });
+      const registerLicenseTermsStub = stub(
+        licenseClient.licenseTemplateClient,
+        "registerLicenseTerms",
+      ).resolves(txHash);
+
+      stub(licenseClient.licenseTemplateClient, "parseTxLicenseTermsRegisteredEvent").returns([
+        {
+          licenseTermsId: BigInt(1),
+          licenseTemplate: zeroAddress,
+          licenseTerms: zeroAddress,
+        },
+      ]);
+
+      await licenseClient.registerPILTerms({
+        ...licenseTerms,
+        commercialRevShare: 100,
+      });
+
+      expect(registerLicenseTermsStub.firstCall.args[0].terms.commercialRevShare).to.equal(
+        100 * 10 ** 6,
+      );
+    });
   });
   describe("Test licenseClient.registerNonComSocialRemixingPIL", () => {
     it("should return licenseTermsId when call registerNonComSocialRemixingPIL given licenseTermsId is registered", async () => {
@@ -316,6 +369,27 @@ describe("Test LicenseClient", () => {
         to: zeroAddress,
         data: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       });
+    });
+    it("should transfer commercialRevShare when commercialRevShare is not normalized", async () => {
+      stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: BigInt(0),
+      });
+      const registerLicenseTermsStub = stub(
+        licenseClient.licenseTemplateClient,
+        "registerLicenseTerms",
+      ).resolves(txHash);
+
+      stub(licenseClient.licenseTemplateClient, "parseTxLicenseTermsRegisteredEvent").returns([
+        {
+          licenseTermsId: BigInt(1),
+          licenseTemplate: zeroAddress,
+          licenseTerms: zeroAddress,
+        },
+      ]);
+
+      await licenseClient.registerNonComSocialRemixingPIL();
+
+      expect(registerLicenseTermsStub.firstCall.args[0].terms.commercialRevShare).to.equal(0);
     });
   });
 
@@ -398,6 +472,29 @@ describe("Test LicenseClient", () => {
         to: zeroAddress,
         data: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       });
+    });
+    it("should transfer commercialRevShare when commercialRevShare is not normalized", async () => {
+      stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: BigInt(0),
+      });
+      stub(licenseClient.licenseTemplateClient, "parseTxLicenseTermsRegisteredEvent").returns([
+        {
+          licenseTermsId: BigInt(1),
+          licenseTemplate: zeroAddress,
+          licenseTerms: zeroAddress,
+        },
+      ]);
+      const registerLicenseTermsStub = stub(
+        licenseClient.licenseTemplateClient,
+        "registerLicenseTerms",
+      ).resolves(txHash);
+
+      await licenseClient.registerCommercialUsePIL({
+        defaultMintingFee: "1",
+        currency: mockAddress,
+      });
+
+      expect(registerLicenseTermsStub.firstCall.args[0].terms.commercialRevShare).to.equal(0);
     });
   });
 
@@ -483,6 +580,59 @@ describe("Test LicenseClient", () => {
         to: zeroAddress,
         data: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       });
+    });
+
+    it("should throw error when commercialRevShare is more than 100", async () => {
+      stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: BigInt(0),
+      });
+      await expect(
+        licenseClient.registerCommercialRemixPIL({
+          defaultMintingFee: "1",
+          currency: mockAddress,
+          commercialRevShare: 101,
+        }),
+      ).to.be.rejectedWith(
+        "Failed to register commercial remix PIL: commercialRevShare must be between 0 and 100.",
+      );
+    });
+    it("should throw error when commercialRevShare is less than 0", async () => {
+      stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: BigInt(0),
+      });
+      await expect(
+        licenseClient.registerCommercialRemixPIL({
+          defaultMintingFee: "1",
+          currency: mockAddress,
+          commercialRevShare: -1,
+        }),
+      ).to.be.rejectedWith(
+        "Failed to register commercial remix PIL: commercialRevShare must be between 0 and 100.",
+      );
+    });
+    it("should transfer commercialRevShare when commercialRevShare is not normalized", async () => {
+      stub(licenseClient.licenseTemplateClient, "getLicenseTermsId").resolves({
+        selectedLicenseTermsId: BigInt(0),
+      });
+      stub(licenseClient.licenseTemplateClient, "parseTxLicenseTermsRegisteredEvent").returns([
+        {
+          licenseTermsId: BigInt(1),
+          licenseTemplate: zeroAddress,
+          licenseTerms: zeroAddress,
+        },
+      ]);
+      const registerLicenseTermsStub = stub(
+        licenseClient.licenseTemplateClient,
+        "registerLicenseTerms",
+      ).resolves(txHash);
+
+      await licenseClient.registerCommercialRemixPIL({
+        defaultMintingFee: "1",
+        commercialRevShare: 10,
+        currency: mockAddress,
+      });
+
+      expect(registerLicenseTermsStub.firstCall.args[0].terms.commercialRevShare).to.equal(10 * 10 ** 6);
     });
   });
 

--- a/packages/core-sdk/test/unit/utils/pilFlavor.test.ts
+++ b/packages/core-sdk/test/unit/utils/pilFlavor.test.ts
@@ -470,6 +470,32 @@ describe("PILFlavor", () => {
       });
     });
 
+    describe("commercialRevShare validation", () => {
+      it("should throw error when commercialRevShare is greater than 100", () => {
+        expect(() => {
+          PILFlavor.commercialUse({
+            defaultMintingFee: 0n,
+            currency: mockAddress,
+            override: {
+              commercialRevShare: 101,
+            },
+          });
+        }).to.throw("commercialRevShare must be between 0 and 100.");
+      });
+
+      it("should throw error when commercialRevShare is less than 0", () => {
+        expect(() => {
+          PILFlavor.commercialUse({
+            defaultMintingFee: 0n,
+            currency: mockAddress,
+            override: {
+              commercialRevShare: -1,
+            },
+          });
+        }).to.throw("commercialRevShare must be between 0 and 100.");
+      });
+    });
+
     describe("numeric field normalization", () => {
       it("should normalize defaultMintingFee to BigInt", () => {
         const pil = PILFlavor.commercialUse({

--- a/packages/core-sdk/test/unit/utils/pilFlavor.test.ts
+++ b/packages/core-sdk/test/unit/utils/pilFlavor.test.ts
@@ -101,7 +101,7 @@ describe("PILFlavor", () => {
       expect(pil).deep.equal({
         commercialAttribution: true,
         commercialRevCeiling: 0n,
-        commercialRevShare: 10000000,
+        commercialRevShare: 10,
         commercialUse: true,
         commercializerChecker: zeroAddress,
         commercializerCheckerData: zeroAddress,
@@ -130,7 +130,7 @@ describe("PILFlavor", () => {
       expect(pil).deep.equal({
         commercialAttribution: true,
         commercialRevCeiling: 0n,
-        commercialRevShare: 10_000_000,
+        commercialRevShare: 10,
         commercialUse: true,
         commercializerChecker: zeroAddress,
         commercializerCheckerData: zeroAddress,
@@ -165,7 +165,7 @@ describe("PILFlavor", () => {
       expect(pil).deep.equal({
         commercialAttribution: true,
         commercialRevCeiling: 0n,
-        commercialRevShare: 1_000_000,
+        commercialRevShare: 1,
         commercialUse: true,
         commercializerChecker: zeroAddress,
         commercializerCheckerData: zeroAddress,
@@ -231,7 +231,7 @@ describe("PILFlavor", () => {
         commercialAttribution: true,
         commercializerChecker: zeroAddress,
         commercializerCheckerData: zeroAddress,
-        commercialRevShare: 100_000_000,
+        commercialRevShare: 100,
         commercialRevCeiling: 0n,
         derivativesAllowed: true,
         derivativesAttribution: true,
@@ -470,74 +470,6 @@ describe("PILFlavor", () => {
       });
     });
 
-    describe("commercialRevShare validation", () => {
-      it("should throw error when commercialRevShare is negative", () => {
-        expect(() => {
-          PILFlavor.commercialRemix({
-            defaultMintingFee: 0n,
-            currency: mockAddress,
-            commercialRevShare: -1,
-          });
-        }).to.throw("commercialRevShare must be between 0 and 100.");
-      });
-
-      it("should throw error when commercialRevShare is greater than 100", () => {
-        expect(() => {
-          PILFlavor.commercialRemix({
-            defaultMintingFee: 0n,
-            currency: mockAddress,
-            commercialRevShare: 101,
-          });
-        }).to.throw("commercialRevShare must be between 0 and 100.");
-      });
-
-      it("should throw error when commercialRevShare is NaN", () => {
-        expect(() => {
-          PILFlavor.commercialRemix({
-            defaultMintingFee: 0n,
-            currency: mockAddress,
-            commercialRevShare: NaN,
-          });
-        }).to.throw("commercialRevShare must be a valid number.");
-      });
-
-      it("should convert 0% to 0 basis points", () => {
-        const pil = PILFlavor.commercialRemix({
-          defaultMintingFee: 0n,
-          currency: mockAddress,
-          commercialRevShare: 0,
-        });
-        expect(pil.commercialRevShare).to.equal(0);
-      });
-
-      it("should convert 1% to 10000 basis points", () => {
-        const pil = PILFlavor.commercialRemix({
-          defaultMintingFee: 0n,
-          currency: mockAddress,
-          commercialRevShare: 1,
-        });
-        expect(pil.commercialRevShare).to.equal(1_000_000);
-      });
-
-      it("should convert 100% to 1000000 basis points", () => {
-        const pil = PILFlavor.commercialRemix({
-          defaultMintingFee: 0n,
-          currency: mockAddress,
-          commercialRevShare: 100,
-        });
-        expect(pil.commercialRevShare).to.equal(100_000_000);
-      });
-
-      it("should round fractional percentages correctly", () => {
-        const pil = PILFlavor.commercialRemix({
-          defaultMintingFee: 0n,
-          currency: mockAddress,
-          commercialRevShare: 33.33,
-        });
-        expect(pil.commercialRevShare).to.equal(33_330_000);
-      });
-    });
-
     describe("numeric field normalization", () => {
       it("should normalize defaultMintingFee to BigInt", () => {
         const pil = PILFlavor.commercialUse({
@@ -546,7 +478,6 @@ describe("PILFlavor", () => {
         });
         expect(pil.defaultMintingFee).to.equal(100n);
       });
-
       it("should normalize expiration to BigInt", () => {
         const pil = PILFlavor.commercialUse({
           defaultMintingFee: 0n,


### PR DESCRIPTION
## Description
- Remove `getRevenueShare` utility  in `PILFlavor` and put it into the `validateLicenseTermsData` method
- Call the `getRevenueShare` method in the `registerPILTermsHelper`
- Add unit tests and integration tests in the following methods:
    1. `mintAndRegisterIpAssetWithPilTerms`
    2. `registerIpAndAttachPilTerms`
    3. `registerPilTermsAndAttach`
    4. `registerIPAndAttachLicenseTermsAndDistributeRoyaltyTokens`
    5. `mintAndRegisterIpAndAttachPilTermsAndDistributeRoyaltyTokens`
    6. `batchRegisterIpAssetsWithOptimizedWorkflows`
