### PR TITLE
fix: throw if address for chainId is missing

### DIFF
--- a/packages/wagmi-generator/resolveProxyContracts.ts
+++ b/packages/wagmi-generator/resolveProxyContracts.ts
@@ -23,7 +23,9 @@ function getAddress(
   if (typeof address == "string") {
     return address as Address;
   } else {
-    return address[chainId];
+    const resolved = address[chainId];
+    if (!resolved) throw new Error(`Address not found for chainId ${chainId}`);
+    return resolved;
   }
 }
 


### PR DESCRIPTION
Prevent getAddress from returning undefined when a mapping for the given chainId is missing. Adds a small fail-fast guard to throw an explicit error instead of returning an undefined address.