### PR TITLE
Add default values

### DIFF
--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -356,7 +356,12 @@ export class GroupClient {
         groupPool: validateAddress(request.groupPool),
         ipIds: request.ipIds,
         licenseData: this.getLicenseData(request.licenseData)[0],
-        maxAllowedRewardShare: BigInt(getRevenueShare(request.maxAllowedRewardShare)),
+        maxAllowedRewardShare: BigInt(
+          getRevenueShare(
+            request.maxAllowedRewardShare ?? 100,
+            RevShareType.MAX_ALLOWED_REWARD_SHARE,
+          ),
+        ),
       };
       for (let i = 0; i < request.ipIds.length; i++) {
         const isRegistered = await this.ipAssetRegistryClient.isRegistered({

--- a/packages/core-sdk/src/resources/group.ts
+++ b/packages/core-sdk/src/resources/group.ts
@@ -163,7 +163,10 @@ export class GroupClient {
         spgNftContract: validateAddress(spgNftContract),
         recipient: validateAddress(recipient || this.wallet.account!.address),
         maxAllowedRewardShare: BigInt(
-          getRevenueShare(request.maxAllowedRewardShare, RevShareType.MAX_ALLOWED_REWARD_SHARE),
+          getRevenueShare(
+            request.maxAllowedRewardShare ?? 100,
+            RevShareType.MAX_ALLOWED_REWARD_SHARE,
+          ),
         ),
         licensesData: this.getLicenseData(request.licenseData),
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
@@ -275,7 +278,10 @@ export class GroupClient {
         ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
         tokenId: BigInt(request.tokenId),
         maxAllowedRewardShare: BigInt(
-          getRevenueShare(request.maxAllowedRewardShare, RevShareType.MAX_ALLOWED_REWARD_SHARE),
+          getRevenueShare(
+            request.maxAllowedRewardShare ?? 100,
+            RevShareType.MAX_ALLOWED_REWARD_SHARE,
+          ),
         ),
         sigAddToGroup: {
           signer: validateAddress(this.wallet.account!.address),
@@ -491,7 +497,7 @@ export class GroupClient {
         ipIds: validateAddresses(ipIds),
         maxAllowedRewardShare: BigInt(
           getRevenueShare(
-            maxAllowedRewardSharePercentage === undefined ? 100 : maxAllowedRewardSharePercentage,
+            maxAllowedRewardSharePercentage ?? 100,
             RevShareType.MAX_ALLOWED_REWARD_SHARE_PERCENTAGE,
           ),
         ),

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -46,7 +46,6 @@ import {
   TotalLicenseTokenLimitHookClient,
   WrappedIpClient,
 } from "../abi/generated";
-import { MAX_ROYALTY_TOKEN } from "../constants/common";
 import { LicenseTermsIdInput, RevShareType } from "../types/common";
 import { ChainIds } from "../types/config";
 import { TransactionResponse } from "../types/options";
@@ -434,7 +433,7 @@ export class IPAssetClient {
             arg.licenseTemplate || this.licenseTemplateAddress,
             zeroAddress,
             BigInt(arg.maxMintingFee || 0),
-            Number(arg.maxRts === undefined ? MAX_ROYALTY_TOKEN : arg.maxRts),
+            validateMaxRts(arg.maxRts),
             getRevenueShare(
               arg.maxRevenueShare === undefined ? 100 : arg.maxRevenueShare,
               RevShareType.MAX_REVENUE_SHARE,
@@ -492,9 +491,8 @@ export class IPAssetClient {
         childIpId: validateAddress(request.childIpId),
         licenseTokenIds: request.licenseTokenIds.map((id) => BigInt(id)),
         royaltyContext: zeroAddress,
-        maxRts: Number(request.maxRts),
+        maxRts: validateMaxRts(request.maxRts),
       };
-      validateMaxRts(req.maxRts);
       const isChildIpIdRegistered = await this.isRegistered(request.childIpId);
       if (!isChildIpIdRegistered) {
         throw new Error(`The child IP with id ${request.childIpId} is not registered.`);
@@ -1049,11 +1047,9 @@ export class IPAssetClient {
           ipMetadata: getIpMetadataForWorkflow(request.ipMetadata),
           licenseTokenIds: licenseTokenIds,
           royaltyContext: zeroAddress,
-          maxRts: Number(request.maxRts),
+          maxRts: validateMaxRts(request.maxRts),
           allowDuplicates: request.allowDuplicates || true,
         };
-      validateMaxRts(object.maxRts);
-
       const encodedTxData =
         this.derivativeWorkflowsClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokensEncode(
           object,
@@ -1130,9 +1126,8 @@ export class IPAssetClient {
           deadline: calculatedDeadline,
           signature,
         },
-        maxRts: Number(request.maxRts),
+        maxRts: validateMaxRts(request.maxRts),
       };
-      validateMaxRts(object.maxRts);
       if (request.txOptions?.encodedTxDataOnly) {
         return {
           encodedTxData:
@@ -1694,7 +1689,7 @@ export class IPAssetClient {
     }
   }
   /**
-   * Register a derivative IP asset, supporting both minted and mint-on-demand NFTs, with optional `derivData`, `royaltyShares` and `licenseTokenIds`, `maxRts`.
+   * Register a derivative IP asset, supporting both minted and mint-on-demand NFTs, with optional `derivData`, `royaltyShares` and `licenseTokenIds`.
    *
    * This method automatically selects and calls the appropriate workflow from 6 available methods based on your input parameters.
    * Here are three common usage patterns:
@@ -1707,7 +1702,6 @@ export class IPAssetClient {
    *     parentIpIds: ["0x..."],
    *     licenseTermsIds: [1n],
    *     maxMintingFee: 10000n,
-   *     maxRts: 100,
    *     maxRevenueShare: 100
    *   },
    *   royaltyShares: [
@@ -1724,18 +1718,16 @@ export class IPAssetClient {
    *     parentIpIds: ["0x..."],
    *     licenseTermsIds: [1n],
    *     maxMintingFee: 10000n,
-   *     maxRts: 100,
    *     maxRevenueShare: 100
    *   }
    * });
    * ```
    *
-   * **3. Mint NFT with License Token IDs and maxRts:**
+   * **3. Mint NFT with License Token IDs:**
    * ```typescript
    * const result = await client.ipAsset.registerDerivativeIpAsset({
    *   nft: { type: "mint", spgNftContract: "0x...", recipient: "0x...", allowDuplicates: false },
    *   licenseTokenIds: [1, 2, 3],
-   *   maxRts: 100
    * });
    * ```
    *
@@ -1752,37 +1744,25 @@ export class IPAssetClient {
    * - It checks allowances for all required spenders and automatically approves them if their current allowance is lower than needed.
    * - These automatic processes can be configured through the `wipOptions` parameter to control behavior like multicall usage and approval settings.
    *
-   * @throws {Error} If `licenseTokenIds` and `maxRts` are not provided together.
    * @throws {Error} If `derivData` is not provided when `royaltyShares` are provided.
-   * @throws {Error} If neither `derivData` nor (`licenseTokenIds` and `maxRts`) are provided.
+   * @throws {Error} If neither `derivData` nor `licenseTokenIds` are provided.
    * @throws {Error} If the NFT type is invalid.
    */
   public async registerDerivativeIpAsset<
     T extends RegisterDerivativeIpAssetRequest<MintedNFT | MintNFT>,
   >(request: T): Promise<RegisterDerivativeIpAssetResponse<T>> {
     try {
-      const { nft, licenseTokenIds, maxRts, royaltyShares, derivData } = request;
-      if (
-        (licenseTokenIds && licenseTokenIds.length > 0 && maxRts === undefined) ||
-        (maxRts !== undefined && (!licenseTokenIds || licenseTokenIds.length === 0))
-      ) {
-        throw new Error("licenseTokenIds and maxRts must be provided together.");
-      }
-
+      const { nft, licenseTokenIds, royaltyShares, derivData } = request;
       if (royaltyShares && !derivData) {
         throw new Error("derivData must be provided when royaltyShares are provided.");
       }
 
       // Validate that at least one valid combination is provided
       const hasDerivData = !!derivData;
-      const hasLicenseTokens = !!(
-        licenseTokenIds &&
-        licenseTokenIds.length > 0 &&
-        maxRts !== undefined
-      );
+      const hasLicenseTokens = !!(licenseTokenIds && licenseTokenIds.length > 0);
 
       if (!hasDerivData && !hasLicenseTokens) {
-        throw new Error("Either derivData or (licenseTokenIds and maxRts) must be provided.");
+        throw new Error("Either derivData or licenseTokenIds must be provided.");
       }
 
       if (nft.type === "minted") {
@@ -1802,7 +1782,7 @@ export class IPAssetClient {
   }
 
   /**
-   * Handles derivative registration for already minted NFTs with optional `derivData`, `royaltyShares` and `licenseTokenIds`, `maxRts`.
+   * Handles derivative registration for already minted NFTs with optional `derivData`, `royaltyShares` and `licenseTokenIds`.
    *
    * Supports the following workflows:
    * - {@link registerDerivativeIpAndAttachLicenseTermsAndDistributeRoyaltyTokens}
@@ -1849,12 +1829,12 @@ export class IPAssetClient {
     return this.registerIpAndMakeDerivativeWithLicenseTokens({
       ...baseParams,
       licenseTokenIds: licenseTokenIds!,
-      maxRts: maxRts!,
+      maxRts,
     });
   }
 
   /**
-   * Handles derivative registration for minted NFTs with optional `derivData`, `royaltyShares` and `licenseTokenIds`, `maxRts`.
+   * Handles derivative registration for minted NFTs with optional `derivData`, `royaltyShares` and `licenseTokenIds`.
    *
    * Supports the following workflows:
    * - {@link mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens}
@@ -1901,7 +1881,7 @@ export class IPAssetClient {
     return this.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
       ...baseParams,
       licenseTokenIds: licenseTokenIds!,
-      maxRts: maxRts!,
+      maxRts,
     });
   }
 
@@ -1916,7 +1896,6 @@ export class IPAssetClient {
    * ```typescript
    * const result = await client.ipAsset.linkDerivative({
    *   licenseTokenIds: [1, 2, 3],
-   *   maxRts: 100,
    *   childIpId: "0x...",
    * });
    * ```
@@ -1926,7 +1905,6 @@ export class IPAssetClient {
    * const result = await client.ipAsset.linkDerivative({
    *   parentIpIds: ["0x..."],
    *   licenseTermsIds: [1],
-   *   maxRts: 100,
    *   childIpId: "0x...",
    * });
    * ```

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -432,12 +432,9 @@ export class IPAssetClient {
             arg.licenseTermsIds.map((id) => BigInt(id)),
             arg.licenseTemplate || this.licenseTemplateAddress,
             zeroAddress,
-            BigInt(arg.maxMintingFee || 0),
+            BigInt(arg.maxMintingFee ?? 0),
             validateMaxRts(arg.maxRts),
-            getRevenueShare(
-              arg.maxRevenueShare??100,
-              RevShareType.MAX_REVENUE_SHARE,
-            ),
+            getRevenueShare(arg.maxRevenueShare ?? 100, RevShareType.MAX_REVENUE_SHARE),
           ],
         });
         const { result: state } = await ipAccount.state();

--- a/packages/core-sdk/src/resources/ipAsset.ts
+++ b/packages/core-sdk/src/resources/ipAsset.ts
@@ -435,7 +435,7 @@ export class IPAssetClient {
             BigInt(arg.maxMintingFee || 0),
             validateMaxRts(arg.maxRts),
             getRevenueShare(
-              arg.maxRevenueShare === undefined ? 100 : arg.maxRevenueShare,
+              arg.maxRevenueShare??100,
               RevShareType.MAX_REVENUE_SHARE,
             ),
           ],

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -186,7 +186,7 @@ export class LicenseClient {
         amount: BigInt(request.amount === undefined ? 1 : request.amount),
         receiver,
         royaltyContext: zeroAddress,
-        maxMintingFee: BigInt(request.maxMintingFee || 0),
+        maxMintingFee: BigInt(request.maxMintingFee ?? 0),
         maxRevenueShare: getRevenueShare(
           request.maxRevenueShare ?? 100,
           RevShareType.MAX_REVENUE_SHARE,

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -187,7 +187,10 @@ export class LicenseClient {
         receiver,
         royaltyContext: zeroAddress,
         maxMintingFee: BigInt(request.maxMintingFee || 0),
-        maxRevenueShare: getRevenueShare(request.maxRevenueShare, RevShareType.MAX_REVENUE_SHARE),
+        maxRevenueShare: getRevenueShare(
+          request.maxRevenueShare ?? 100,
+          RevShareType.MAX_REVENUE_SHARE,
+        ),
       } as const;
       if (req.maxMintingFee < 0) {
         throw new Error(`The maxMintingFee must be greater than 0.`);

--- a/packages/core-sdk/src/resources/license.ts
+++ b/packages/core-sdk/src/resources/license.ts
@@ -186,7 +186,7 @@ export class LicenseClient {
         amount: BigInt(request.amount === undefined ? 1 : request.amount),
         receiver,
         royaltyContext: zeroAddress,
-        maxMintingFee: BigInt(request.maxMintingFee),
+        maxMintingFee: BigInt(request.maxMintingFee || 0),
         maxRevenueShare: getRevenueShare(request.maxRevenueShare, RevShareType.MAX_REVENUE_SHARE),
       } as const;
       if (req.maxMintingFee < 0) {

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -43,8 +43,10 @@ export type MintAndRegisterIpAndAttachLicenseAndAddToGroupRequest = {
   /**
    * The maximum reward share percentage that can be allocated to each member IP.
    * Must be between 0 and 100 (where 100% represents 100_000_000).
+   *
+   * @default 100
    */
-  maxAllowedRewardShare: RevShareInput;
+  maxAllowedRewardShare?: RevShareInput;
   /** The data of the license and its configuration to be attached to the new group IP. */
   licenseData: LicenseDataInput[];
   /** The address of the recipient of the minted NFT. If not provided, the function will use the user's own wallet address. */
@@ -85,8 +87,13 @@ export type RegisterIpAndAttachLicenseAndAddToGroupRequest = {
   deadline?: DeadlineInput;
   /** The data of the license and its configuration to be attached to the new group IP. */
   licenseData: LicenseDataInput[];
-  /** The maximum reward share percentage that can be allocated to each member IP. */
-  maxAllowedRewardShare: RevShareInput;
+  /**
+   * The maximum reward share percentage that can be allocated to each member IP.
+   * Must be between 0 and 100 (where 100% represents 100_000_000).
+   *
+   * @default 100
+   */
+  maxAllowedRewardShare?: RevShareInput;
 } & IpMetadataAndTxOptions;
 
 export type RegisterIpAndAttachLicenseAndAddToGroupResponse = {

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -125,8 +125,10 @@ export type RegisterGroupAndAttachLicenseAndAddIpsRequest = {
   /**
    * The maximum reward share percentage that can be allocated to each member IP.
    * Must be between 0 and 100 (where 100% represents 100_000_000).
+   * 
+   * @default 100
    */
-  maxAllowedRewardShare: RevShareInput;
+  maxAllowedRewardShare?: RevShareInput;
   txOptions?: TxOptions;
 };
 

--- a/packages/core-sdk/src/types/resources/group.ts
+++ b/packages/core-sdk/src/types/resources/group.ts
@@ -125,7 +125,7 @@ export type RegisterGroupAndAttachLicenseAndAddIpsRequest = {
   /**
    * The maximum reward share percentage that can be allocated to each member IP.
    * Must be between 0 and 100 (where 100% represents 100_000_000).
-   * 
+   *
    * @default 100
    */
   maxAllowedRewardShare?: RevShareInput;

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -265,7 +265,8 @@ export type BatchMintAndRegisterIpAssetWithPilTermsResponse = {
 
 export type BatchRegisterDerivativeRequest = {
   args: RegisterDerivativeRequest[];
-  /** The deadline for the signature in seconds.
+  /** 
+   * The deadline for the signature in seconds.
    * @default 1000
    */
   deadline?: DeadlineInput;

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -265,7 +265,7 @@ export type BatchMintAndRegisterIpAssetWithPilTermsResponse = {
 
 export type BatchRegisterDerivativeRequest = {
   args: RegisterDerivativeRequest[];
-  /** 
+  /**
    * The deadline for the signature in seconds.
    * @default 1000
    */

--- a/packages/core-sdk/src/types/resources/ipAsset.ts
+++ b/packages/core-sdk/src/types/resources/ipAsset.ts
@@ -85,8 +85,11 @@ export type RegisterDerivativeWithLicenseTokensRequest = {
   childIpId: Address;
   /** The IDs of the license tokens. */
   licenseTokenIds: LicenseTermsIdInput[];
-  /** The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000). */
-  maxRts: MaxRtsInput;
+  /**
+   * The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000).
+   * @default 100_000_000
+   */
+  maxRts?: MaxRtsInput;
   txOptions?: TxOptions;
 };
 
@@ -213,8 +216,11 @@ export type MintAndRegisterIpAndMakeDerivativeWithLicenseTokensRequest = {
   licenseTokenIds: LicenseTermsIdInput[];
   /** The address of the recipient of the minted NFT. If not provided, the client's own wallet address will be used. */
   recipient?: Address;
-  /** The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000). */
-  maxRts: MaxRtsInput;
+  /**
+   * The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000).
+   * @default 100_000_000
+   */
+  maxRts?: MaxRtsInput;
   /**
    * Set to true to allow minting an NFT with a duplicate metadata hash.
    * @default true
@@ -228,8 +234,11 @@ export type RegisterIpAndMakeDerivativeWithLicenseTokensRequest = {
   tokenId: TokenIdInput;
   /** The IDs of the license tokens to be burned for linking the IP to parent IPs. */
   licenseTokenIds: LicenseTermsIdInput[];
-  /** The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000). */
-  maxRts: MaxRtsInput;
+  /**
+   * The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000).
+   * @default 100_000_000
+   */
+  maxRts?: MaxRtsInput;
   /**
    * The deadline for the signature in seconds.
    * @default 1000
@@ -773,12 +782,10 @@ export type RegisterDerivativeIpAssetRequest<T extends MintedNFT | MintNFT> = Wi
     derivData?: DerivativeDataInput;
     /**
      * The maximum number of royalty tokens that can be distributed to the external royalty policies (max: 100,000,000).
-     * Must be provided together with `licenseTokenIds`.
+     * @default 100_000_000
      */
     maxRts?: MaxRtsInput;
-    /** The IDs of the license tokens to be burned for linking the IP to parent IPs.
-     * Must be provided together with `maxRts`.
-     */
+    /** The IDs of the license tokens to be burned for linking the IP to parent IPs. */
     licenseTokenIds?: LicenseTermsIdInput[];
     /**
      * The deadline for the signature in seconds.

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -121,8 +121,12 @@ export type MintLicenseTokensRequest = {
    * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | PIL} address if not provided.
    */
   licenseTemplate?: Address;
-  /** The maximum minting fee that the caller is willing to pay. if set to 0 then no limit. */
-  maxMintingFee: FeeInput;
+  /** 
+   * The maximum minting fee that the caller is willing to pay.if set to 0 then no limit.
+   *
+   * @default 0
+   */
+  maxMintingFee?: FeeInput;
   /** The maximum revenue share percentage allowed for minting the License Tokens. Must be between 0 and 100,000,000 (where 100,000,000 represents 100%). */
   maxRevenueShare: RevShareInput;
   /**

--- a/packages/core-sdk/src/types/resources/license.ts
+++ b/packages/core-sdk/src/types/resources/license.ts
@@ -121,14 +121,18 @@ export type MintLicenseTokensRequest = {
    * Defaults to {@link https://docs.story.foundation/docs/programmable-ip-license | PIL} address if not provided.
    */
   licenseTemplate?: Address;
-  /** 
+  /**
    * The maximum minting fee that the caller is willing to pay.if set to 0 then no limit.
    *
    * @default 0
    */
   maxMintingFee?: FeeInput;
-  /** The maximum revenue share percentage allowed for minting the License Tokens. Must be between 0 and 100,000,000 (where 100,000,000 represents 100%). */
-  maxRevenueShare: RevShareInput;
+  /**
+   * The maximum revenue share percentage allowed for minting the License Tokens. Must be between 0 and 100,000,000 (where 100,000,000 represents 100%).
+   *
+   *  @default 100
+   */
+  maxRevenueShare?: RevShareInput;
   /**
    * The amount of license tokens to mint.
    * @default 1

--- a/packages/core-sdk/src/utils/registrationUtils/registerValidation.ts
+++ b/packages/core-sdk/src/utils/registrationUtils/registerValidation.ts
@@ -135,9 +135,7 @@ export const validateDerivativeData = async ({
     licenseTemplate: validateAddress(derivativeDataInput.licenseTemplate || licenseTemplateAddress),
     royaltyContext: zeroAddress,
     maxMintingFee: BigInt(derivativeDataInput.maxMintingFee || 0),
-    maxRts: Number(
-      derivativeDataInput.maxRts === undefined ? MAX_ROYALTY_TOKEN : derivativeDataInput.maxRts,
-    ),
+    maxRts: validateMaxRts(derivativeDataInput.maxRts),
     maxRevenueShare: getRevenueShare(
       derivativeDataInput.maxRevenueShare === undefined ? 100 : derivativeDataInput.maxRevenueShare,
       RevShareType.MAX_REVENUE_SHARE,
@@ -158,7 +156,7 @@ export const validateDerivativeData = async ({
   if (derivativeData.maxMintingFee < 0) {
     throw new Error(`The maxMintingFee must be greater than 0.`);
   }
-  validateMaxRts(derivativeData.maxRts);
+
   for (let i = 0; i < derivativeData.parentIpIds.length; i++) {
     const parentId = derivativeData.parentIpIds[i];
     const isParentIpRegistered = await ipAssetRegistryClient.isRegistered({
@@ -191,10 +189,13 @@ export const validateDerivativeData = async ({
   return derivativeData;
 };
 
-export const validateMaxRts = (maxRts: MaxRtsInput): void => {
-  if (maxRts < 0 || maxRts > MAX_ROYALTY_TOKEN) {
+export const validateMaxRts = (maxRts: MaxRtsInput | undefined): number => {
+  if (maxRts === undefined) {
+    return MAX_ROYALTY_TOKEN;
+  } else if (maxRts < 0 || maxRts > MAX_ROYALTY_TOKEN) {
     throw new Error(`The maxRts must be greater than 0 and less than ${MAX_ROYALTY_TOKEN}.`);
   }
+  return maxRts;
 };
 
 export const getIpIdAddress = async ({

--- a/packages/core-sdk/src/utils/registrationUtils/registerValidation.ts
+++ b/packages/core-sdk/src/utils/registrationUtils/registerValidation.ts
@@ -134,10 +134,10 @@ export const validateDerivativeData = async ({
     licenseTermsIds: derivativeDataInput.licenseTermsIds.map((id) => BigInt(id)),
     licenseTemplate: validateAddress(derivativeDataInput.licenseTemplate || licenseTemplateAddress),
     royaltyContext: zeroAddress,
-    maxMintingFee: BigInt(derivativeDataInput.maxMintingFee || 0),
+    maxMintingFee: BigInt(derivativeDataInput.maxMintingFee ?? 0),
     maxRts: validateMaxRts(derivativeDataInput.maxRts),
     maxRevenueShare: getRevenueShare(
-      derivativeDataInput.maxRevenueShare === undefined ? 100 : derivativeDataInput.maxRevenueShare,
+      derivativeDataInput.maxRevenueShare ?? 100,
       RevShareType.MAX_REVENUE_SHARE,
     ),
   };

--- a/packages/core-sdk/src/utils/validateLicenseConfig.ts
+++ b/packages/core-sdk/src/utils/validateLicenseConfig.ts
@@ -18,7 +18,10 @@ export const validateLicenseConfig = (licensingConfig?: LicensingConfigInput): L
     };
   }
   const licenseConfig = {
-    expectMinimumGroupRewardShare: Number(licensingConfig.expectMinimumGroupRewardShare),
+    expectMinimumGroupRewardShare: getRevenueShare(
+      licensingConfig.expectMinimumGroupRewardShare,
+      RevShareType.EXPECT_MINIMUM_GROUP_REWARD_SHARE,
+    ),
     commercialRevShare: getRevenueShare(licensingConfig.commercialRevShare),
     mintingFee: BigInt(licensingConfig.mintingFee),
     expectGroupRewardPool: validateAddress(licensingConfig.expectGroupRewardPool),
@@ -27,18 +30,6 @@ export const validateLicenseConfig = (licensingConfig?: LicensingConfigInput): L
     isSet: licensingConfig.isSet,
     disabled: licensingConfig.disabled,
   };
-
-  if (
-    licenseConfig.expectMinimumGroupRewardShare < 0 ||
-    licenseConfig.expectMinimumGroupRewardShare > 100
-  ) {
-    throw new Error(`The expectMinimumGroupRewardShare must be greater than 0 and less than 100.`);
-  } else {
-    licenseConfig.expectMinimumGroupRewardShare = getRevenueShare(
-      licenseConfig.expectMinimumGroupRewardShare,
-      RevShareType.EXPECT_MINIMUM_GROUP_REWARD_SHARE,
-    );
-  }
 
   if (licenseConfig.mintingFee < 0) {
     throw new Error(`The mintingFee must be greater than 0.`);

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -196,7 +196,7 @@ describe("Group Functions", () => {
     it("should successfully register group with license and add multiple IPs", async () => {
       const result = await client.groupClient.registerGroupAndAttachLicenseAndAddIps({
         groupPool: groupPoolAddress,
-        maxAllowedRewardShare: 55.5,
+        maxAllowedRewardShare: 50,
         ipIds: [ipId],
         licenseData: {
           licenseTermsId,
@@ -263,7 +263,7 @@ describe("Group Functions", () => {
         const result = await client.groupClient.addIpsToGroup({
           groupIpId: groupId,
           ipIds: ipIds,
-          maxAllowedRewardSharePercentage: 55.55555555,
+          maxAllowedRewardSharePercentage: 55,
         });
         expect(result.txHash).to.be.a("string");
       });

--- a/packages/core-sdk/test/integration/group.test.ts
+++ b/packages/core-sdk/test/integration/group.test.ts
@@ -151,7 +151,7 @@ describe("Group Functions", () => {
             },
           },
         ],
-        maxAllowedRewardShare: 5,
+        maxAllowedRewardShare: 100,
       });
 
       expect(result.txHash).to.be.a("string");
@@ -172,7 +172,6 @@ describe("Group Functions", () => {
         groupId,
         nftContract: spgNftContract,
         tokenId,
-        maxAllowedRewardShare: 5,
         licenseData: [
           {
             licenseTermsId,
@@ -197,7 +196,7 @@ describe("Group Functions", () => {
     it("should successfully register group with license and add multiple IPs", async () => {
       const result = await client.groupClient.registerGroupAndAttachLicenseAndAddIps({
         groupPool: groupPoolAddress,
-        maxAllowedRewardShare: 5,
+        maxAllowedRewardShare: 55.5,
         ipIds: [ipId],
         licenseData: {
           licenseTermsId,
@@ -264,7 +263,7 @@ describe("Group Functions", () => {
         const result = await client.groupClient.addIpsToGroup({
           groupIpId: groupId,
           ipIds: ipIds,
-          maxAllowedRewardSharePercentage: 5,
+          maxAllowedRewardSharePercentage: 55.55555555,
         });
         expect(result.txHash).to.be.a("string");
       });

--- a/packages/core-sdk/test/integration/ipAsset.test.ts
+++ b/packages/core-sdk/test/integration/ipAsset.test.ts
@@ -234,7 +234,6 @@ describe("IP Asset Functions", () => {
       const response = await client.ipAsset.registerDerivativeWithLicenseTokens({
         childIpId: ipId,
         licenseTokenIds: [mintLicenseTokensResult.licenseTokenIds![0]],
-        maxRts: 5 * 10 ** 6,
       });
       expect(response.txHash).to.be.a("string");
     });
@@ -537,7 +536,6 @@ describe("IP Asset Functions", () => {
       const result = await client.ipAsset.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
         spgNftContract: nftContract,
         licenseTokenIds: [mintLicenseTokensResult.licenseTokenIds![0]],
-        maxRts: 5 * 10 ** 6,
         ipMetadata: {
           ipMetadataURI: "test-uri",
           ipMetadataHash: toHex("test-metadata-hash", { size: 32 }),
@@ -1116,7 +1114,7 @@ describe("IP Asset Functions", () => {
         await client.ipAsset.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
           spgNftContract: nftContractWithMintingFee,
           licenseTokenIds: licenseTokenIds!,
-          maxRts: MAX_ROYALTY_TOKEN,
+          maxRts: 0,
           ipMetadata: {
             ipMetadataURI: "test",
             ipMetadataHash: zeroHash,
@@ -1603,15 +1601,12 @@ describe("IP Asset Functions", () => {
             childIpId: childIpId,
             parentIpIds: [parentIpId],
             licenseTermsIds: [noCommercialLicenseTermsId],
-            maxMintingFee: 0,
-            maxRts: 5 * 10 ** 6,
-            maxRevenueShare: 0,
           },
           {
             childIpId: childIpId2,
             parentIpIds: [parentIpId],
             licenseTermsIds: [noCommercialLicenseTermsId],
-            maxMintingFee: 0,
+            maxMintingFee: 10000000,
             maxRts: 5 * 10 ** 6,
             maxRevenueShare: 0,
           },
@@ -1875,7 +1870,7 @@ describe("IP Asset Functions", () => {
             })
           ).ipId!,
           licenseTokenIds: [mintLicenseTokensResult.licenseTokenIds![0]],
-          maxRts: 5 * 10 ** 6,
+          maxRts: 0,
         });
 
         const tokenId2 = await getTokenId();
@@ -3568,9 +3563,6 @@ describe("IP Asset Functions", () => {
           derivData: {
             parentIpIds: [parentIpId!],
             licenseTermsIds: [commercialRemixLicenseTermsId],
-            maxMintingFee: 10000n,
-            maxRts: 100,
-            maxRevenueShare: 100,
           },
           royaltyShares: [
             {
@@ -3620,6 +3612,7 @@ describe("IP Asset Functions", () => {
           nft: { type: "minted", nftContract: mockERC721, tokenId: tokenId! },
           licenseTokenIds: licenseTokenIds!,
           maxRts: 100,
+          maxMintingFee: 10000n,
         });
 
         expect(result.ipId).to.be.a("string");

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -133,7 +133,7 @@ describe("License Functions", () => {
         licenseTermsId: licenseId,
         licensorIpId: ipIdB,
         maxMintingFee: 10000000,
-        maxRevenueShare: 55.55555555,
+        maxRevenueShare: 55,
       });
       expect(result.txHash).to.be.a("string");
       expect(result.licenseTokenIds).to.be.a("array");

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -133,7 +133,7 @@ describe("License Functions", () => {
         licenseTermsId: licenseId,
         licensorIpId: ipIdB,
         maxMintingFee: 10000000,
-        maxRevenueShare: 55,
+        maxRevenueShare: 100,
       });
       expect(result.txHash).to.be.a("string");
       expect(result.licenseTokenIds).to.be.a("array");

--- a/packages/core-sdk/test/integration/license.test.ts
+++ b/packages/core-sdk/test/integration/license.test.ts
@@ -109,8 +109,6 @@ describe("License Functions", () => {
       const result = await client.license.mintLicenseTokens({
         licenseTermsId: licenseId,
         licensorIpId: ipId,
-        maxMintingFee: 1,
-        maxRevenueShare: 100,
       });
       expect(result.txHash).to.be.a("string");
       expect(result.licenseTokenIds).to.be.a("array");
@@ -134,8 +132,8 @@ describe("License Functions", () => {
       const result = await client.license.mintLicenseTokens({
         licenseTermsId: licenseId,
         licensorIpId: ipIdB,
-        maxMintingFee: 1,
-        maxRevenueShare: 100,
+        maxMintingFee: 10000000,
+        maxRevenueShare: 55.55555555,
       });
       expect(result.txHash).to.be.a("string");
       expect(result.licenseTokenIds).to.be.a("array");

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -194,9 +194,10 @@ describe("Test IpAssetClient", () => {
     it("should return txHash when call registerGroupAndAttachLicenseAndAddIps given correct args ", async () => {
       stub(groupClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
       stub(groupClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      stub(groupClient.groupingWorkflowsClient, "registerGroupAndAttachLicenseAndAddIps").resolves(
-        txHash,
-      );
+      const registerGroupAndAttachLicenseAndAddIpsStub = stub(
+        groupClient.groupingWorkflowsClient,
+        "registerGroupAndAttachLicenseAndAddIps",
+      ).resolves(txHash);
       stub(groupClient.groupingModuleEventClient, "parseTxIpGroupRegisteredEvent").returns([
         {
           groupId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -205,10 +206,34 @@ describe("Test IpAssetClient", () => {
       ]);
       const result = await groupClient.registerGroupAndAttachLicenseAndAddIps({
         groupPool: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-        maxAllowedRewardShare: 5,
+        maxAllowedRewardShare: 0,
         ipIds: ["0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"],
         licenseData: mockLicenseData,
       });
+      expect(registerGroupAndAttachLicenseAndAddIpsStub.args[0][0].maxAllowedRewardShare).equal(0n);
+      expect(result.txHash).equal(txHash);
+    });
+    it("should call with default value of maxAllowedRewardShare when registerGroupAndAttachLicenseAndAddIps without maxAllowedRewardShare", async () => {
+      stub(groupClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
+      stub(groupClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      const registerGroupAndAttachLicenseAndAddIpsStub = stub(
+        groupClient.groupingWorkflowsClient,
+        "registerGroupAndAttachLicenseAndAddIps",
+      ).resolves(txHash);
+      stub(groupClient.groupingModuleEventClient, "parseTxIpGroupRegisteredEvent").returns([
+        {
+          groupId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          groupPool: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        },
+      ]);
+      const result = await groupClient.registerGroupAndAttachLicenseAndAddIps({
+        groupPool: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        ipIds: ["0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"],
+        licenseData: mockLicenseData,
+      });
+      expect(registerGroupAndAttachLicenseAndAddIpsStub.args[0][0].maxAllowedRewardShare).equal(
+        BigInt(100 * 10 ** 6),
+      );
       expect(result.txHash).equal(txHash);
     });
   });

--- a/packages/core-sdk/test/unit/resources/group.test.ts
+++ b/packages/core-sdk/test/unit/resources/group.test.ts
@@ -234,7 +234,7 @@ describe("Test IpAssetClient", () => {
 
     it("should return txHash when call mintAndRegisterIpAndAttachLicenseAndAddToGroup given correct args ", async () => {
       stub(groupClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      stub(
+      const mintAndRegisterIpAndAttachLicenseAndAddToGroupStub = stub(
         groupClient.groupingWorkflowsClient,
         "mintAndRegisterIpAndAttachLicenseAndAddToGroup",
       ).resolves(txHash);
@@ -252,10 +252,13 @@ describe("Test IpAssetClient", () => {
       const result = await groupClient.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
         groupId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         spgNftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-        maxAllowedRewardShare: 5,
+        maxAllowedRewardShare: 0,
         licenseData: [mockLicenseData],
         allowDuplicates: true,
       });
+      expect(
+        mintAndRegisterIpAndAttachLicenseAndAddToGroupStub.args[0][0].maxAllowedRewardShare,
+      ).to.equal(0n);
       expect(result.txHash).equal(txHash);
       expect(result.ipId).equal("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
       expect(result.tokenId).equal(0n);
@@ -296,7 +299,7 @@ describe("Test IpAssetClient", () => {
       expect(result.encodedTxData!.data).to.be.a("string");
     });
 
-    it("should call with default values when mintAndRegisterIpAndAttachLicenseAndAddToGroup without providing allowDuplicates, ipMetadata, recipient", async () => {
+    it("should call with default values when mintAndRegisterIpAndAttachLicenseAndAddToGroup without default values", async () => {
       stub(groupClient.ipAssetRegistryClient, "isRegistered").resolves(true);
       const mintAndRegisterIpAndAttachLicenseAndAddToGroupStub = stub(
         groupClient.groupingWorkflowsClient,
@@ -315,7 +318,6 @@ describe("Test IpAssetClient", () => {
       ]);
       await groupClient.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
         groupId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-        maxAllowedRewardShare: 5,
         spgNftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         licenseData: [mockLicenseData],
       });
@@ -329,6 +331,7 @@ describe("Test IpAssetClient", () => {
         nftMetadataHash: zeroHash,
       });
       expect(args.recipient).to.equal(walletAddress);
+      expect(args.maxAllowedRewardShare).to.equal(BigInt(100 * 10 ** 6));
     });
   });
 
@@ -397,9 +400,10 @@ describe("Test IpAssetClient", () => {
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       );
       stub(groupClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      stub(groupClient.groupingWorkflowsClient, "registerIpAndAttachLicenseAndAddToGroup").resolves(
-        txHash,
-      );
+      const registerIpAndAttachLicenseAndAddToGroupStub = stub(
+        groupClient.groupingWorkflowsClient,
+        "registerIpAndAttachLicenseAndAddToGroup",
+      ).resolves(txHash);
       stub(groupClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
         {
           ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
@@ -416,8 +420,43 @@ describe("Test IpAssetClient", () => {
         nftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         tokenId: 100,
         licenseData: [mockLicenseData],
-        maxAllowedRewardShare: 5,
+        maxAllowedRewardShare: 0,
       });
+      expect(registerIpAndAttachLicenseAndAddToGroupStub.args[0][0].maxAllowedRewardShare).to.equal(
+        0n,
+      );
+      expect(result.txHash).equal(txHash);
+      expect(result.ipId).equal("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
+    });
+    it("should call with default value of maxAllowedRewardShare when registerIpAndAttachLicenseAndAddToGroup without maxAllowedRewardShare", async () => {
+      stub(groupClient.ipAssetRegistryClient, "ipId").resolves(
+        "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+      );
+      stub(groupClient.ipAssetRegistryClient, "isRegistered").resolves(true);
+      const registerIpAndAttachLicenseAndAddToGroupStub = stub(
+        groupClient.groupingWorkflowsClient,
+        "registerIpAndAttachLicenseAndAddToGroup",
+      ).resolves(txHash);
+      stub(groupClient.ipAssetRegistryClient, "parseTxIpRegisteredEvent").returns([
+        {
+          ipId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+          chainId: 0n,
+          tokenContract: "0x",
+          tokenId: 0n,
+          name: "",
+          uri: "",
+          registrationDate: 0n,
+        },
+      ]);
+      const result = await groupClient.registerIpAndAttachLicenseAndAddToGroup({
+        groupId: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        nftContract: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+        tokenId: 100,
+        licenseData: [mockLicenseData],
+      });
+      expect(registerIpAndAttachLicenseAndAddToGroupStub.args[0][0].maxAllowedRewardShare).to.equal(
+        BigInt(100 * 10 ** 6),
+      );
       expect(result.txHash).equal(txHash);
       expect(result.ipId).equal("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
     });
@@ -621,9 +660,18 @@ describe("Test IpAssetClient", () => {
       const result = await groupClient.addIpsToGroup({
         groupIpId: mockAddress,
         ipIds: [mockAddress],
-        maxAllowedRewardSharePercentage: 5,
+        maxAllowedRewardSharePercentage: 0,
       });
-      expect(addIpStub.args[0][0].maxAllowedRewardShare).to.equal(5000000n);
+      expect(addIpStub.args[0][0].maxAllowedRewardShare).to.equal(0n);
+      expect(result.txHash).equal(txHash);
+    });
+    it("should call with default value of maxAllowedRewardSharePercentage when addIpsToGroup without maxAllowedRewardSharePercentage", async () => {
+      const addIpStub = stub(groupClient.groupingModuleClient, "addIp").resolves(txHash);
+      const result = await groupClient.addIpsToGroup({
+        groupIpId: mockAddress,
+        ipIds: [mockAddress],
+      });
+      expect(addIpStub.args[0][0].maxAllowedRewardShare).to.equal(BigInt(100 * 10 ** 6));
       expect(result.txHash).equal(txHash);
     });
 

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -592,11 +592,14 @@ describe("Test IpAssetClient", () => {
         licenseTermsIds: [1n],
         licenseTemplate: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         maxRevenueShare: 0,
+        maxRts: 0,
+        maxMintingFee: 0n,
       });
 
       expect(res.txHash).equal(txHash);
-      expect(registerDerivativeStub.args[0][0].maxRts).equal(MAX_ROYALTY_TOKEN);
+      expect(registerDerivativeStub.args[0][0].maxRts).equal(0);
       expect(registerDerivativeStub.args[0][0].maxMintingFee).equal(0n);
+      expect(registerDerivativeStub.args[0][0].maxRevenueShare).equal(0);
     });
 
     it("should return encoded tx data when registerDerivative given correct childIpId, parentIpId, licenseTermsIds and encodedTxDataOnly of true ", async () => {
@@ -627,7 +630,6 @@ describe("Test IpAssetClient", () => {
           encodedTxDataOnly: true,
         },
       });
-
       expect(res.encodedTxData!.data).to.be.a("string");
     });
 

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -3129,7 +3129,7 @@ describe("Test IpAssetClient", () => {
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       );
 
-      stub(
+      const registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub = stub(
         ipAssetClient.royaltyTokenDistributionWorkflowsClient,
         "registerIpAndMakeDerivativeAndDeployRoyaltyVault",
       ).resolves(txHash);
@@ -3170,9 +3170,6 @@ describe("Test IpAssetClient", () => {
           derivData: {
             parentIpIds: ["0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"],
             licenseTermsIds: [1n],
-            maxMintingFee: 100,
-            maxRts: 100,
-            maxRevenueShare: 100,
           },
           royaltyShares: [
             { recipient: "0x73fcb515cee99e4991465ef586cfe2b072ebb512", percentage: 100 },
@@ -3187,6 +3184,15 @@ describe("Test IpAssetClient", () => {
         ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         tokenId: 0n,
       });
+      expect(
+        registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0].derivData.maxMintingFee,
+      ).to.equal(0n);
+      expect(
+        registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0].derivData.maxRts,
+      ).to.equal(100 * 10 ** 6);
+      expect(
+        registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0].derivData.maxRevenueShare,
+      ).to.equal(100 * 10 ** 6);
     });
 
     it("should return txHash when registerDerivativeAndAttachLicenseTermsAndDistributeRoyaltyTokens given correct args with waitForTransaction of true", async () => {
@@ -3241,9 +3247,9 @@ describe("Test IpAssetClient", () => {
           derivData: {
             parentIpIds: ["0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"],
             licenseTermsIds: [1n],
-            maxMintingFee: 100,
-            maxRts: 100,
-            maxRevenueShare: 100,
+            maxMintingFee: 0,
+            maxRts: 0,
+            maxRevenueShare: 0,
           },
           royaltyShares: [
             { recipient: "0x73fcb515cee99e4991465ef586cfe2b072ebb512", percentage: 100 },
@@ -3264,8 +3270,15 @@ describe("Test IpAssetClient", () => {
         ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         tokenId: 0n,
       });
-      console.log(registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0]);
-      // expect(registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0].maxMintingFee).to.equal(0n);
+      expect(
+        registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0].derivData.maxMintingFee,
+      ).to.equal(0n);
+      expect(
+        registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0].derivData.maxRts,
+      ).to.equal(0);
+      expect(
+        registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0].derivData.maxRevenueShare,
+      ).to.equal(0);
     });
   });
 

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -575,7 +575,10 @@ describe("Test IpAssetClient", () => {
         .resolves(true);
 
       stub(ipAssetClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
-      stub(ipAssetClient.licensingModuleClient, "registerDerivative").resolves(txHash);
+      const registerDerivativeStub = stub(
+        ipAssetClient.licensingModuleClient,
+        "registerDerivative",
+      ).resolves(txHash);
       stub(LicenseRegistryReadOnlyClient.prototype, "getRoyaltyPercent").resolves({
         royaltyPercent: 100,
       });
@@ -588,12 +591,12 @@ describe("Test IpAssetClient", () => {
         parentIpIds: ["0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4"],
         licenseTermsIds: [1n],
         licenseTemplate: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
-        maxMintingFee: 0n,
-        maxRts: 0,
         maxRevenueShare: 0,
       });
 
       expect(res.txHash).equal(txHash);
+      expect(registerDerivativeStub.args[0][0].maxRts).equal(MAX_ROYALTY_TOKEN);
+      expect(registerDerivativeStub.args[0][0].maxMintingFee).equal(0n);
     });
 
     it("should return encoded tx data when registerDerivative given correct childIpId, parentIpId, licenseTermsIds and encodedTxDataOnly of true ", async () => {
@@ -3195,7 +3198,7 @@ describe("Test IpAssetClient", () => {
         "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
       );
 
-      stub(
+      const registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub = stub(
         ipAssetClient.royaltyTokenDistributionWorkflowsClient,
         "registerIpAndMakeDerivativeAndDeployRoyaltyVault",
       ).resolves(txHash);
@@ -3259,6 +3262,8 @@ describe("Test IpAssetClient", () => {
         ipRoyaltyVault: "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
         tokenId: 0n,
       });
+      console.log(registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0]);
+      // expect(registerIpAndMakeDerivativeAndDeployRoyaltyVaultStub.args[0][0].maxMintingFee).to.equal(0n);
     });
   });
 

--- a/packages/core-sdk/test/unit/resources/ipAsset.test.ts
+++ b/packages/core-sdk/test/unit/resources/ipAsset.test.ts
@@ -784,17 +784,18 @@ describe("Test IpAssetClient", () => {
         "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
       );
 
-      stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens").resolves(
-        txHash,
-      );
+      const registerDerivativeWithLicenseTokensStub = stub(
+        ipAssetClient.licensingModuleClient,
+        "registerDerivativeWithLicenseTokens",
+      ).resolves(txHash);
 
       const res = await ipAssetClient.registerDerivativeWithLicenseTokens({
         childIpId: "0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4",
         licenseTokenIds: [1n],
-        maxRts: 0,
       });
 
       expect(res.txHash).equal(txHash);
+      expect(registerDerivativeWithLicenseTokensStub.args[0][0].maxRts).equal(MAX_ROYALTY_TOKEN);
     });
 
     it("should return encoded tx data when registerDerivativeWithLicenseTokens given correct args and encodedTxDataOnly of true", async () => {
@@ -1902,7 +1903,6 @@ describe("Test IpAssetClient", () => {
       await ipAssetClient.mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
         spgNftContract,
         licenseTokenIds: [1n],
-        maxRts: 0,
       });
 
       expect(
@@ -1921,6 +1921,9 @@ describe("Test IpAssetClient", () => {
       ).to.equal(zeroAddress);
       expect(mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub.args[0][0].recipient).to.equal(
         walletAddress,
+      );
+      expect(mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub.args[0][0].maxRts).to.equal(
+        MAX_ROYALTY_TOKEN,
       );
     });
   });
@@ -1972,7 +1975,7 @@ describe("Test IpAssetClient", () => {
         "0x73fcb515cee99e4991465ef586cfe2b072ebb512",
       );
 
-      stub(
+      const registerIpAndMakeDerivativeWithLicenseTokensStub = stub(
         ipAssetClient.derivativeWorkflowsClient,
         "registerIpAndMakeDerivativeWithLicenseTokens",
       ).resolves(txHash);
@@ -1989,12 +1992,14 @@ describe("Test IpAssetClient", () => {
       ]);
       const result = await ipAssetClient.registerIpAndMakeDerivativeWithLicenseTokens({
         nftContract: spgNftContract,
-        maxRts: 0,
         tokenId: 3,
         licenseTokenIds: [1n],
       });
       expect(result.txHash).to.equal(txHash);
       expect(result.ipId).to.equal("0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c");
+      expect(registerIpAndMakeDerivativeWithLicenseTokensStub.args[0][0].maxRts).to.equal(
+        MAX_ROYALTY_TOKEN,
+      );
     });
 
     it("should return encoded tx data when registerIpAndMakeDerivativeWithLicenseTokens given correct args and encodedTxDataOnly of true", async () => {
@@ -5577,41 +5582,6 @@ describe("Test IpAssetClient", () => {
         }),
       ).to.be.rejectedWith("Failed to register derivative IP Asset: Invalid NFT type.");
     });
-
-    it("should throw error when licenseTokenIds provided without maxRts", async () => {
-      await expect(
-        ipAssetClient.registerDerivativeIpAsset({
-          nft: { type: "minted", nftContract: mockERC721, tokenId: 1n },
-          licenseTokenIds: [1, 2, 3],
-        }),
-      ).to.be.rejectedWith(
-        "Failed to register derivative IP Asset: licenseTokenIds and maxRts must be provided together.",
-      );
-    });
-
-    it("should throw error when maxRts provided without licenseTokenIds", async () => {
-      await expect(
-        ipAssetClient.registerDerivativeIpAsset({
-          nft: { type: "minted", nftContract: mockERC721, tokenId: 1n },
-          maxRts: 100,
-        }),
-      ).to.be.rejectedWith(
-        "Failed to register derivative IP Asset: licenseTokenIds and maxRts must be provided together.",
-      );
-    });
-
-    it("should throw error when empty licenseTokenIds array provided with maxRts", async () => {
-      await expect(
-        ipAssetClient.registerDerivativeIpAsset({
-          nft: { type: "minted", nftContract: mockERC721, tokenId: 1n },
-          licenseTokenIds: [],
-          maxRts: 100,
-        }),
-      ).to.be.rejectedWith(
-        "Failed to register derivative IP Asset: licenseTokenIds and maxRts must be provided together.",
-      );
-    });
-
     it("should throw error when royaltyShares provided without derivData", async () => {
       await expect(
         ipAssetClient.registerDerivativeIpAsset({
@@ -5634,7 +5604,7 @@ describe("Test IpAssetClient", () => {
           nft: { type: "minted", nftContract: mockERC721, tokenId: 1n },
         }),
       ).to.be.rejectedWith(
-        "Failed to register derivative IP Asset: Either derivData or (licenseTokenIds and maxRts) must be provided.",
+        "Failed to register derivative IP Asset: Either derivData or licenseTokenIds must be provided.",
       );
     });
 
@@ -5728,7 +5698,7 @@ describe("Test IpAssetClient", () => {
             nft: { type: "minted", nftContract: mockERC721, tokenId: 1n },
           }),
         ).to.be.rejectedWith(
-          "Failed to register derivative IP Asset: Either derivData or (licenseTokenIds and maxRts) must be provided.",
+          "Failed to register derivative IP Asset: Either derivData or licenseTokenIds must be provided.",
         );
       });
     });
@@ -5800,6 +5770,9 @@ describe("Test IpAssetClient", () => {
 
         expect(mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub.callCount).to.equal(1);
         expect(result.txHash).to.equal(mintAndRegisterIpAndMakeDerivativeWithLicenseTokensTxHash);
+        expect(mintAndRegisterIpAndMakeDerivativeWithLicenseTokensStub.args[0][0].maxRts).to.equal(
+          100,
+        );
         expect(result.ipId).to.equal(ipId);
         expect(result.tokenId).to.equal(1n);
       });
@@ -5810,7 +5783,7 @@ describe("Test IpAssetClient", () => {
             nft: { type: "mint", spgNftContract: mockERC721, recipient: mockAddress },
           }),
         ).to.be.rejectedWith(
-          "Failed to register derivative IP Asset: Either derivData or (licenseTokenIds and maxRts) must be provided.",
+          "Failed to register derivative IP Asset: Either derivData or licenseTokenIds must be provided.",
         );
       });
     });
@@ -6138,7 +6111,10 @@ describe("Test IpAssetClient", () => {
     });
     it("should successfully when give parentIpIds", async () => {
       stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      stub(ipAssetClient.licensingModuleClient, "registerDerivative").resolves(txHash);
+      const registerDerivativeStub = stub(
+        ipAssetClient.licensingModuleClient,
+        "registerDerivative",
+      ).resolves(txHash);
       const result = await ipAssetClient.linkDerivative({
         childIpId: ipId,
         parentIpIds: [ipId],
@@ -6149,13 +6125,15 @@ describe("Test IpAssetClient", () => {
         txOptions: { timeout: 10000 },
       });
       expect(result.txHash).to.equal(txHash);
+      expect(registerDerivativeStub.args[0][0].maxRts).to.equal(100);
     });
 
     it("should successfully when give licenseTokenIds", async () => {
       stub(ipAssetClient.ipAssetRegistryClient, "isRegistered").resolves(true);
-      stub(ipAssetClient.licensingModuleClient, "registerDerivativeWithLicenseTokens").resolves(
-        txHash,
-      );
+      const registerDerivativeWithLicenseTokensStub = stub(
+        ipAssetClient.licensingModuleClient,
+        "registerDerivativeWithLicenseTokens",
+      ).resolves(txHash);
       const result = await ipAssetClient.linkDerivative({
         childIpId: ipId,
         licenseTokenIds: [1, 2, 3],
@@ -6165,6 +6143,7 @@ describe("Test IpAssetClient", () => {
         txOptions: { timeout: 10000 },
       });
       expect(result.txHash).to.equal(txHash);
+      expect(registerDerivativeWithLicenseTokensStub.args[0][0].maxRts).to.equal(100);
     });
 
     it("should throw error when parent ip is not registered", async () => {

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -685,13 +685,13 @@ describe("Test LicenseClient", () => {
       const result = await licenseClient.mintLicenseTokens({
         licensorIpId: zeroAddress,
         licenseTermsId: 1,
-        maxRevenueShare: 1,
         licenseTemplate: zeroAddress,
       });
 
       expect(result.txHash).to.equal(txHash);
       expect(result.licenseTokenIds).to.deep.equal([1n]);
       expect(mintLicenseTokensStub.args[0][0].maxMintingFee).to.equal(0n);
+      expect(mintLicenseTokensStub.args[0][0].maxRevenueShare).to.equal(100 * 10 ** 6);
     });
 
     it("should return txHash when call mintLicenseTokens given args is correct , amount of 5", async () => {

--- a/packages/core-sdk/test/unit/resources/license.test.ts
+++ b/packages/core-sdk/test/unit/resources/license.test.ts
@@ -666,7 +666,10 @@ describe("Test LicenseClient", () => {
       stub(IpAccountImplClient.prototype, "owner").resolves(walletAddress);
 
       stub(licenseClient.licenseRegistryReadOnlyClient, "hasIpAttachedLicenseTerms").resolves(true);
-      stub(licenseClient.licensingModuleClient, "mintLicenseTokens").resolves(txHash);
+      const mintLicenseTokensStub = stub(
+        licenseClient.licensingModuleClient,
+        "mintLicenseTokens",
+      ).resolves(txHash);
       stub(licenseClient.licensingModuleClient, "parseTxLicenseTokensMintedEvent").returns([
         {
           caller: zeroAddress,
@@ -682,13 +685,13 @@ describe("Test LicenseClient", () => {
       const result = await licenseClient.mintLicenseTokens({
         licensorIpId: zeroAddress,
         licenseTermsId: 1,
-        maxMintingFee: 1,
         maxRevenueShare: 1,
         licenseTemplate: zeroAddress,
       });
 
       expect(result.txHash).to.equal(txHash);
       expect(result.licenseTokenIds).to.deep.equal([1n]);
+      expect(mintLicenseTokensStub.args[0][0].maxMintingFee).to.equal(0n);
     });
 
     it("should return txHash when call mintLicenseTokens given args is correct , amount of 5", async () => {
@@ -798,7 +801,6 @@ describe("Test LicenseClient", () => {
         const result = await licenseClient.mintLicenseTokens({
           licensorIpId: zeroAddress,
           licenseTermsId: 1,
-          maxMintingFee: 1,
           maxRevenueShare: 1,
           options: {
             wipOptions: { useMulticallWhenPossible: false },
@@ -814,6 +816,9 @@ describe("Test LicenseClient", () => {
           (simulateContractStub.firstCall.args[0] as { functionName: string }).functionName,
           "deposit",
         );
+        expect(
+          (mintLicenseTokensStub.firstCall.args[0] as { maxMintingFee: bigint }).maxMintingFee,
+        ).to.equal(0n);
       });
 
       it("should support multicall when converting IP to WIP", async () => {

--- a/packages/core-sdk/test/unit/utils/validateLicenseConfig.test.ts
+++ b/packages/core-sdk/test/unit/utils/validateLicenseConfig.test.ts
@@ -33,7 +33,7 @@ describe("validateLicenseConfig", () => {
       expectGroupRewardPool: zeroAddress,
     };
     expect(() => validateLicenseConfig(licensingConfig)).to.throw(
-      "The expectMinimumGroupRewardShare must be greater than 0 and less than 100.",
+      "expectMinimumGroupRewardShare must be between 0 and 100.",
     );
   });
   it("should throw error when expectMinimumGroupRewardShare is less than 0", () => {
@@ -48,7 +48,7 @@ describe("validateLicenseConfig", () => {
       expectGroupRewardPool: zeroAddress,
     };
     expect(() => validateLicenseConfig(licensingConfig)).to.throw(
-      "The expectMinimumGroupRewardShare must be greater than 0 and less than 100.",
+      "expectMinimumGroupRewardShare must be between 0 and 100.",
     );
   });
   it("should throw error when mintingFee is less than 0", () => {


### PR DESCRIPTION
## Description
In the following field, make it optional and give a default value:
- maxMintingFee: 0
- maxRts: 100*10**6
- maxRevenueShare: 100*10**6
- maxAllowedRewardShare: 100*10**6
- maxAllowedRewardSharePercentage: 100*10**6

And add related unit tests to coverage.

## Question
I don't give the default value of `expectMinimumGroupRewardShare`; I am not sure what value I should provide.

Confirmed with @jacob-tucker , we don't need to give the default value of `expectMinimumGroupRewardShare`.