### PR TITLE
feat: re-design the link Derivative method

### DIFF
--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -89,9 +89,7 @@ import {
   RegisterDerivativeIpAssetRequest,
   RegisterDerivativeIpAssetResponse,
   RegisterDerivativeRequest,
-  RegisterDerivativeResponse,
   RegisterDerivativeWithLicenseTokensRequest,
-  RegisterDerivativeWithLicenseTokensResponse,
   RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensRequest,
   RegisterIPAndAttachLicenseTermsAndDistributeRoyaltyTokensResponse,
   RegisterIpAndAttachPilTermsRequest,
@@ -357,7 +355,7 @@ export class IPAssetClient {
    */
   public async registerDerivative(
     request: RegisterDerivativeRequest,
-  ): Promise<RegisterDerivativeResponse> {
+  ): Promise<LinkDerivativeResponse> {
     try {
       const isChildIpIdRegistered = await this.isRegistered(request.childIpId);
       if (!isChildIpIdRegistered) {
@@ -489,7 +487,7 @@ export class IPAssetClient {
    */
   public async registerDerivativeWithLicenseTokens(
     request: RegisterDerivativeWithLicenseTokensRequest,
-  ): Promise<RegisterDerivativeWithLicenseTokensResponse> {
+  ): Promise<LinkDerivativeResponse> {
     try {
       const req = {
         childIpId: validateAddress(request.childIpId),
@@ -1968,10 +1966,10 @@ export class IPAssetClient {
   }
 
   /**
-   * Links a derivative IP asset by either registering an existing IP as derivative or registering a new IP and making it derivative.
+   * Link a derivative IP asset using parent IP's license terms or license tokens.
    *
    * Supports the following workflows:
-   * - {@link registerDerivativeIp}
+   * - {@link registerDerivative}
    * - {@link registerDerivativeWithLicenseTokens}
    *
    * @example
@@ -1986,9 +1984,10 @@ export class IPAssetClient {
    * @example
    * ```typescript
    * const result = await client.ipAsset.linkDerivative({
-   *   nftContract: "0x...",
-   *   tokenId: 1n,
-   *   derivData: { parentIpIds: ["0x..."], licenseTermsIds: [1n], maxRts: 100 },
+   *   parentIpIds: ["0x..."],
+   *   licenseTermsIds: [1],
+   *   maxRts: 100,
+   *   childIpId: "0x...",
    * });
    * ```
    *
@@ -1997,12 +1996,12 @@ export class IPAssetClient {
    * - It checks allowances for all required spenders and automatically approves them if their current allowance is lower than needed.
    * - These automatic processes can be configured through the `wipOptions` parameter to control behavior like multicall usage and approval settings.
    */
-  public async linkDerivative<
-    T extends RegisterDerivativeWithLicenseTokensRequest | RegisterIpAndMakeDerivativeRequest,
-  >(request: T): Promise<LinkDerivativeResponse<T>> {
+  public async linkDerivative(
+    request: RegisterDerivativeWithLicenseTokensRequest | RegisterDerivativeRequest,
+  ): Promise<LinkDerivativeResponse> {
     try {
-      if ("derivData" in request) {
-        return this.registerDerivativeIp(request);
+      if ("parentIpIds" in request) {
+        return this.registerDerivative(request);
       } else {
         return this.registerDerivativeWithLicenseTokens(request);
       }

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -71,6 +71,7 @@ import {
   DistributeRoyaltyTokens,
   ExtraData,
   IpIdAndTokenId,
+  LinkDerivativeResponse,
   MintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokensRequest,
   MintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokensResponse,
   MintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokensRequest,
@@ -1966,6 +1967,49 @@ export class IPAssetClient {
     });
   }
 
+  /**
+   * Links a derivative IP asset by either registering an existing IP as derivative or registering a new IP and making it derivative.
+   *
+   * Supports the following workflows:
+   * - {@link registerDerivativeIp}
+   * - {@link registerDerivativeWithLicenseTokens}
+   *
+   * @example
+   * ```typescript
+   * const result = await client.ipAsset.linkDerivative({
+   *   licenseTokenIds: [1, 2, 3],
+   *   maxRts: 100,
+   *   childIpId: "0x...",
+   * });
+   * ```
+   *
+   * @example
+   * ```typescript
+   * const result = await client.ipAsset.linkDerivative({
+   *   nftContract: "0x...",
+   *   tokenId: 1n,
+   *   derivData: { parentIpIds: ["0x..."], licenseTermsIds: [1n], maxRts: 100 },
+   * });
+   * ```
+   *
+   * **Automatic Token Handling:**
+   * - If the wallet's IP token balance is insufficient to cover minting fees, it automatically wraps native IP tokens into WIP tokens.
+   * - It checks allowances for all required spenders and automatically approves them if their current allowance is lower than needed.
+   * - These automatic processes can be configured through the `wipOptions` parameter to control behavior like multicall usage and approval settings.
+   */
+  public async linkDerivative<
+    T extends RegisterDerivativeWithLicenseTokensRequest | RegisterIpAndMakeDerivativeRequest,
+  >(request: T): Promise<LinkDerivativeResponse<T>> {
+    try {
+      if ("derivData" in request) {
+        return this.registerDerivativeIp(request);
+      } else {
+        return this.registerDerivativeWithLicenseTokens(request);
+      }
+    } catch (error) {
+      return handleError(error, "Failed to link derivative");
+    }
+  }
   /**
    * Handles registration for already minted NFTs with optional license terms and royalty shares.
    *

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -871,3 +871,10 @@ export type RegisterDerivativeIpAssetResponse<
 }
   ? RegisterDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokensResponse
   : RegisterIpResponse;
+
+
+export type LinkDerivativeResponse<
+  T extends RegisterIpAndMakeDerivativeRequest | RegisterDerivativeWithLicenseTokensRequest,
+> = T extends RegisterIpAndMakeDerivativeRequest
+  ? RegisterIpAndMakeDerivativeResponse
+  : RegisterDerivativeWithLicenseTokensResponse;

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -86,21 +86,12 @@ export type RegisterDerivativeWithLicenseTokensRequest = {
   txOptions?: TxOptions;
 };
 
-export type RegisterDerivativeWithLicenseTokensResponse = {
-  txHash?: Hash;
-  encodedTxData?: EncodedTxData;
-};
-
 export type RegisterDerivativeRequest = WithWipOptions &
   DerivativeDataInput & {
     txOptions?: TxOptions;
     childIpId: Address;
   };
 
-export type RegisterDerivativeResponse = {
-  txHash?: Hash;
-  encodedTxData?: EncodedTxData;
-};
 export type LicenseTermsDataInput<T = LicenseTermsInput, C = LicensingConfigInput> = {
   /** Programmable IP License */
   terms: T;
@@ -872,9 +863,7 @@ export type RegisterDerivativeIpAssetResponse<
   ? RegisterDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokensResponse
   : RegisterIpResponse;
 
-
-export type LinkDerivativeResponse<
-  T extends RegisterIpAndMakeDerivativeRequest | RegisterDerivativeWithLicenseTokensRequest,
-> = T extends RegisterIpAndMakeDerivativeRequest
-  ? RegisterIpAndMakeDerivativeResponse
-  : RegisterDerivativeWithLicenseTokensResponse;
+export type LinkDerivativeResponse = {
+  txHash?: Hash;
+  encodedTxData?: EncodedTxData;
+};

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -3897,24 +3897,24 @@ describe("IP Asset Functions", () => {
     });
 
     it("should successfully when give parentIpId and licenseTokenIds", async () => {
-      const tokenChildId = await getTokenId();
+      const tokenId = await getTokenId();
+      const childIpId = (
+        await client.ipAsset.register({
+          nftContract: mockERC721,
+          tokenId: tokenId!,
+        })
+      ).ipId!;
+
       const result = await client.ipAsset.linkDerivative({
-        nftContract: mockERC721,
-        tokenId: tokenChildId!,
-        derivData: {
-          parentIpIds: [parentIpId!],
-          licenseTermsIds: [commercialRemixLicenseTermsId],
-          maxMintingFee: 0n,
-          maxRts: 5 * 10 ** 6,
-          maxRevenueShare: 0,
-        },
-        deadline: 1000n,
+        childIpId: childIpId,
+        parentIpIds: [parentIpId],
+        licenseTermsIds: [commercialRemixLicenseTermsId],
+        maxMintingFee: "0",
+        maxRts: 5 * 10 ** 6,
+        maxRevenueShare: "0",
       });
 
       expect(result.txHash).to.be.a("string");
-      expect(result.ipId).to.be.a("string");
-      expect(result.tokenId).to.be.a("bigint");
-      expect(result.receipt?.status).to.be.equal("success");
     });
   });
 });

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -6339,66 +6339,53 @@ describe("Test IpAssetClient", () => {
 
   describe("Link Derivative", () => {
     beforeEach(() => {
-      stub(IpAssetRegistryClient.prototype, "ipId").resolves(ipId);
-      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
-        {
-          ipId: ipId,
-          tokenId: 1n,
-          chainId: 0n,
-          tokenContract: mockAddress,
-          name: "",
-          uri: "",
-          registrationDate: 0n,
-        },
-      ]);
+      stub(ipAssetClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([]);
     });
-    it("should successfully when give derivData", async () => {
-      stub(ipAssetClient.derivativeWorkflowsClient, "registerIpAndMakeDerivative").resolves(txHash);
-      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
+    it("should successfully when give parentIpIds", async () => {
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.licensingModuleClient, "registerDerivative").resolves(txHash);
       const result = await ipAssetClient.linkDerivative({
-        nftContract: mockERC721,
-        tokenId: 1n,
-        derivData: {
-          parentIpIds: [ipId],
-          licenseTermsIds: [1],
-          maxRts: 100,
-        },
+        childIpId: ipId,
+        parentIpIds: [ipId],
+        licenseTermsIds: [1],
+        maxRts: 100,
+        maxMintingFee: "0",
+        maxRevenueShare: "0",
         txOptions: { timeout: 10000 },
       });
       expect(result.txHash).to.equal(txHash);
-      expect(result.ipId).to.equal(ipId);
-      expect(result.tokenId).to.equal(1n);
     });
 
     it("should successfully when give licenseTokenIds", async () => {
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens").resolves(
         txHash,
       );
-      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       const result = await ipAssetClient.linkDerivative({
-        tokenId: 1n,
+        childIpId: ipId,
         licenseTokenIds: [1, 2, 3],
         maxRts: 100,
-        childIpId: ipId,
+        maxMintingFee: "0",
+        maxRevenueShare: "0",
+        txOptions: { timeout: 10000 },
       });
       expect(result.txHash).to.equal(txHash);
     });
 
     it("should throw error when parent ip is not registered", async () => {
-      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(false);
       await expect(
         ipAssetClient.linkDerivative({
-          nftContract: mockERC721,
-          tokenId: 1n,
-          derivData: {
-            parentIpIds: [ipId],
-            licenseTermsIds: [1],
-            maxRts: 100,
-          },
+          childIpId: ipId,
+          parentIpIds: [ipId],
+          licenseTermsIds: [1],
+          maxRts: 100,
+          maxMintingFee: "0",
+          maxRevenueShare: "0",
           txOptions: { timeout: 10000 },
         }),
       ).to.be.rejectedWith(
-        "Failed to register derivative IP: The NFT with id 1 is already registered as IP.",
+        `Failed to register derivative: The child IP with id ${ipId} is not registered.`,
       );
     });
   });


### PR DESCRIPTION
## Description
- Add the linkDerivative method
- Add unit and integration tests

## Breaking Change
Since `registerDerivative` and `registerDerivativeWithLicenseTokens` keep the same structure as `linkDerivative`,
to stay consistent, keep the same type of `LinkDerivativeResponse`
- Change the `registerDerivative`'s response from `RegisterDerivativeResponse` to `LinkDerivativeResponse`
- Change the `registerDerivativeWithLicenseTokens` response from `RegisterDerivativeWithLicenseTokensResponse` to `LinkDerivativeResponse`